### PR TITLE
fix(net/dns): eliminate forwarder catalog write-starvation livelock (#3473)

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -135,6 +135,22 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **DNS forwarder no longer wedges box-wide after an upstream blip (#3473).**
+  After a WAN, tunnel, or DHCP event degraded the currently-configured upstream
+  resolvers, container DNS could go dark for every service on the box — external
+  lookups failing with `Temporary failure in name resolution` — until the
+  upstreams recovered or the box was rebooted. The forwarder held a read lock on
+  its upstream catalog across each upstream query (up to 30s) while the task
+  installing new upstreams gave up after 10s and retried, starving the very
+  update that would have replaced the dead upstreams. The resolver now snapshots
+  the catalog and releases the lock before forwarding, and installs new upstreams
+  by atomic swap — no lock wait, no timeout, no retry — so a pending upstream
+  change always applies immediately. Forward queries also use a 5-second
+  per-attempt upstream timeout (matching what container clients wait) rather than
+  30 seconds, and names in the private `.startos`/`.embassy` zones that no
+  running service claims are answered
+  authoritatively (`NXDOMAIN`) instead of being forwarded to — and leaked at —
+  upstream resolvers.
 - **Enabling a public IPv4 address on an SSL service interface now opens the
   gateway port automatically.** Only a public _domain_ on an SSL-terminated port
   used to trigger automatic port forwarding (PCP/NAT-PMP/UPnP); turning on the

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -1839,13 +1839,6 @@ net.gateway.no-configured-echoip-urls:
   pl_PL: "Brak skonfigurowanych adresów URL echoip"
 
 # net/dns.rs
-net.dns.timeout-updating-catalog:
-  en_US: "timed out waiting to update dns catalog"
-  de_DE: "Zeitüberschreitung beim Warten auf Aktualisierung des DNS-Katalogs"
-  es_ES: "tiempo de espera agotado esperando actualizar catálogo DNS"
-  fr_FR: "délai d'attente dépassé pour la mise à jour du catalogue DNS"
-  pl_PL: "przekroczono limit czasu oczekiwania na aktualizację katalogu DNS"
-
 net.dns.could-not-determine-source-interface:
   en_US: "Could not determine source interface of %{src}"
   de_DE: "Quellschnittstelle von %{src} konnte nicht ermittelt werden"

--- a/shared-libs/crates/start-core/src/net/dns.rs
+++ b/shared-libs/crates/start-core/src/net/dns.rs
@@ -26,7 +26,6 @@ use rpc_toolkit::{
 };
 use serde::{Deserialize, Serialize};
 use tokio::net::UdpSocket;
-use tokio::sync::RwLock;
 use tracing::instrument;
 use ts_rs::TS;
 
@@ -303,7 +302,7 @@ enum PrivateScope {
 }
 
 struct Resolver {
-    catalog: Arc<RwLock<Catalog>>,
+    catalog: Arc<SyncRwLock<Arc<Catalog>>>,
     resolve: Arc<SyncRwLock<ResolveMap>>,
     net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
     scope: PrivateScope,
@@ -313,7 +312,7 @@ struct Resolver {
 /// user's static upstream servers.
 fn spawn_forwarder(
     db: TypedPatchDb<Database>,
-    catalog: Arc<RwLock<Catalog>>,
+    catalog: Arc<SyncRwLock<Arc<Catalog>>>,
 ) -> NonDetachingJoinHandle<()> {
     tokio::spawn(async move {
         let mut prev = crate::util::serde::hash_serializable::<sha2::Sha256, _>(&(
@@ -344,7 +343,10 @@ fn spawn_forwarder(
                                     ErrorKind::Network,
                                 ))?;
                             let (config, mut opts) = parse_resolv_conf(conf)?;
-                            opts.timeout = Duration::from_secs(30);
+                            // Per-attempt upstream timeout. Container stub
+                            // resolvers give up around 5s, so a longer forward
+                            // serves nobody; keep the default retry count.
+                            opts.timeout = Duration::from_secs(5);
                             last_config = Some((config, opts));
                             true
                         }
@@ -408,19 +410,9 @@ fn spawn_forwarder(
                         .build()
                         .map_err(|e| Error::new(eyre!("{e}"), ErrorKind::Network))?,
                     )];
-                    {
-                        let mut guard =
-                            tokio::time::timeout(Duration::from_secs(10), catalog.write())
-                                .await
-                                .map_err(|_| {
-                                    Error::new(
-                                        eyre!("{}", t!("net.dns.timeout-updating-catalog")),
-                                        ErrorKind::Timeout,
-                                    )
-                                })?;
-                        guard.upsert(Name::root().into(), auth);
-                        drop(guard);
-                    }
+                    let mut next = Catalog::new();
+                    next.upsert(Name::root().into(), auth);
+                    catalog.mutate(|c| *c = Arc::new(next));
                     prev = hash;
                 }
             }
@@ -434,10 +426,27 @@ fn spawn_forwarder(
     })
     .into()
 }
+/// How a query should be answered.
+enum Resolution {
+    /// Answer these addresses locally (an empty vec for the queried family is a
+    /// NODATA answer, as before).
+    Answer(Vec<IpAddr>),
+    /// The name is in a private StartOS zone but no service claims it — answer
+    /// authoritatively with NXDOMAIN instead of forwarding it upstream (which
+    /// would both leak internal hostnames and, during an upstream outage, pile
+    /// restarting-service lookups onto the slow forwarder).
+    NxDomain,
+    /// Not ours — forward upstream.
+    Forward,
+}
+
 impl Resolver {
-    fn resolve(&self, name: &Name, mut src: IpAddr) -> Option<Vec<IpAddr>> {
+    fn resolve(&self, name: &Name, mut src: IpAddr) -> Resolution {
         if name.zone_of(&*LOCALHOST) {
-            return Some(vec![Ipv4Addr::LOCALHOST.into(), Ipv6Addr::LOCALHOST.into()]);
+            return Resolution::Answer(vec![
+                Ipv4Addr::LOCALHOST.into(),
+                Ipv6Addr::LOCALHOST.into(),
+            ]);
         }
         src = match src {
             IpAddr::V6(v6) => {
@@ -470,7 +479,7 @@ impl Resolver {
                                     res.into_iter().map(|s| s.addr()).collect()
                                 })
                         }) {
-                            return Some(res);
+                            return Resolution::Answer(res);
                         }
                     }
                 }
@@ -479,7 +488,7 @@ impl Resolver {
                         .get(domain)
                         .map_or(false, |(_, rc)| rc.strong_count() > 0)
                     {
-                        return Some(addrs.clone());
+                        return Resolution::Answer(addrs.clone());
                     }
                 }
             }
@@ -494,23 +503,23 @@ impl Resolver {
                     .map_err(|_| ())
                     .and_then(|s| s.map(PackageId::from_str).transpose().map_err(|_| ()))
                 else {
-                    return None;
+                    return Resolution::NxDomain;
                 };
                 // the server's own services are registered under `None`;
                 // `start-os.startos` is the server, same as bare `startos`
                 let pkg = pkg.filter(|p| !p.is_start_os());
                 if let Some(ip) = r.services.get(&pkg) {
-                    Some(
+                    Resolution::Answer(
                         ip.iter()
                             .filter(|(_, rc)| rc.strong_count() > 0)
                             .map(|(ip, _)| (*ip).into())
                             .collect(),
                     )
                 } else {
-                    None
+                    Resolution::NxDomain
                 }
             } else {
-                None
+                Resolution::Forward
             }
         })
     }
