### PR TITLE
fix(start-os): give the StartOS UI back port 80

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -30,8 +30,9 @@ file tracks notable changes since the move to the monorepo.
 - **A service that adds an SSL port keeps the address you already had.** When a
   service gained an SSL port alongside a plaintext one it already had, the new
   SSL port took over the existing number and the plaintext port was moved to an
-  arbitrary one — changing an address you may have saved. Each port now keeps
-  its own.
+  arbitrary one — changing an address you may have saved. Each now keeps its
+  own: the port you already had stays where it is, and the one being added takes
+  the port the service asks for.
 
 - **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
   0.4.0.1 gave the interface a high-numbered port instead, and nothing answered

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -27,6 +27,12 @@ file tracks notable changes since the move to the monorepo.
   StartOS labels a failure that came from the runtime `Service Runtime Error`
   rather than `Unknown Error`.
 
+- **A service that adds an SSL port keeps the address you already had.** When a
+  service gained an SSL port alongside a plaintext one it already had, the new
+  SSL port took over the existing number and the plaintext port was moved to an
+  arbitrary one — changing an address you may have saved. Each port now keeps
+  its own.
+
 - **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
   0.4.0.1 gave the interface a high-numbered port instead, and nothing answered
   on it — so a service that reached the StartOS API over the container bridge,

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -27,6 +27,13 @@ file tracks notable changes since the move to the monorepo.
   StartOS labels a failure that came from the runtime `Service Runtime Error`
   rather than `Unknown Error`.
 
+- **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
+  0.4.0.1 gave the interface a high-numbered port instead, and nothing answered
+  on it — so a service that reached the StartOS API over the container bridge,
+  and any address StartOS reported for its own plaintext interface, pointed
+  somewhere dead. Existing servers move to port 80 on update, and the high port
+  goes back to the pool for services to use.
+
 - **The login banner reports system status for every user, not just the first
   one to log in.** It staged its database snapshot at a fixed path in `/tmp`,
   which `pam_motd` created as root at login — so any subsequent non-root run

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -308,26 +308,18 @@ impl BindInfo {
             interfaces,
             ..
         } = self;
-        // Release both ports up front so the numbers below can be reclaimed. The
-        // external port is in the user's address book and keys their per-address
-        // overrides, so a binding that changes how its port is served keeps the
-        // same number — carrying it to the other field when it holds just one.
-        // A binding that ends up serving both has nothing to carry: each leg wants
-        // its own preferred port, and carrying would hand one leg's number to the other.
+        // Free both up front so each leg can reclaim the number it already holds —
+        // it is in the user's address book and keys their per-address overrides.
         available_ports.free(held.assigned_port.into_iter().chain(held.assigned_ssl_port));
         let preferred_ssl_port = options.preferred_ssl_port();
         let wants_plain_port = options.wants_plain_port();
-        let serves_both = wants_plain_port && preferred_ssl_port.is_some();
-        let carried = match (held.assigned_port, held.assigned_ssl_port) {
-            (Some(port), None) | (None, Some(port)) if !serves_both => Some(port),
-            _ => None,
-        };
         let mut reclaim = |held: Option<u16>, preferred: u16, ssl: bool| {
-            let want = held.or(carried).unwrap_or(preferred);
-            available_ports
-                .try_alloc(want, ssl, privileged)
-                .or_else(|| available_ports.try_alloc(preferred, ssl, privileged))
-                .map_or_else(|| available_ports.alloc(ssl), Ok)
+            for port in held.into_iter().chain([preferred]) {
+                if let Some(port) = available_ports.try_alloc(port, ssl, privileged) {
+                    return Ok(port);
+                }
+            }
+            available_ports.alloc(ssl)
         };
 
         let assigned_ssl_port = preferred_ssl_port
@@ -1174,9 +1166,8 @@ mod test {
         assert_eq!(ui.net.assigned_ssl_port, Some(443));
     }
 
