### PR TITLE
fix(cli): resolve a .local host lazily, not at context build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7729,7 +7729,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-cli"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "start-core",
  "tracing",

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -9,6 +9,19 @@ Because `start-cli` is a thin client over `start-core`, most user-visible CLI ch
 in `start-core`; record here anything that changes this crate's entrypoint, features, packaging,
 or the CLI's externally observable behavior.
 
+## [1.1.1]
+
+### Fixed
+
+- **A configured `.local` host no longer breaks commands that never use it.** Resolving that
+  host to an address happened while the client context was built, before the subcommand was
+  dispatched, so whenever the named box was off the LAN _every_ invocation died with
+  `Network Error: Failed to resolve hostname: <name>` — including the registry, s9pk, and
+  tunnel commands that contact no StartOS host at all. Resolution is now deferred to the first
+  request that actually needs the address: unrelated commands are unaffected, commands against
+  the host still fail with the same message, and a box that comes up mid-session resolves on
+  the next attempt rather than needing a new invocation.
+
 ## [1.1.0]
 
 ### Changed

--- a/projects/start-cli/Cargo.toml
+++ b/projects/start-cli/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-cli"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "1.1.0"                                               # VERSION_BUMP
+version = "1.1.1"                                               # VERSION_BUMP
 
 [[bin]]
 name = "start-cli"

--- a/shared-libs/crates/start-core/src/context/cli.rs
+++ b/shared-libs/crates/start-core/src/context/cli.rs
@@ -24,7 +24,7 @@ use crate::developer::{
     OS_ID_KEY_PATH, default_id_key_path, load_signing_key, migrate_legacy_key_file,
 };
 use crate::middleware::auth::local::{is_loopback, local_auth_header};
-use crate::net::mdns::pin_mdns_host;
+use crate::net::mdns::LazyPinnedUrl;
 use crate::prelude::*;
 use crate::rpc_continuations::Guid;
 use crate::s9pk::init::{BUILD_KEY_FILE, LEGACY_BUILD_KEY_FILE, STARTOS_DIR};