@@ -530,8 +539,27 @@ impl RequestHandler for Resolver {
             let query = req.query;
             let name = query.name();
 
-            if let Some(ip) = self.resolve(name, req.src.ip()) {
-                match query.query_type() {
+            match self.resolve(name, req.src.ip()) {
+                Resolution::Forward => Ok(None),
+                Resolution::NxDomain => {
+                    let mut header = Metadata::response_from_request(&request.metadata);
+                    header.recursion_available = true;
+                    header.authoritative = true;
+                    header.response_code = ResponseCode::NXDomain;
+                    response_handle
+                        .send_response(
+                            MessageResponseBuilder::from_message_request(&*request).build(
+                                header,
+                                [],
+                                [],
+                                [],
+                                [],
+                            ),
+                        )
+                        .await
+                        .map(Some)
+                }
+                Resolution::Answer(ip) => match query.query_type() {
                     RecordType::A => {
                         let mut header = Metadata::response_from_request(&request.metadata);
                         header.recursion_available = true;
@@ -602,9 +630,7 @@ impl RequestHandler for Resolver {
                             .await
                             .map(Some)
                     }
-                }
-            } else {
-                Ok(None)
+                },
             }
         }
         .await
@@ -640,9 +666,8 @@ impl RequestHandler for Resolver {
                     });
             }
         }
-        self.catalog
-            .read()
-            .await
+        let catalog = self.catalog.peek(|c| c.clone());
+        catalog
             .handle_request::<R, T>(request, response_handle)
             .await
     }