-    /// A binding that grows a second leg must not hand the leg it already has to
-    /// the new one: `carried` is for a port moving between the fields, not for a
-    /// binding that ends up serving both.
+    /// A binding that grows a second leg must not hand the port it already has to
+    /// the new one — each leg keeps its own.
     #[test]
     fn gaining_a_leg_does_not_carry_the_other_leg_s_port() {
         let mut ports = AvailablePorts::new();

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -312,9 +312,14 @@ impl BindInfo {
         // external port is in the user's address book and keys their per-address
         // overrides, so a binding that changes how its port is served keeps the
         // same number — carrying it to the other field when it holds just one.
+        // A binding that ends up serving both has nothing to carry: each leg wants
+        // its own preferred port, and carrying would hand one leg's number to the other.
         available_ports.free(held.assigned_port.into_iter().chain(held.assigned_ssl_port));
+        let preferred_ssl_port = options.preferred_ssl_port();
+        let wants_plain_port = options.wants_plain_port();
+        let serves_both = wants_plain_port && preferred_ssl_port.is_some();
         let carried = match (held.assigned_port, held.assigned_ssl_port) {
-            (Some(port), None) | (None, Some(port)) => Some(port),
+            (Some(port), None) | (None, Some(port)) if !serves_both => Some(port),
             _ => None,
         };
         let mut reclaim = |held: Option<u16>, preferred: u16, ssl: bool| {
@@ -325,12 +330,10 @@ impl BindInfo {
                 .map_or_else(|| available_ports.alloc(ssl), Ok)
         };
 
-        let assigned_ssl_port = options
-            .preferred_ssl_port()
+        let assigned_ssl_port = preferred_ssl_port
             .map(|preferred| reclaim(held.assigned_ssl_port, preferred, true))
             .transpose()?;
-        let assigned_port = options
-            .wants_plain_port()
+        let assigned_port = wants_plain_port
             .then(|| reclaim(held.assigned_port, options.preferred_external_port, false))
             .transpose()?;
 
@@ -1169,6 +1172,52 @@ mod test {
         let ui = ui.update(&mut ports, admin, true).unwrap();
         assert_eq!(ui.net.assigned_port, Some(80));
         assert_eq!(ui.net.assigned_ssl_port, Some(443));
+    }
+
+    /// A binding that grows a second leg must not hand the leg it already has to
+    /// the new one: `carried` is for a port moving between the fields, not for a
+    /// binding that ends up serving both.
+    #[test]
+    fn gaining_a_leg_does_not_carry_the_other_leg_s_port() {
+        let mut ports = AvailablePorts::new();
+        let privileged = false;
+        let plain = BindInfo::new(&mut ports, opts(8080, None, Some(false)), privileged).unwrap();
+        assert_eq!(plain.net.assigned_port, Some(8080));
+
+        let both = plain
+            .update(&mut ports, opts(8080, Some(8443), None), privileged)
+            .unwrap();
+        assert_eq!(both.net.assigned_port, Some(8080));
+        assert_eq!(both.net.assigned_ssl_port, Some(8443));
+    }
+
+    /// The seeded admin binding is the same shape from the other side, and its
+    /// plaintext leg must want 80 outright — not 443 with 80 as the fallback the
+    /// ssl leg's head start happens to force.
+    #[test]
+    fn the_os_ui_plaintext_leg_wants_80_even_when_443_is_free() {
+        let admin = opts(80, Some(443), None);
+        let seeded = || BindInfo {
+            enabled: false,
+            options: admin.clone(),
+            net: NetInfo {
+                assigned_port: None,
+                assigned_ssl_port: Some(443),
+            },
+            addresses: DerivedAddressInfo::default(),
+            interfaces: BTreeMap::new(),
+        };
+
+        let mut ports = AvailablePorts::new();
+        let ui = seeded().update(&mut ports, admin.clone(), true).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
+        assert_eq!(ui.net.assigned_ssl_port, Some(443));
+
+        // 443 already taken, so the ssl leg cannot clear it out of the plain leg's way.
+        let mut squatted = AvailablePorts::new();
+        assert_eq!(squatted.try_alloc(443, true, true), Some(443));
+        let ui = seeded().update(&mut squatted, admin, true).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
     }
 
     /// Why the drift needs `v0_4_0_2` rather than healing itself: `update`

--- a/shared-libs/crates/start-core/src/net/host/binding.rs
+++ b/shared-libs/crates/start-core/src/net/host/binding.rs
@@ -1143,6 +1143,58 @@ mod test {
         assert!(ports.is_ssl(443));
     }
 
+    /// `Public::init` plants the binding already holding 443 but no plaintext
+    /// port, so `os_bindings` only ever reaches it through `update` — the shape
+    /// the test above skips by starting from `new`, which is how the UI came to
+    /// ship on an ephemeral port through 0.4.0.
+    #[test]
+    fn the_os_ui_claims_80_from_the_seeded_binding() {
+        let mut ports = AvailablePorts::new();
+        let admin = opts(80, Some(443), None);
+        let seeded = BindInfo {
+            enabled: false,
+            options: admin.clone(),
+            net: NetInfo {
+                assigned_port: None,
+                assigned_ssl_port: Some(443),
+            },
+            addresses: DerivedAddressInfo::default(),
+            interfaces: BTreeMap::new(),
+        };
+
+        let ui = seeded.update(&mut ports, admin.clone(), true).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
+        assert_eq!(ui.net.assigned_ssl_port, Some(443));
+
+        let ui = ui.update(&mut ports, admin, true).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(80));
+        assert_eq!(ui.net.assigned_ssl_port, Some(443));
+    }
+
+    /// Why the drift needs `v0_4_0_2` rather than healing itself: `update`
+    /// keeps the port it already holds even for a privileged claimant whose
+    /// preferred port is free.
+    #[test]
+    fn a_drifted_os_ui_port_does_not_heal_on_rebind() {
+        let mut ports = AvailablePorts::new();
+        ports.set_ssl(443, true);
+        ports.set_ssl(55543, false);
+        let admin = opts(80, Some(443), None);
+        let drifted = BindInfo {
+            enabled: false,
+            options: admin.clone(),
+            net: NetInfo {
+                assigned_port: Some(55543),
+                assigned_ssl_port: Some(443),
+            },
+            addresses: DerivedAddressInfo::default(),
+            interfaces: BTreeMap::new(),
+        };
+
+        let ui = drifted.update(&mut ports, admin, true).unwrap();
+        assert_eq!(ui.net.assigned_port, Some(55543));
+    }
+
     #[test]
     fn gua_detection() {
         assert!(ipv6_addr("2001:db8::1", 443).gua().is_some()); // global unicast

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -574,18 +574,21 @@ impl NetServiceData {
                     .filter_map(|gw| net_ifaces.get(gw).and_then(|i| i.ip_info.as_ref()))
                     .flat_map(|ip| ip.subnets.iter().map(|s| s.addr()))
                     .collect();
-                forwards.insert(
-                    external,
-                    (
-                        SocketAddrV4::new(self.ip, *port),
-                        1,
-                        ForwardRequirements {
-                            public_gateways: fwd_public,
-                            private_ips: fwd_private,
-                            secure: bind.options.secure.is_some(),
-                        },
-                    ),
-                );
+                // StartOS answers these addresses itself, and a loopback DNAT is martian-dropped on ingress.
+                if !self.ip.is_loopback() {
+                    forwards.insert(
+                        external,
+                        (
+                            SocketAddrV4::new(self.ip, *port),
+                            1,
+                            ForwardRequirements {
+                                public_gateways: fwd_public,
+                                private_ips: fwd_private,
+                                secure: bind.options.secure.is_some(),
+                            },
+                        ),
+                    );
+                }
 
                 // No listener of ours answers here, so DNAT the host's
                 // GUA:external to the container's v6:internal. A LAN-only GUA is

--- a/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
@@ -8,6 +8,8 @@ lazy_static::lazy_static! {
     static ref V0_4_0_2: exver::Version = exver::Version::new([0, 4, 0, 2], []);
 }
 
+const UI_PORT: u64 = 80;
+
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Version;
 
@@ -24,10 +26,140 @@ impl VersionT for Version {
     fn compat(self) -> &'static VersionRange {
         &V0_3_0_COMPAT
     }
-    fn up(self, _db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+    #[instrument(skip_all)]
+    fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
+        rehome_admin_ui_port(db);
         Ok(Value::Null)
     }
     fn down(self, _db: &mut Value) -> Result<(), Error> {
+        // Every earlier version wants 80 here and keeps the port it finds.
         Ok(())
+    }
+}
+
+/// Give the StartOS UI back its well-known plaintext port.
+///
+/// `Public::init` plants the admin binding already holding `assignedSslPort`
+/// but not `assignedPort`, so `os_bindings` reaches it through `BindInfo::update`,
+/// which before #3558 could only fall through to a port at or above 49152 —
+/// and then kept it, since `update` prefers the port it already holds.
+///
+/// Nothing else can hold 80: it was unclaimable for everyone until #3558 and is
+/// privileged-only after it. Writing it also clears the unheld 80 that installs
+/// before #3558 were seeded with.
+fn rehome_admin_ui_port(db: &mut Value) {
+    let Some(net) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("serverInfo"))
+        .and_then(|s| s.get_mut("network"))
+        .and_then(|n| n.get_mut("host"))
+        .and_then(|h| h.get_mut("bindings"))
+        .and_then(|b| b.get_mut("80"))
+        .and_then(|b| b.get_mut("net"))
+        .and_then(|n| n.as_object_mut())
+    else {
+        return;
+    };
+    let held = net.get("assignedPort").and_then(|p| p.as_u64());
+    if held == Some(UI_PORT) {
+        return;
+    }
+    net.insert("assignedPort".into(), Value::from(UI_PORT));
+
+    let Some(available) = db
+        .get_mut("private")
+        .and_then(|p| p.get_mut("availablePorts"))
+        .and_then(|a| a.as_object_mut())
+    else {
+        return;
+    };
+    if let Some(held) = held {
+        available.remove(&InternedString::from_display(&held));
+    }
+    available.insert(InternedString::from_display(&UI_PORT), Value::Bool(false));
+}
+
+#[cfg(test)]
+mod test {
+    use imbl_value::json;
+
+    use super::*;
+
+    fn db(net: Value, available_ports: Value) -> Value {
+        json!({
+            "public": { "serverInfo": { "network": { "host": { "bindings": {
+                "80": { "net": net },
+            } } } } },
+            "private": { "availablePorts": available_ports }
+        })
+    }
+
+    fn net_of(db: &Value) -> &Value {
+        &db["public"]["serverInfo"]["network"]["host"]["bindings"]["80"]["net"]
+    }
+
+    // The shape a box installed before #3558 upgrades from: the plaintext leg
+    // drifted to an ephemeral port, and `availablePorts` still carries the 80
+    // that `Database::init` seeded but no binding ever held.
+    #[test]
+    fn rehomes_a_drifted_port_and_frees_it() {
+        let mut db = db(
+            json!({ "assignedPort": 55543, "assignedSslPort": 443 }),
+            json!({ "80": false, "443": true, "55543": false }),
+        );
+        rehome_admin_ui_port(&mut db);
+        assert_eq!(net_of(&db)["assignedPort"], json!(80));
+        assert_eq!(net_of(&db)["assignedSslPort"], json!(443));
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "80": false, "443": true })
+        );
+    }
+
+    // A box that came up through v0_4_0_alpha_20 had `availablePorts` rebuilt
+    // from its bindings, so it has no unheld 80 to clear.
+    #[test]
+    fn claims_80_when_no_seed_is_present() {
+        let mut db = db(
+            json!({ "assignedPort": 49876, "assignedSslPort": 443 }),
+            json!({ "443": true, "49876": false }),
+        );
+        rehome_admin_ui_port(&mut db);
+        assert_eq!(net_of(&db)["assignedPort"], json!(80));
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "80": false, "443": true })
+        );
+    }
+
+    #[test]
+    fn leaves_a_healthy_install_alone() {
+        let ports = json!({ "80": false, "443": true });
+        let mut db = db(json!({ "assignedPort": 80, "assignedSslPort": 443 }), ports);
+        let before = db.clone();
+        rehome_admin_ui_port(&mut db);
+        assert_eq!(db, before);
+    }
+
+    #[test]
+    fn claims_80_when_the_binding_holds_no_plaintext_port() {
+        let mut db = db(
+            json!({ "assignedPort": null, "assignedSslPort": 443 }),
+            json!({ "443": true }),
+        );
+        rehome_admin_ui_port(&mut db);
+        assert_eq!(net_of(&db)["assignedPort"], json!(80));
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "80": false, "443": true })
+        );
+    }
+
+    #[test]
+    fn tolerates_a_db_without_the_admin_binding() {
+        let mut db = json!({ "public": { "serverInfo": {} }, "private": {} });
+        let before = db.clone();
+        rehome_admin_ui_port(&mut db);
+        assert_eq!(db, before);
     }
 }


