### PR TITLE
docs(start-sdk): document retiring a task's replay key

### DIFF
--- a/projects/start-sdk/docs/src/dependencies.md
+++ b/projects/start-sdk/docs/src/dependencies.md
@@ -122,7 +122,7 @@ sdk.action.createTask(
   effects,
   packageId: string,         // dependency service ID
   action: ActionDefinition,  // imported from the dependency package
-  severity: 'critical' | 'high' | 'medium' | 'low',
+  severity: 'critical' | 'important' | 'optional',
   options?: {
     input?: { kind: 'partial', accept: Partial<InputSpec>[], set: Partial<InputSpec> },
     when?: { condition: 'input-not-matches', once: boolean },
@@ -137,7 +137,7 @@ sdk.action.createTask(
 > - Import the action object from the dependency's published package.
 > - The dependency must be listed in your `package.json` — see [Adding the Dependency to `package.json`](#adding-the-dependency-to-packagejson), including the required `overrides` entry.
 > - `when: { condition: 'input-not-matches', once: false }` re-triggers until the action's input matches.
-> - `replayId` prevents duplicate tasks across restarts.
+> - `replayId` prevents duplicate tasks across restarts. It defaults to `[package-id]:[action-id]`, so it changes whenever you rename the action, retarget the task, or point it at a different package — and the key you stop writing is left behind, still enforcing the old contract. Clearing it is your package's job: see [Retiring a replay key](./tasks.md#retiring-a-replay-key).
 
 > [!IMPORTANT]
 > **`accept` entries are matched against the dependency's _resolved_ action input, not its raw config file.** That input is the dependency action's prefill — its config parsed through its file model — so an optional field comes back carrying its **resolved default**, never a missing key. bitcoind's `prune`, for example, reads as the number `0` on an unpruned node (its file model coerces an absent `prune` to `0`), so `accept: [{ prune: 0 }]` matches an unpruned node exactly. Match the concrete value the input actually holds.

--- a/projects/start-sdk/docs/src/tasks.md
+++ b/projects/start-sdk/docs/src/tasks.md
@@ -117,7 +117,7 @@ With `condition: 'input-not-matches'`, the task is **satisfied** when the action
 
 ### Idempotency and `replayId`
 
-Tasks are idempotent by default. The SDK computes a default `replayId` of `[package-id]:[action-id]`, so calling `createOwnTask` / `createTask` multiple times with the same action does **not** create duplicate tasks — subsequent calls are no-ops against the same replay key. You can safely re-run your init function on every container rebuild without accumulating stale tasks.
+Tasks are idempotent by default. The SDK computes a default `replayId` of `[package-id]:[action-id]`, so calling `createOwnTask` / `createTask` multiple times with the same action does **not** create duplicate tasks — subsequent calls are no-ops against the same replay key. You can safely re-run your init function on every container rebuild without accumulating stale tasks — for as long as the key itself stays the same. See [Retiring a replay key](#retiring-a-replay-key) for what to do when it changes.
 
 Provide a custom `replayId` only when you need to intentionally create multiple distinct tasks for the same action (e.g., one-per-peer setup prompts). Each unique `replayId` becomes a separate task.
 
@@ -125,4 +125,37 @@ To cancel a task programmatically, clear it by its replay key:
 
 ```typescript
 await sdk.action.clearTask(effects, 'my-service:set-admin-password')
+```
+
+### Retiring a replay key
+
+The default key is derived from the action id, so it is stable only for as long as that id is. Change either half — **rename the action, point the task at a different action, or target a different package** — and the SDK writes a _new_ key. The old one is not rewritten and not reaped: it stays in the database exactly as last written, still enforcing a contract you no longer intend.
+
+**Clearing it is the job of the package that created the task**, in the migration for the version that changes the key:
+
+```typescript
+export const current = VersionInfo.of({
+  version: '1.2.0:1',
+  releaseNotes: { en_US: '…' },
+  migrations: {
+    up: async ({ effects }) => {
+      await sdk.action.clearTask(effects, 'bitcoind:other-config')
+    },
+  },
+})
+```
+
+Nothing else can do this for you. StartOS cannot distinguish a key you retired from one you simply did not write on a given run, and the SDK cannot reap "keys I did not create this run" because tasks are legitimately raised from init, from actions, and by other packages.
+
+Skipping it fails in one of two ways, neither of them visible from inside your own package:
+
+- **The retired action still exists.** Both keys stay live and both keep re-arming. If they set different values, satisfying one un-satisfies the other, and the user ping-pongs between them with no way to settle.
+- **The retired action is gone.** StartOS can no longer resolve its input, so the task's state freezes at whatever it last held. If that was active and `critical`, the package stays stopped and **no user action can clear it** — the task points at an action that no longer exists to be run.
+
+The same applies when a task becomes conditional. If you only raise it for some configurations — one backend of several, say — clear the keys for the branches you are not on, so a task never lingers against a service the user no longer talks to. `fulcrum-bch-startos` does this with a `NODE_TASK_KEYS` map and a single `clearTask` call covering every unselected node.
+
+A user already stuck in either state can only be recovered from the CLI, naming the package that _created_ the task (not the one it targets):
+
+```bash
+start-cli package action clear-task <creating-package> '<replay-id>' --force
 ```


### PR DESCRIPTION
## Why

A user updated StartOS, Knots, and DATUM Gateway and landed in an unrecoverable loop: two critical tasks on bitcoind's `blocknotify`, each demanding a different URL, each re-arming the moment the other was satisfied. DATUM was stopped the whole time, and no sequence of UI actions could settle it.

The cause is a documented-but-incomplete contract. `createTask` derives its `replayId` from `[package-id]:[action-id]`, so when Knots renamed its config action `other-config` → `autoconfig`, DATUM's next release minted a **new** key rather than updating the old one. Nothing rewrites or reaps the abandoned key — it sat in the database still enforcing `http://datum.startos:7152/NOTIFY` from a pre-2.0 release, while the live key demanded the bridge address. The OS honors the legacy task shape (`db/model/package.rs`), so the orphan stayed fully functional.

The guide covered `replayId` idempotency but never the flip side, and `tasks.md` actively asserted the opposite:

> You can safely re-run your init function on every container rebuild without accumulating stale tasks.

True only while the key itself is stable. That sentence is a fair part of why this went unnoticed.

An audit of the fleet found the same orphan in six other bitcoind dependents (lnd, fulcrum, mempool, public-pool, electrs, umbrel-bitcoin-ui). Those are currently harmless only because their demanded values happen to be unchanged — the next edit to any of those `accept`/`set` blocks reproduces this bug. A second class exists where the retired action was deleted rather than renamed; those are worse, because `recheck_tasks` can no longer resolve the action's input, the task's `active` flag freezes, and a frozen `active: true` + `critical` stops the package with no in-product remedy.

## What changed

**`tasks.md`**

- Qualified the idempotency claim and linked it to the new section.
- Added **Retiring a replay key**: what changes the key, that clearing it belongs to the package that created the task, the migration pattern, and why neither StartOS nor the SDK can do it automatically — the OS can't distinguish a retired key from one not written this run, and the SDK can't reap "keys I didn't create this run" because tasks are legitimately raised from init, from actions, and by other packages.
- Documented both failure modes, the conditional-task case (citing `fulcrum-bch-startos`'s `NODE_TASK_KEYS` + `clearTask`, which already solves this), and the `start-cli package action clear-task … --force` recovery path for boxes already stuck.

**`dependencies.md`**

- Expanded the one-line `replayId` note and cross-linked the new section, since that's where someone wiring up a cross-service task is actually reading.
- Fixed the `severity` union in the API signature: it read `'critical' | 'high' | 'medium' | 'low'`, but `TaskSeverity` is `'optional' | 'important' | 'critical'`. Unrelated to the incident, corrected in passing.

Docs-only; no SDK surface change, so no version bump or changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