@@ -690,7 +715,7 @@ fn dns_server_on(resolver: Resolver, addr: SocketAddr) -> Result<Server<Resolver
 /// every private domain locally; the wildcard answers none.
 async fn run_dns_servers(
     db: TypedPatchDb<Database>,
-    catalog: Arc<RwLock<Catalog>>,
+    catalog: Arc<SyncRwLock<Arc<Catalog>>>,
     resolve: Arc<SyncRwLock<ResolveMap>>,
     mut net_iface: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
 ) -> Result<(), Error> {
@@ -773,7 +798,7 @@ impl DnsController {
         watcher: &NetworkInterfaceWatcher,
     ) -> Result<Self, Error> {
         let resolve = Arc::new(SyncRwLock::new(ResolveMap::default()));
-        let catalog = Arc::new(RwLock::new(Catalog::new()));
+        let catalog = Arc::new(SyncRwLock::new(Arc::new(Catalog::new())));
         let weak = Arc::downgrade(&resolve);
         let net_iface = watcher.subscribe();
 


### PR DESCRIPTION
Fixes #3473.

## The bug

startd's DNS forwarder kept its upstream hickory `Catalog` behind a `tokio::sync::RwLock`. Every forwarded (non-`.startos`) query held `catalog.read()` **across the entire upstream forward** (up to 30s), while the rebuild task that installs new upstreams waited at most **10s** for `catalog.write()`, logged `timed out waiting to update dns catalog`, slept 1s, and retried — re-entering the fair-lock queue at the back.

Under sustained query load with slow or dead upstreams (exactly the conditions after a WAN/tunnel/DHCP event), the writer starves indefinitely. Because tokio's `RwLock` is write-preferring, every **new** forwarded query also blocks behind the starved writer — a near-total external-DNS outage for **all containers on the box** for the duration of the episode, while the one action that would repair the upstream list (the catalog rebuild) is the thing being starved.

The reporter's journal evidence (issue #3473) shows the error repeating at a ~11s cadence (10s write timeout + 1s retry sleep) for 10–34 minutes at a stretch, with every containerized external lookup failing `Temporary failure in name resolution`.

## The fix

**Snapshot the catalog instead of guarding it across the forward.** The field becomes `Arc<SyncRwLock<Arc<Catalog>>>` — the same `Arc<SyncRwLock<…>>` pattern `ResolveMap` already uses a few lines up in this file. `SyncRwLock` is the crate's `std::sync::RwLock` wrapper.

- **Reader:** `let catalog = self.catalog.peek(|c| c.clone());` clones the inner `Arc` under a sub-microsecond synchronous lock, releases it, and forwards on the owned snapshot. No lock is held across the `.await`. An in-flight reader keeps its old `Arc<Catalog>` alive until it finishes, so a concurrent swap can't pull the catalog out from under it.
- **Writer:** builds a fresh `Catalog`, upserts the root forward zone, and swaps via `catalog.mutate(|c| *c = Arc::new(next))`. No `write()` timeout, no retry, no starvation — a pending upstream change always applies immediately. (The catalog only ever holds the root zone, so rebuild-fresh-and-swap is equivalent to the old in-place `upsert`.)

This is suggested fix **#1 + #2** from the issue, and it structurally eliminates the livelock: the writer now contends only with `Arc::clone` critical sections, never with forwards.

Complementary changes (also from the issue's suggested-fixes list):

- **Per-attempt forward timeout 30s → 5s** (fix #3). Container stub resolvers give up around 5s, so a longer server-side forward serves nobody. `attempts` is left at its resolv.conf default (retry resilience for transient loss on *working* upstreams), so the worst case on a dead upstream is ~15s of background effort rather than the old ~90s — and it no longer blocks anything.
- **Authoritative NXDOMAIN for unclaimed internal zones** (fix #4). Names in the private `.startos`/`.embassy` zones that no running service claims are now answered authoritatively (`NXDOMAIN`) instead of being forwarded — and leaked — to upstream resolvers. This also removes the episode amplification from restarting-service lookups piling onto the slow forwarder. Names a service *does* claim are unchanged, including the empty-answer/NODATA case; only previously-forwarded unclaimed names in those two zones change behavior.

Removes the now-dead `net.dns.timeout-updating-catalog` i18n key. Adds a `### Fixed` entry under the unreleased `0.4.0-beta.10` changelog heading.

## Verification

- `cargo check -p start-core` — clean (only pre-existing, unrelated warnings).
- `cargo fmt` — clean; the response-handler arm bodies are byte-identical to `master` (only control flow changed).
- clippy-neutral: the only `dns.rs` lints are pre-existing pedantic ones in untouched code.
- Adversarial multi-agent review (concurrency / DNS-semantics / regression lenses): confirmed no std lock held across an await, the livelock eliminated, the NXDOMAIN change narrow and safe (no-SOA negative answer, and the actual consumers — glibc stubs at `10.0.3.1` — do no negative caching, so a restarting service re-resolves cleanly).

Not exercised on a live box in this environment (needs a WAN/upstream-outage scenario across multiple containers); the reproduction sketch is in the issue.