### PR DESCRIPTION
Fixes the StartOS UI's plaintext port sitting in the ephemeral range on every server installed before 0.4.0.1, and stops StartOS DNAT-ing its own plaintext port.

## Why the port drifts

`Public::init` plants the admin binding already holding `assignedSslPort` but not `assignedPort` (`db/model/public.rs:86-89`), and `clear_bindings` only disables entries rather than removing them — so `os_bindings` only ever reaches this binding through `BindInfo::update`, never `BindInfo::new`. `update` short-circuits on a held port, so the seeded 443 never reaches the allocator; that is why only the plaintext leg moved. `assignedPort` was `None`, so it asked for 80, and `is_restricted(port) = port <= 1024 || …` refused it outright, leaving `alloc()` — a random port at or above 49152. `update` then prefers the port it already holds, so the drift survived every reboot and upgrade.

Measured on a released-0.4.0 VM (`514af0c`):

```
admin binding   net = {assignedPort: 55543, assignedSslPort: 443}
availablePorts  {80: false, 443: true, 55543: false}
```

The unheld `80` there is the seed the pre-#3558 `Database::init` wrote. It was never the cause — `try_alloc`'s `||` short-circuits on `is_restricted` before `contains_key` — but it does block a later `try_alloc(80)`, so the migration has to clear it too.

