### PR TITLE
fix(start-os): remove an interface's old record when re-export moves it

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -28,6 +28,15 @@ file tracks notable changes since the move to the monorepo.
   published port range. It withdraws both when the address is disabled or
   deleted.
 
+- **An interface a service update moves to a different internal port is listed
+  once, not twice.** StartOS keeps a service's former port binding dormant so
+  its addresses and external port survive if the service returns to it — but
+  the interface record exported from that binding lingered too, so after an
+  update like Jitsi's (Web UI moved from port 80 to 8000) the service showed
+  the same interface twice. Exporting an interface now removes the record of
+  its previous export, wherever it lived; a lingering duplicate clears the next
+  time its service initializes — at the reboot this update performs.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/shared-libs/crates/start-core/src/service/effects/net/interface.rs
+++ b/shared-libs/crates/start-core/src/service/effects/net/interface.rs
@@ -59,11 +59,14 @@ pub async fn export_service_interface(
         .ctx
         .db
         .mutate(|db| {
-            db.as_public_mut()
+            let hosts = db
+                .as_public_mut()
                 .as_package_data_mut()
                 .as_idx_mut(&package_id)
                 .or_not_found(&package_id)?
-                .as_hosts_mut()
+                .as_hosts_mut();
+            remove_interface_records(hosts, &id)?;
+            hosts
                 .as_idx_mut(&host_id)
                 .or_not_found(&host_id)?
                 .as_bindings_mut()
@@ -117,11 +120,14 @@ pub async fn export_range_service_interface(
         .ctx
         .db
         .mutate(|db| {
-            db.as_public_mut()
+            let hosts = db
+                .as_public_mut()
                 .as_package_data_mut()
                 .as_idx_mut(&package_id)
                 .or_not_found(&package_id)?
-                .as_hosts_mut()
+                .as_hosts_mut();
+            remove_interface_records(hosts, &interface.id)?;
+            hosts
                 .as_idx_mut(&host_id)
                 .or_not_found(&host_id)?
                 .as_binding_ranges_mut()
@@ -133,6 +139,30 @@ pub async fn export_range_service_interface(
         .await
         .result?;
 
+    Ok(())
+}
+
+/// An exported interface id lives under exactly one binding or range. When a
+/// package update moves an interface (new internal port, host, or origin kind),
+/// re-exporting it must remove the record under its old location —
+/// `clear_service_interfaces` won't, since the id is still exported.
+fn remove_interface_records(
+    hosts: &mut Model<Hosts>,
+    id: &ServiceInterfaceId,
+) -> Result<(), Error> {
+    for (_, host) in hosts.as_entries_mut()? {
+        for (_, bind) in host.as_bindings_mut().as_entries_mut()? {
+            bind.as_interfaces_mut().remove(id)?;
+        }
+        for (_, range) in host.as_binding_ranges_mut().as_entries_mut()? {
+            range.as_interface_mut().mutate(|iface| {
+                if iface.as_ref().map_or(false, |i| &i.id == id) {
+                    *iface = None;
+                }
+                Ok(())
+            })?;
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

After updating Jitsi (Web UI internal port moved 80 → 8000), the service's
Interfaces page showed two "Web UI" entries. The db held two records of the
same interface id — one under the dormant port-80 binding, one under the
live port-8000 binding:

- A service interface record lives under the binding it was exported from
  (`hosts/{hostId}/bindings/{internalPort}/interfaces/{id}`).
- When a package update moves an interface to a different internal port, the
  old binding is kept dormant by design (its external port and address book
  survive for a future rebind) — but the interface record exported from it
  lingered too: `clear_service_interfaces` retains by interface id alone, and
  the id is still exported, so the stale record survived every setup pass.
- Beyond the double listing, `find_service_interface` scans bindings in port
  order and took the stale record first (80 < 8000), so the
  `getServiceInterface` effect and interface callback watches resolved the
  wrong node, and the Launch UI menu / port-forward labels flattened the same
  duplicate.

## Fix

`exportServiceInterface` / `exportRangeServiceInterface` now remove any
record of the exported id across the package's hosts, bindings, and ranges
before inserting at its current location — an exported interface id lives in
exactly one place. No frontend change: the UI was faithfully rendering what
the db contained.

Existing stale records self-heal on the next service init (install, update,
restore, rebuild, or server boot — the OS update's reboot re-inits every
installed service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)