### PR TITLE
docs(start-os): name the installer's Preserve button in the password-reset guides

### DIFF
--- a/projects/start-os/docs/src/forgot-password.md
+++ b/projects/start-os/docs/src/forgot-password.md
@@ -12,5 +12,5 @@ If no device is still signed in, you can reset your password by reinstalling Sta
 
 1. Download and flash the latest version of StartOS, using the appropriate [installation guide](installing-startos.md) for your hardware.
 1. Visit http://start.local.
-1. When selecting your data drive, select **Keep my data**.
+1. When prompted, select **Preserve** to keep your existing data.
 1. Create a new password and complete setup. All your previous addresses and data will be preserved.

--- a/projects/start-os/docs/src/reset-password.md
+++ b/projects/start-os/docs/src/reset-password.md
@@ -6,6 +6,6 @@ This guide should only be used if you have lost or forgotten your StartOS master
 
 1. Visit http://start.local
 
-1. When selecting your data drive, be sure to select "Keep my data".
+1. When prompted, select **Preserve** to keep your existing data.
 
 1. Create a new password and complete setup. All your previous addresses and data will be preserved.


### PR DESCRIPTION
Both password-reset guides told the user to select **Keep my data** when choosing a drive. That label does not exist in StartOS.

## The drift

The setup wizard's **StartOS Data Detected** dialog offers **Preserve** / **Overwrite** — see [`projects/start-os/web/setup-wizard/src/app/components/preserve-overwrite.dialog.ts`](https://github.com/Start9Labs/start-technologies/blob/master/projects/start-os/web/setup-wizard/src/app/components/preserve-overwrite.dialog.ts) (`Preserve` at L49 and L86, `Overwrite` at L53 and L75, the dialog heading at L35). "Keep my data" appears nowhere in the repo.

This matters more than a typical wording slip: `reset-password.md` and `forgot-password.md` are the two pages a **locked-out user lands on**. A wrong button name hits at the worst possible moment, on a screen where the other button erases their data.

## The fix

Both pages now name **Preserve**, matching the pages that already had it right — `installing-startos.md` (Install section) and `update-040.md` (Step 7, Flash Update tab).

The step is also reworded from "When selecting your data drive, select …" to "When prompted, select …": the dialog opens *after* the data drive has been chosen, not during selection, so the old phrasing folded two screens into one.

## Notes

- **Docs-only, no behavior change** — so no `CHANGELOG.md` entry, per the root `AGENTS.md` rule (which is conditioned on changes that alter user-visible behavior). Independently: `start-os/v0.4.0.1` is a cut tag on origin and the changelog's top heading is `## [0.4.0.1]`, so that line is fully released — an entry would require cutting a new heading and bumping the manifest, which a docs correction does not warrant.
- Swept the repo for other occurrences of the same drift; there are none. The remaining `to keep your data` hits are the real product strings in the dialog and `drives.page.ts`.

## Verification

- `mdbook build` on the StartOS book — clean.
- `prettier --check` on both pages — clean.