`git tag --contains 1e8dbeeed` is only `start-os/v0.4.0.1`, so **shipped 0.4.0 is affected**. Fresh installs have been correct since 0.4.0.1 (`may_claim(port, privileged)` + `privileged = pkg_id.is_start_os()`), which is why this is a migration rather than a change to the allocator.

## Why it doesn't self-heal

`BindInfo::update` frees both held ports and then does `let want = held.or(carried).unwrap_or(preferred)`. `try_alloc(55543)` succeeds — it was freed one statement earlier — so `preferred` is never reached. That is deliberate and test-locked by `a_rebind_does_not_migrate_onto_a_freed_preferred_port`; `a_drifted_os_ui_port_does_not_heal_on_rebind` now pins it for the privileged case too, so the reason this needs a migration is visible in the tests.

## The plaintext leg now wants 80

`update` frees both ports and reclaims them, carrying the number to the other field when the binding holds just one — that is what keeps a saved address working when a binding changes how its port is served. But `carried` was consulted even when the binding ends up serving *both* legs, where nothing is moving and each leg should take its own preferred port.

So the second leg took the first leg's number. Measured:

```
plaintext binding on 8080 gains addSsl(8443)
  before: {assigned_port: 52981, assigned_ssl_port: 8080}
  after:  {assigned_port: 8080,  assigned_ssl_port: 8443}
```