@@ -32,14 +32,12 @@ use crate::s9pk::init::{BUILD_KEY_FILE, LEGACY_BUILD_KEY_FILE, STARTOS_DIR};
 #[derive(Debug)]
 pub struct CliContextSeed {
     pub runtime: OnceCell<Arc<Runtime>>,
-    pub base_url: Url,
-    /// The host the user named the server by, captured before `pin_mdns_host`
-    /// rewrites a `.local` host to an address. Request signatures are bound to
-    /// this identity — one of the server's sig contexts — not to the pinned
-    /// transport address, which the server does not necessarily recognize.
+    pub base_url: LazyPinnedUrl,
+    /// The host the user named the server by, taken from the unresolved URL. Request
+    /// signatures are bound to this identity — one of the server's sig contexts — not to
+    /// the pinned transport address, which the server does not necessarily recognize.
     pub host_identity: Option<InternedString>,
-    pub rpc_url: Url,
-    pub registry_url: Option<Url>,
+    pub registry_base_url: Option<LazyPinnedUrl>,
     pub registry_hostname: Vec<InternedString>,
     pub registry_listen: Option<SocketAddr>,
     pub s9pk_s3base: Option<Url>,
@@ -71,40 +69,16 @@ impl CliContext {
         // Follow each namespace's `default` profile to a URL (`load` already seeded
         // -H/-r as `default` and layered every config file in), then localhost / no
         // registry when unset.
-        let mut url = match resolve_target(config.host.as_ref())? {
+        let url = match resolve_target(config.host.as_ref())? {
             Some(url) => url,
             None => "http://localhost".parse()?,
         };
-        // Before anything derives a URL from this one: a `.local` host is unresolvable from a
-        // musl-static binary, so pin it to an address the system resolver found.
         let host_identity = url.host_str().map(InternedString::intern);
-        pin_mdns_host(&mut url)?;
-
-        let registry = resolve_target(config.registry.as_ref())?;
 
         Ok(CliContext(Arc::new(CliContextSeed {
             runtime: OnceCell::new(),
-            base_url: url.clone(),
-            rpc_url: {
-                url.path_segments_mut()
-                    .map_err(|_| eyre!("Url cannot be base"))
-                    .with_kind(crate::ErrorKind::ParseUrl)?
-                    .push("rpc")
-                    .push("v1");
-                url
-            },
-            registry_url: registry
-                .map(|mut registry| {
-                    pin_mdns_host(&mut registry)?;
-                    registry
-                        .path_segments_mut()
-                        .map_err(|_| eyre!("Url cannot be base"))
-                        .with_kind(crate::ErrorKind::ParseUrl)?
-                        .push("rpc")
-                        .push("v0");
-                    Ok::<_, Error>(registry)
-                })
-                .transpose()?,
+            base_url: LazyPinnedUrl::new(url),
+            registry_base_url: resolve_target(config.registry.as_ref())?.map(LazyPinnedUrl::new),
             registry_hostname: config.registry_hostname.unwrap_or_default(),
             registry_listen: config.registry_listen,
             s9pk_s3base: config.s9pk_s3base,
@@ -139,6 +113,34 @@ impl CliContext {
             root_ca: config.root_ca.unwrap_or_default(),
             insecure: config.insecure,
         })))
+    }
+
+    /// The host's JSON-RPC endpoint. BLOCKING when it resolves a `.local` host.
+    pub fn rpc_url(&self) -> Result<Url, Error> {
+        let mut url = self.base_url.get()?.clone();
+        url.path_segments_mut()
+            .map_err(|_| eyre!("Url cannot be base"))
+            .with_kind(crate::ErrorKind::ParseUrl)?
+            .push("rpc")
+            .push("v1");
+        Ok(url)
+    }
+
+    /// The configured registry's JSON-RPC endpoint, or `None` when no registry is set.
+    /// BLOCKING when it resolves a `.local` host.
+    pub fn registry_url(&self) -> Result<Option<Url>, Error> {
+        self.registry_base_url
+            .as_ref()
+            .map(|registry| {
+                let mut url = registry.get()?.clone();
+                url.path_segments_mut()
+                    .map_err(|_| eyre!("Url cannot be base"))
+                    .with_kind(crate::ErrorKind::ParseUrl)?
+                    .push("rpc")
+                    .push("v0");
+                Ok(url)
+            })
+            .transpose()
     }
 
     fn ws_tls_connector(&self) -> Result<Option<Connector>, Error> {
@@ -227,7 +229,7 @@ impl CliContext {
         &self,
         guid: Guid,
     ) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, Error> {
-        let mut url = self.base_url.clone();
+        let mut url = self.base_url.get()?.clone();
         let ws_scheme = match url.scheme() {
             "https" => "wss",
             "http" => "ws",
@@ -265,7 +267,7 @@ impl CliContext {
         body: reqwest::Body,
         headers: reqwest::header::HeaderMap,
     ) -> Result<reqwest::Response, Error> {
-        let mut url = self.base_url.clone();
+        let mut url = self.base_url.get()?.clone();
         url.path_segments_mut()
             .map_err(|_| eyre!("Url cannot be base"))
             .with_kind(crate::ErrorKind::ParseUrl)?
@@ -362,15 +364,16 @@ impl CallRemote<RpcContext> for CliContext {
         params: Value,
         _: Empty,
     ) -> Result<Value, RpcError> {
+        let rpc_url = self.rpc_url()?;
         let mut headers = HeaderMap::new();
-        if is_loopback(&self.rpc_url) {
+        if is_loopback(&rpc_url) {
             if let Some(auth) = local_auth_header::<RpcContext>().await {
                 headers.insert(AUTHORIZATION, auth);
             }
         }
         crate::middleware::auth::signature::call_remote(
             self,
-            self.rpc_url.clone(),
+            rpc_url,
             headers,
             self.host_identity.as_deref(),
             method,
@@ -389,7 +392,7 @@ impl CallRemote<DiagnosticContext> for CliContext {
     ) -> Result<Value, RpcError> {
         crate::middleware::auth::signature::call_remote(
             self,
-            self.rpc_url.clone(),
+            self.rpc_url()?,
             HeaderMap::new(),
             self.host_identity.as_deref(),
             method,
@@ -408,7 +411,7 @@ impl CallRemote<InitContext> for CliContext {
     ) -> Result<Value, RpcError> {
         crate::middleware::auth::signature::call_remote(
             self,
-            self.rpc_url.clone(),
+            self.rpc_url()?,
             HeaderMap::new(),
             self.host_identity.as_deref(),
             method,
@@ -427,7 +430,7 @@ impl CallRemote<SetupContext> for CliContext {
     ) -> Result<Value, RpcError> {
         crate::middleware::auth::signature::call_remote(
             self,
-            self.rpc_url.clone(),
+            self.rpc_url()?,
             HeaderMap::new(),
             self.host_identity.as_deref(),
             method,

--- a/shared-libs/crates/start-core/src/install/mod.rs
+++ b/shared-libs/crates/start-core/src/install/mod.rs
@@ -519,7 +519,7 @@ pub async fn cli_install(
                 &method.join("."),
                 to_value(&InstallParams {
                     id,
-                    registry: ctx.registry_url.clone().or_not_found("--registry")?,
+                    registry: ctx.registry_url()?.or_not_found("--registry")?,
                     version,
                 })?,
             )

--- a/shared-libs/crates/start-core/src/net/mdns.rs
+++ b/shared-libs/crates/start-core/src/net/mdns.rs
@@ -1,11 +1,44 @@
 use std::net::Ipv4Addr;
 
 use color_eyre::eyre::eyre;
+use once_cell::sync::OnceCell;
 use reqwest::Url;
 use tokio::process::Command;
 
 use crate::prelude::*;
 use crate::util::Invoke;
+
+/// A URL whose `.local` host is resolved on first use rather than when the context is built.
+///
+/// Resolution needs the named box to be answering mDNS, so doing it up front fails *every*
+/// subcommand the moment that box is off — including the registry, s9pk, and tunnel commands
+/// that never contact a StartOS host at all. Deferring it puts the failure on the request that
+/// actually needs an address, and leaves the rest working.
+///
+/// The resolved URL is memoized, and a failure is not: like [`OnceCell::get_or_try_init`], a
+/// later call retries, so a box that comes up mid-session resolves on the next attempt.
+#[derive(Debug)]
+pub struct LazyPinnedUrl {
+    raw: Url,
+    pinned: OnceCell<Url>,
+}
+impl LazyPinnedUrl {
+    pub fn new(raw: Url) -> Self {
+        Self {
+            raw,
+            pinned: OnceCell::new(),
+        }
+    }
+
+    /// BLOCKING on the call that populates it.
+    pub fn get(&self) -> Result<&Url, Error> {
+        self.pinned.get_or_try_init(|| {
+            let mut url = self.raw.clone();
+            pin_mdns_host(&mut url)?;
+            Ok(url)
+        })
+    }
+}
 
 /// BLOCKING. Point a `*.local` URL at its resolved address, leaving every other URL alone.
 ///

--- a/shared-libs/crates/start-core/src/registry/context.rs
+++ b/shared-libs/crates/start-core/src/registry/context.rs
@@ -205,7 +205,7 @@ impl CallRemote<RegistryContext> for CliContext {
     ) -> Result<Value, RpcError> {
         let local_auth = local_auth_header::<RegistryContext>().await;
 
-        let url = if let Some(url) = self.registry_url.clone() {
+        let url = if let Some(url) = self.registry_url()? {
             url
         } else if local_auth.is_some() || !self.registry_hostname.is_empty() {
             let mut url: Url = format!(

--- a/shared-libs/crates/start-core/src/registry/package/promote.rs
+++ b/shared-libs/crates/start-core/src/registry/package/promote.rs
@@ -41,8 +41,8 @@ pub fn registry_rpc_url(url: &Url) -> Result<Url, Error> {
 pub fn resolve_registry_url(explicit: Option<&Url>, ctx: &CliContext) -> Result<Url, Error> {
     if let Some(url) = explicit {
         registry_rpc_url(url)
-    } else if let Some(url) = &ctx.registry_url {
-        Ok(url.clone())
+    } else if let Some(url) = ctx.registry_url()? {
+        Ok(url)
     } else {
         Err(Error::new(
             eyre!("{}", t!("registry.context.registry-required")),


### PR DESCRIPTION
## Problem

`CliContext::init` resolved the configured host to an address *before* the subcommand was dispatched. Resolution goes through the system resolver (`getent ahosts`), so it needs the named box to be answering mDNS — and when it isn't, **every** `start-cli` invocation dies at context construction:

```
$ start-cli --registry=https://alpha-registry-x.start9.com registry package get lnd full --format=json
Network Error: Failed to resolve hostname: demo.local     (exit 9)
```

That command never contacts a StartOS host. Neither do the rest of the registry commands, nor `s9pk`, nor the tunnel commands — but a `host` profile pointing at an offline `.local` box takes all of them down. It surfaced while promoting packages between registries from a workspace whose `.startos/config.yaml` names a dev box that happened to be powered off.

The eager pinning itself is correct and stays (#3471): a musl-static binary can't resolve `.local` in-process. Only its *timing* was wrong.

## Fix

`LazyPinnedUrl` (in `net::mdns`) holds the URL as configured and resolves it on first use, memoizing via `OnceCell::get_or_try_init`. `CliContextSeed` stores the host and registry URLs that way, and the `rpc/v1` and `rpc/v0` endpoints are derived from them on demand instead of being baked at init.

Consequences:

- Commands that talk to the host fail exactly as they did, with the same message, at the request that needs the address.
- Commands that don't, run regardless of whether the box is up.
- Failure isn't memoized, so a box that comes up mid-session resolves on the next attempt rather than needing a fresh invocation.
- `host_identity` still comes from the *unresolved* URL, so request signatures keep committing to the `.local` name rather than the pinned IP — unchanged from 1.1.0.

`registry_url` is now a method returning `Result<Option<Url>, Error>`; its three call sites (`install`, `registry::context`, `registry::package::promote`) are updated.

## Notes

- start-cli `1.1.0` is a cut tag, so this opens a new prospective `1.1.1` heading and bumps the manifest + lockfile with it.
- Not compiled locally — a cold `start-core` build is heavy on my machine, so I'm leaning on the CI matrix here. Worth a look at the darwin leg in particular: `pin_mdns_host` is a no-op there, so `LazyPinnedUrl::get` just clones, but that path isn't exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)