### PR TITLE
docs(os): FAQ + mDNS — why .local can stop resolving while a VPN is connected

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -271,6 +271,16 @@ file tracks notable changes since the move to the monorepo.
   servers are cleaned up automatically: startup deserializes the database
   through the typed model, which drops the removed key.
 
+### Documentation
+
+- **`.local` while a VPN is connected (FAQ + mDNS page).** The "unable to
+  connect to server-name.local" FAQ entry gains an early step — disconnect any
+  VPN on the client device — and the mDNS page's Limitations section now notes
+  that on Android, `.local` can stop working even on the home LAN while a VPN
+  that supplies DNS is connected (Android excludes VPN connections from mDNS
+  resolution). Both link the StartTunnel FAQ's permanent fix: a manual DNS
+  record for the `.local` hostname.
+
 ## [0.4.0-beta.9] and earlier
 
 See the [GitHub releases page](https://github.com/Start9Labs/start-technologies/releases)

--- a/projects/start-os/docs/src/faq.md
+++ b/projects/start-os/docs/src/faq.md
@@ -43,6 +43,8 @@ If you encounter Diagnostic Mode, your best bet is stop clicking and [contact su
 
 1. First, try [these steps](#during-initial-setup-i-am-unable-to-connect-to-startlocal). If none resolve the issue, continue below.
 
+1. If your phone/computer is connected to a VPN (including WireGuard/StartTunnel), try disconnecting it. `.local` addresses may not resolve while a VPN is connected — in particular, Android [excludes VPN connections from mDNS resolution](https://source.android.com/docs/core/ota/modular-system/dns-resolver), so a VPN that supplies DNS breaks `.local` even on your home network. If the VPN is StartTunnel, see [this FAQ entry](/start-tunnel/faq.html#why-cant-my-android-phone-resolve-local-addresses-while-the-tunnel-is-on) for the permanent fix: a manual DNS record for your server's `.local` name.
+
 1. Hard refresh the browser:
    - Linux/Windows: `ctrl+shift+R`
    - macOS Firefox: `cmd+shift+R`

--- a/projects/start-os/docs/src/mdns.md
+++ b/projects/start-os/docs/src/mdns.md
@@ -15,4 +15,4 @@ mDNS resolves your server's `.local` address to its LAN IP address without relyi
 
 ## Limitations
 
-mDNS only works on the local network. It does not work over [VPN](inbound-vpn.md) or the Internet. For remote access using a custom domain, see [Private Domains](private-domains.md).
+mDNS only works on the local network. It does not work over [VPN](inbound-vpn.md) or the Internet. On Android, `.local` can also stop working _on the local network_ while a VPN that supplies DNS is connected, because Android [excludes VPN connections from mDNS resolution](https://source.android.com/docs/core/ota/modular-system/dns-resolver) — see [this StartTunnel FAQ entry](/start-tunnel/faq.html#why-cant-my-android-phone-resolve-local-addresses-while-the-tunnel-is-on) for the fix. For remote access using a custom domain, see [Private Domains](private-domains.md).


### PR DESCRIPTION
## Motivation

Companion to #3523. A user on Android lost `.local` access while WireGuard was up: Android [excludes VPN connections from mDNS resolution](https://source.android.com/docs/core/ota/modular-system/dns-resolver), so once a config carries `DNS =`, the `.local` lookup goes to the tunnel's resolver as ordinary unicast DNS and gets NXDOMAIN — even at home on the LAN. #3523 documents the StartTunnel side; the StartOS book's `.local` troubleshooting walk never mentioned VPNs at all, and `mdns.md`'s Limitations framed the failure as "over VPN" only, not the at-home Android case.

## Change

- **`faq.md`** — the "unable to connect to server-name.local" entry gains an early step (right after the initial-setup cross-reference): disconnect any VPN, including WireGuard/StartTunnel; explains the Android mechanism, and links the StartTunnel FAQ entry from #3523 for the permanent fix — a manual DNS record for the server's `.local` name.
- **`mdns.md`** — Limitations now notes that on Android, `.local` can also stop working _on the local network_ while a VPN that supplies DNS is connected, linking the same StartTunnel FAQ entry.
- **`CHANGELOG.md`** — `### Documentation` entry under the unreleased `[0.4.0-beta.10]` (no `start-os/v0.4.0-beta.10` tag on origin, verified after a fresh `git fetch --tags`).

## Verification

- `mdbook build` passes in `projects/start-os/docs` (local v0.4.40; CI's v0.5.2 + prettier gate are authoritative); prettier check passes on all three files.
- The cross-book anchor `/start-tunnel/faq.html#why-cant-my-android-phone-resolve-local-addresses-while-the-tunnel-is-on` was confirmed by building #3523's exact heading in a scratch mdBook book. mdBook doesn't validate cross-book links, so this PR is independent of #3523's merge order — the anchor simply resolves once #3523 deploys; until then the link lands at the top of the existing StartTunnel FAQ page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