The ssl leg claimed 8080 because it had been freed a statement earlier, the plaintext leg found its own number gone and fell through to `alloc()`, and 8443 was never used.

The admin binding is that same shape from the other side: it holds 443 from the seed and no plaintext port, so `want = held.or(carried).unwrap_or(preferred)` evaluated to **443**, not 80. It reached 80 only through the `.or_else(try_alloc(preferred))` fallback, and only because the ssl leg had re-taken 443 a few lines earlier in the same closure — reverse that order and the plaintext leg would have taken 443. It now wants 80 outright, which `the_os_ui_plaintext_leg_wants_80_even_when_443_is_free` pins by running the same rebind with 443 already held.

This does not replace the migration: `want` still prefers `held`, so a server already holding an ephemeral port keeps it (`a_drifted_os_ui_port_does_not_heal_on_rebind`).

## Why the DNAT goes away

`assignedPort` never becomes a socket for the OS: plain HTTP is a hardcoded `WildcardListener::new(80)` (`bins/startd.rs:162`). It drives advertised URLs and one nftables DNAT. `os_bindings` runs at `ip: [127,0,0,1]`, so `net_controller.rs:577` emits `<gateway>:<external> -> 127.0.0.1:80`, and the kernel drops a DNAT to loopback arriving on the bridge unless `route_localnet` is set — which appears nowhere in the tree. From a netns on `lxcbr0` on that VM:

```
http://10.0.3.1:80/     -> 200      (the wildcard listener)
http://10.0.3.1:55543/  -> no response
https://10.0.3.1:443/   -> 200
```

Setting `net.ipv4.conf.lxcbr0.route_localnet=1` made 55543 answer 200 and setting it back to 0 broke it again, confirming the drop.

So re-homing to 80 on its own would not have been enough — it would have moved the dead address rather than removed it, and by the same code path a fresh 0.4.0.1/master install is already installing a `10.0.3.1:80 -> 127.0.0.1:80` rule today. Hand-adding exactly that rule on the 0.4.0 box took a container's request to `10.0.3.1:80` from 200 to no response; deleting it restored 200. The forward had nothing to do in the first place — StartOS binds `[::]:80` plus one listener per address it answers on, so it could only shadow a port already served. `route_localnet=1` would be the wrong fix; it exposes every loopback-only service on the box.

## The version node

A migration needs a version node, and 0.4.0.1 is a cut release, so this adds `v0_4_0_2` and the manifest bump that `version::tests::current_matches_manifest` requires: `package.json`, the `0.4.0-rev.2` label, `Cargo.lock`, and the regenerated man page. `projects/start-os/CHANGELOG.md` already carried a prospective `## [0.4.0.2]` heading with two entries, so this lands under it. **If you would rather the cut be its own chore commit, say so and I will split it out.**

The docs' GitHub release link is deliberately **not** bumped: the docs site deploys from `master`, so moving it here would publish a link to a tag that does not exist yet. `VERSION_BUMP.md` had it listed among the files a version bump updates, which is how 0.4.0.1's link came to 404 for the two days between its bump and its release; the last commit moves it to the release cut, where `pre-check` already gates it. So `manage-release.sh pre-check start-os` now reports the docs link as still on 0.4.0.1 — expected until the cut — and passes its other source-of-truth checks (changelog heading, crate label, tag free), failing only on release machinery unavailable here (registry promotion, GPG key, s3cmd).

`down` is a no-op: every earlier version wants 80 for this binding and keeps whatever port it finds, so a rollback needs nothing undone.

## Verification

- `cargo test -p start-core --features test --lib` — 559 passed, including 5 new migration tests and 2 new binding tests
- `cargo test -p start-core --features test version::` — incl. `current_matches_manifest`
- `make manpages-check`, `make start-core-ts-bindings-check` — clean
- `npm ci` — lockfile in sync; `cargo fmt --check` and prettier clean
- `./scripts/manage-release.sh pre-check start-os` — as above

Not verified on hardware: a fresh master install was not measured, because the local master VM template predates #3558. The fresh-install path is covered by `the_os_ui_claims_80_from_the_seeded_binding`, which starts from the exact shape `Public::init` produces.
