### PR TITLE
fix(sdk): don't SIGKILL a database dump copy after 30 seconds

### DIFF
--- a/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
+++ b/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
@@ -138,7 +138,10 @@ export class DockerProcedureContainer extends Drop {
     timeoutMs?: number | null,
   ) {
     try {
-      return await this.subcontainer.exec(commands, { ...options, timeoutMs })
+      return await this.subcontainer.exec(commands, {
+        ...options,
+        timeout: timeoutMs,
+      })
     } finally {
       await this.subcontainer.destroy?.()
     }
@@ -152,7 +155,7 @@ export class DockerProcedureContainer extends Drop {
     try {
       const res = await this.subcontainer.exec(commands, {
         ...options,
-        timeoutMs,
+        timeout: timeoutMs,
       })
       if (res.exitCode !== 0) {
         const codeOrSignal =

--- a/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
+++ b/projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/DockerProcedureContainer.ts
@@ -138,7 +138,7 @@ export class DockerProcedureContainer extends Drop {
     timeoutMs?: number | null,
   ) {
     try {
-      return await this.subcontainer.exec(commands, options, timeoutMs)
+      return await this.subcontainer.exec(commands, { ...options, timeoutMs })
     } finally {
       await this.subcontainer.destroy?.()
     }
@@ -150,7 +150,10 @@ export class DockerProcedureContainer extends Drop {
     options?: CommandOptions & ExecOptions,
   ) {
     try {
-      const res = await this.subcontainer.exec(commands, options, timeoutMs)
+      const res = await this.subcontainer.exec(commands, {
+        ...options,
+        timeoutMs,
+      })
       if (res.exitCode !== 0) {
         const codeOrSignal =
           res.exitCode !== null

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -9,13 +9,13 @@
   a package built with this SDK now writes as its manifest `osVersion` — so the
   registry offers that package to servers on 0.4.0 or later
 
-- **`SubContainer.exec` / `execFail` take `timeoutMs` and `abort` as named
+- **`SubContainer.exec` / `execFail` take `timeout` and `abort` as named
   options rather than as third and fourth positional arguments.**
   `sub.execFail(cmd, { user: 'root' }, null)` becomes
-  `sub.execFail(cmd, { user: 'root', timeoutMs: null })`. A bare `null` in the
+  `sub.execFail(cmd, { user: 'root', timeout: null })`. A bare `null` in the
   third position gave no hint which of the two knobs it was setting or what it
   meant, and reaching the fourth argument meant supplying the third. Both moved
-  together because dropping only `timeoutMs` would have left `abort` sliding
+  together because dropping only `timeout` would have left `abort` sliding
   into a position whose type it does not match. Passing either positionally is
   now a compile error, so anything that needs updating says so at build time
 
@@ -129,7 +129,7 @@
   cp timed out after 30000ms and was killed with SIGKILL:
   ```
 
-  `exec`'s result carries `timedOutAfterMs` — the limit that fired, or `null`
+  `exec`'s result carries `timedOutAfter` — the limit that fired, or `null`
   when the process was not killed by this timer — alongside `exitCode` and
   `exitSignal`
 

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -9,6 +9,16 @@
   a package built with this SDK now writes as its manifest `osVersion` — so the
   registry offers that package to servers on 0.4.0 or later
 
+- **`SubContainer.exec` / `execFail` take `timeoutMs` and `abort` as named
+  options rather than as third and fourth positional arguments.**
+  `sub.execFail(cmd, { user: 'root' }, null)` becomes
+  `sub.execFail(cmd, { user: 'root', timeoutMs: null })`. A bare `null` in the
+  third position gave no hint which of the two knobs it was setting or what it
+  meant, and reaching the fourth argument meant supplying the third. Both moved
+  together because dropping only `timeoutMs` would have left `abort` sliding
+  into a position whose type it does not match. Passing either positionally is
+  now a compile error, so anything that needs updating says so at build time
+
 ### Added
 
 - **`sdk.getRootCa(effects)` returns this server's root CA certificate.** A

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -75,6 +75,54 @@
   one, so the guard only duplicated that check while giving the filename a
   second place to go stale. Cosmetic — no build ever failed over it
 
+- **A database dump backup or restore is no longer killed after exactly thirty
+  seconds.** Steps in `Backups.withPgDump` / `Backups.withMysqlDump` run under
+  `SubContainer.exec`'s default 30 s cap unless they opt out, and 1.5.2 — which
+  began staging the dump in `/tmp` and copying it to the backup target, rather
+  than dumping onto the target directly — left the opt-out on `pg_dump` and
+  gave the new `cp` none. The copy's duration is set by the size of the dump and
+  the speed of the target. So a backup that had succeeded for months began
+  failing the first time that copy crossed thirty seconds, with nothing to point
+  at the cause:
+
+  ```
+  Failed: Unknown Error: Error: cp terminated with signal SIGKILL:
+  ```
+
+  Restore stages the dump off the target through the same kind of copy, under
+  the same cap — so a database whose dump took longer than thirty seconds to
+  copy could not be restored at all, which is discovered during recovery, when
+  the backup is all the user has. Every step of a dump or restore whose
+  duration follows the data now opts out: both copies, `pg_ctl start` and
+  `pg_ctl stop` (which wait on the cluster's crash recovery and its shutdown
+  checkpoint), the recursive `chown`s over the data directory, `initdb`,
+  `mysql_install_db` / `mysqld --initialize-insecure`, and the foreground
+  `mysqld` MariaDB runs for the length of the dump.
+
+  The two `pg_ctl` steps keep a bound, because `pg_ctl` has its own: `-w` is its
+  default and it gives up after `-t` seconds, which was 60 regardless of what
+  the SDK allowed. `PgDumpConfig.readyTimeout` — the knob 2.0.1 added for
+  clusters that need longer — now supplies that `-t`, so raising it reaches the
+  step that actually blocks instead of stopping at the readiness poll. Its
+  default is 60 000 ms, which is `pg_ctl`'s own default, so nothing changes
+  until you raise it. Fixes
+  [#3636](https://github.com/Start9Labs/start-technologies/issues/3636)
+
+- **A command killed by `SubContainer.exec`'s own timeout now says that it timed
+  out.** The error was built from the signal alone, so the SDK's timer read
+  exactly like an OOM kill, a cgroup kill, or an operator's `kill -9` — and
+  since `cp` writes nothing to stderr when it is killed, the whole user-facing
+  notification was `cp terminated with signal SIGKILL:`. The message now names
+  the timeout and the limit that elapsed:
+
+  ```
+  cp timed out after 30000ms and was killed with SIGKILL:
+  ```
+
+  `exec`'s result carries `timedOutAfterMs` — the limit that fired, or `null`
+  when the process was not killed by this timer — alongside `exitCode` and
+  `exitSignal`
+
 ## 2.0.9 — StartOS 0.4.0-beta.10 (2026-07-25)
 
 ### Fixed

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -499,14 +499,17 @@ The `user` option is optional. If omitted, commands run as the default user defi
 
 ### Commands That Run Longer Than 30 Seconds
 
-`exec` and `execFail` both take a third argument, `timeoutMs`: how long the SDK waits before it gives up and fails the call. It defaults to **30 s**, so a command that legitimately takes longer — cloning a large repository, importing a database, copying a multi-gigabyte file — fails partway through unless you say otherwise. Pass `null` to wait as long as it takes:
+`exec` and `execFail` take a `timeoutMs` option: how long the SDK waits before it gives up and fails the call. It defaults to **30 s**, so a command that legitimately takes longer — cloning a large repository, importing a database, copying a multi-gigabyte file — fails partway through unless you say otherwise. Pass `null` to wait as long as it takes:
 
 ```typescript
 // Gives up after 30 s — fine for a command that either answers quickly or is stuck
 await appSub.execFail(['update-ca-certificates'], { user: 'root' })
 
 // No limit — takes as long as the database takes
-await appSub.execFail(['pg_restore', '-U', user, '-d', database, dumpFile], { user: 'postgres' }, null)
+await appSub.execFail(['pg_restore', '-U', user, '-d', database, dumpFile], {
+  user: 'postgres',
+  timeoutMs: null,
+})
 ```
 
 Opt out whenever the runtime is set by something you cannot bound: the size of the data, the speed of a disk or backup target, or another process you are waiting on. Keep the default for commands that should answer promptly, where the timeout is what stops a wedged container from hanging the service.

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -477,7 +477,7 @@ if (result.exitCode !== 0) {
 
 // execFail() - throws on error (good for required commands)
 // Uses the default user from the Dockerfile (no need to specify { user: '...' })
-await appSub.execFail(['git', 'clone', 'https://github.com/user/repo.git'])
+await appSub.execFail(['myapp', 'check-config'])
 
 // Override user when needed (e.g., run as root)
 await appSub.exec(['update-ca-certificates'], { user: 'root' })
@@ -496,6 +496,23 @@ The `user` option is optional. If omitted, commands run as the default user defi
 - The command failure is not critical (warnings, optional setup)
 - You need to inspect the exit code or output regardless of success/failure
 - You want custom error handling logic
+
+### Commands That Run Longer Than 30 Seconds
+
+`exec` and `execFail` both take a third argument, `timeoutMs`: how long the SDK waits before it gives up and fails the call. It defaults to **30 s**, so a command that legitimately takes longer — cloning a large repository, importing a database, copying a multi-gigabyte file — fails partway through unless you say otherwise. Pass `null` to wait as long as it takes:
+
+```typescript
+// Gives up after 30 s — fine for a command that either answers quickly or is stuck
+await appSub.execFail(['update-ca-certificates'], { user: 'root' })
+
+// No limit — takes as long as the database takes
+await appSub.execFail(['pg_restore', '-U', user, '-d', database, dumpFile], { user: 'postgres' }, null)
+```
+
+Opt out whenever the runtime is set by something you cannot bound: the size of the data, the speed of a disk or backup target, or another process you are waiting on. Keep the default for commands that should answer promptly, where the timeout is what stops a wedged container from hanging the service.
+
+> [!NOTE]
+> On timeout the SDK sends `SIGKILL` to the process it spawned and reports `timed out after <n>ms and was killed with SIGKILL`; `exec()`'s result carries `timedOutAfterMs`, set to the limit that elapsed. The command itself runs inside the subcontainer and is not signalled — it stops when the subcontainer is torn down, so treat a timeout as "the SDK stopped waiting", not "the work stopped".
 
 ## PostgreSQL Sidecar
 

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -499,7 +499,7 @@ The `user` option is optional. If omitted, commands run as the default user defi
 
 ### Commands That Run Longer Than 30 Seconds
 
-`exec` and `execFail` take a `timeoutMs` option: how long the SDK waits before it gives up and fails the call. It defaults to **30 s**, so a command that legitimately takes longer — cloning a large repository, importing a database, copying a multi-gigabyte file — fails partway through unless you say otherwise. Pass `null` to wait as long as it takes:
+`exec` and `execFail` take a `timeout` option: how long the SDK waits before it gives up and fails the call. It defaults to **30 s**, so a command that legitimately takes longer — cloning a large repository, importing a database, copying a multi-gigabyte file — fails partway through unless you say otherwise. Pass `null` to wait as long as it takes:
 
 ```typescript
 // Gives up after 30 s — fine for a command that either answers quickly or is stuck
@@ -508,14 +508,14 @@ await appSub.execFail(['update-ca-certificates'], { user: 'root' })
 // No limit — takes as long as the database takes
 await appSub.execFail(['pg_restore', '-U', user, '-d', database, dumpFile], {
   user: 'postgres',
-  timeoutMs: null,
+  timeout: null,
 })
 ```
 
 Opt out whenever the runtime is set by something you cannot bound: the size of the data, the speed of a disk or backup target, or another process you are waiting on. Keep the default for commands that should answer promptly, where the timeout is what stops a wedged container from hanging the service.
 
 > [!NOTE]
-> On timeout the SDK sends `SIGKILL` to the process it spawned and reports `timed out after <n>ms and was killed with SIGKILL`; `exec()`'s result carries `timedOutAfterMs`, set to the limit that elapsed. The command itself runs inside the subcontainer and is not signalled — it stops when the subcontainer is torn down, so treat a timeout as "the SDK stopped waiting", not "the work stopped".
+> On timeout the SDK sends `SIGKILL` to the process it spawned and reports `timed out after <n>ms and was killed with SIGKILL`; `exec()`'s result carries `timedOutAfter`, set to the limit that elapsed. The command itself runs inside the subcontainer and is not signalled — it stops when the subcontainer is torn down, so treat a timeout as "the SDK stopped waiting", not "the work stopped".
 
 ## PostgreSQL Sidecar
 

--- a/projects/start-sdk/lib/backup/Backups.ts
+++ b/projects/start-sdk/lib/backup/Backups.ts
@@ -12,6 +12,8 @@ import {
 
 const BACKUP_HOST_PATH = '/media/startos/backup'
 const BACKUP_CONTAINER_MOUNT = '/backup-target'
+// these steps can outlast exec's 30 s default
+const NO_TIMEOUT = null
 
 /** A password value, or a function that returns one. Functions are resolved lazily (only during restore). */
 export type LazyPassword = string | (() => string | Promise<string>) | null
@@ -41,7 +43,7 @@ export type PgDumpConfig<M extends T.SDKManifest> = {
   initdbArgs?: string[]
   /** Additional options passed to `pg_ctl start -o` (e.g. '-c shared_preload_libraries=vectorchord'). Appended after `-c listen_addresses=`. */
   pgOptions?: string
-  /** Milliseconds to wait for PostgreSQL to accept connections before failing (default 60000). Raise for large clusters that need longer to start or run crash recovery. */
+  /** Milliseconds to wait for PostgreSQL to accept connections before failing (default 60000). Also passed to `pg_ctl` as `-t`, bounding its own wait for startup and for the shutdown checkpoint. Raise for large clusters that need longer to start, run crash recovery, or shut down. */
   readyTimeout?: number
 }
 
@@ -193,7 +195,8 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * this uses `pg_dump` to create a logical dump before backup and `pg_restore` to rebuild
    * the database after restore.
    *
-   * The dump file is written directly to the backup target — no data duplication on disk.
+   * The dump is staged in the subcontainer's `/tmp` and copied to the backup
+   * target, so it needs transient room for one copy of the dump.
    *
    * @returns A configured Backups instance with pre/post hooks. Chain `.addVolume()` or
    * `.addSync()` to include additional volumes/paths in the backup.
@@ -214,6 +217,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       readyTimeout = 60_000,
     } = config
     const pgdata = `${mountpoint}${pgdataPath}`
+    const pgCtlTimeout = String(Math.ceil(readyTimeout / 1000))
     const dumpFile = `${BACKUP_CONTAINER_MOUNT}/${database}-db.dump`
     // pg_dump's writes are silently dropped on the backup-fs FUSE mount —
     // pg_dump exits 0 but the file stays 0 bytes. `cp` writes through the
@@ -231,17 +235,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       })
     }
 
-    async function startPg(
-      sub: {
-        exec(cmd: string[], opts?: any): Promise<{ exitCode: number | null }>
-        execFail(
-          cmd: string[],
-          opts?: any,
-          timeout?: number | null,
-        ): Promise<any>
-      },
-      label: string,
-    ) {
+    async function startPg(sub: SubContainer<M>, label: string) {
       await sub.exec(['rm', '-f', `${pgdata}/postmaster.pid`], {
         user: 'postgres',
       })
@@ -255,9 +249,20 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       const pgStartOpts = pgOptions
         ? `-c listen_addresses= ${pgOptions}`
         : '-c listen_addresses='
-      await sub.execFail(['pg_ctl', 'start', '-D', pgdata, '-o', pgStartOpts], {
-        user: 'postgres',
-      })
+      await sub.execFail(
+        [
+          'pg_ctl',
+          'start',
+          '-D',
+          pgdata,
+          '-t',
+          pgCtlTimeout,
+          '-o',
+          pgStartOpts,
+        ],
+        { user: 'postgres' },
+        NO_TIMEOUT,
+      )
       for (let elapsed = 0; elapsed < readyTimeout; elapsed += 1000) {
         const { exitCode } = await sub.exec(['pg_isready', '-U', user], {
           user: 'postgres',
@@ -292,14 +297,20 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             await sub.execFail(
               ['pg_dump', '-U', user, '-Fc', '-f', tmpDumpFile, database],
               { user: 'postgres' },
-              null,
+              NO_TIMEOUT,
             )
             console.log('[pg-dump] copying dump to backup target')
-            await sub.execFail(['cp', tmpDumpFile, dumpFile], { user: 'root' })
+            await sub.execFail(
+              ['cp', tmpDumpFile, dumpFile],
+              { user: 'root' },
+              NO_TIMEOUT,
+            )
             console.log('[pg-dump] stopping postgres')
-            await sub.execFail(['pg_ctl', 'stop', '-D', pgdata, '-w'], {
-              user: 'postgres',
-            })
+            await sub.execFail(
+              ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
+              { user: 'postgres' },
+              NO_TIMEOUT,
+            )
             console.log('[pg-dump] complete')
           },
         )
@@ -315,17 +326,23 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             await mountBackupTarget(sub.rootfs)
             // Stage the dump off the FUSE before pg_restore reads it — see
             // the comment on `tmpDumpFile` above.
-            await sub.execFail(['cp', dumpFile, tmpDumpFile], { user: 'root' })
+            await sub.execFail(
+              ['cp', dumpFile, tmpDumpFile],
+              { user: 'root' },
+              NO_TIMEOUT,
+            )
             await sub.execFail(['chown', 'postgres:postgres', tmpDumpFile], {
               user: 'root',
             })
             await sub.execFail(
               ['chown', '-R', 'postgres:postgres', mountpoint],
               { user: 'root' },
+              NO_TIMEOUT,
             )
             await sub.execFail(
               ['initdb', '-D', pgdata, '-U', user, ...initdbArgs],
               { user: 'postgres' },
+              NO_TIMEOUT,
             )
             await startPg(sub, 'pg-restore')
             await sub.execFail(['createdb', '-U', user, database], {
@@ -343,7 +360,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 tmpDumpFile,
               ],
               { user: 'postgres' },
-              null,
+              NO_TIMEOUT,
             )
             if (resolvedPassword !== null) {
               await sub.execFail(
@@ -359,9 +376,11 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 { user: 'postgres' },
               )
             }
-            await sub.execFail(['pg_ctl', 'stop', '-D', pgdata, '-w'], {
-              user: 'postgres',
-            })
+            await sub.execFail(
+              ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
+              { user: 'postgres' },
+              NO_TIMEOUT,
+            )
           },
         )
       })
@@ -374,7 +393,8 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
    * this uses `mysqldump` to create a logical dump before backup and `mysql` to restore
    * the database after restore.
    *
-   * The dump file is stored temporarily in `dumpVolume` during backup and cleaned up afterward.
+   * The dump is staged in the subcontainer's `/tmp` and copied to the backup
+   * target, so it needs transient room for one copy of the dump.
    *
    * @returns A configured Backups instance with pre/post hooks. Chain `.addVolume()` or
    * `.addSync()` to include additional volumes/paths in the backup.
@@ -409,10 +429,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       })
     }
 
-    async function waitForMysql(
-      sub: { exec(cmd: string[]): Promise<{ exitCode: number | null }> },
-      cmd: string[],
-    ) {
+    async function waitForMysql(sub: SubContainer<M>, cmd: string[]) {
       for (let elapsed = 0; elapsed < readyTimeout; elapsed += 1000) {
         const { exitCode } = await sub.exec(cmd)
         if (exitCode === 0) return
@@ -423,10 +440,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
       )
     }
 
-    async function startMysql(sub: {
-      exec(cmd: string[], opts?: any): Promise<{ exitCode: number | null }>
-      execFail(cmd: string[], opts?: any, timeout?: number | null): Promise<any>
-    }) {
+    async function startMysql(sub: SubContainer<M>) {
       if (engine === 'mariadb') {
         // MariaDB doesn't support --daemonize; fire-and-forget the exec
         sub
@@ -439,6 +453,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               ...mysqldOptions,
             ],
             { user: 'root' },
+            NO_TIMEOUT,
           )
           .catch(e =>
             console.error('[mysql-backup] mysqld exited unexpectedly:', e),
@@ -454,15 +469,12 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             ...mysqldOptions,
           ],
           { user: 'root' },
-          null,
+          NO_TIMEOUT,
         )
       }
     }
 
-    async function stopMysql(sub: {
-      exec(cmd: string[], opts?: any): Promise<{ exitCode: number | null }>
-      execFail(cmd: string[], opts?: any, timeout?: number | null): Promise<any>
-    }) {
+    async function stopMysql(sub: SubContainer<M>) {
       // SIGTERM mysqld and wait for it to finish flushing before teardown.
       // A killed-but-unreaped mysqld lingers as a zombie that keeps its PID,
       // so `tail --pid`/`kill -0` would block here forever — treat the zombie
@@ -485,7 +497,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           ].join('\n'),
         ],
         { user: 'root' },
-        null,
+        NO_TIMEOUT,
       )
     }
 
@@ -514,9 +526,11 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               user: 'root',
             })
             if (engine === 'mysql') {
-              await sub.execFail(['chown', '-R', 'mysql:mysql', datadir], {
-                user: 'root',
-              })
+              await sub.execFail(
+                ['chown', '-R', 'mysql:mysql', datadir],
+                { user: 'root' },
+                NO_TIMEOUT,
+              )
             }
             await startMysql(sub)
             await waitForMysql(sub, readyCmd)
@@ -531,9 +545,13 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 database,
               ],
               { user: 'root' },
-              null,
+              NO_TIMEOUT,
             )
-            await sub.execFail(['cp', tmpDumpFile, dumpFile], { user: 'root' })
+            await sub.execFail(
+              ['cp', tmpDumpFile, dumpFile],
+              { user: 'root' },
+              NO_TIMEOUT,
+            )
             await stopMysql(sub)
           },
         )
@@ -558,6 +576,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               await sub.execFail(
                 ['mysql_install_db', '--user=mysql', `--datadir=${datadir}`],
                 { user: 'root' },
+                NO_TIMEOUT,
               )
             } else {
               await sub.execFail(
@@ -568,6 +587,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                   `--datadir=${datadir}`,
                 ],
                 { user: 'root' },
+                NO_TIMEOUT,
               )
             }
             await startMysql(sub)
@@ -589,7 +609,11 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             })
             // Stage the dump off the FUSE before mysql reads it — see
             // the comment on `tmpDumpFile` above.
-            await sub.execFail(['cp', dumpFile, tmpDumpFile], { user: 'root' })
+            await sub.execFail(
+              ['cp', dumpFile, tmpDumpFile],
+              { user: 'root' },
+              NO_TIMEOUT,
+            )
             // Restore from dump
             await sub.execFail(
               [
@@ -598,7 +622,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 `mysql -u root ${pw !== null ? `-p'${pw}'` : ''} ${database} < ${tmpDumpFile}`,
               ],
               { user: 'root' },
-              null,
+              NO_TIMEOUT,
             )
             await stopMysql(sub)
           },

--- a/projects/start-sdk/lib/backup/Backups.ts
+++ b/projects/start-sdk/lib/backup/Backups.ts
@@ -258,7 +258,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           '-o',
           pgStartOpts,
         ],
-        { user: 'postgres', timeoutMs: null },
+        { user: 'postgres', timeout: null },
       )
       for (let elapsed = 0; elapsed < readyTimeout; elapsed += 1000) {
         const { exitCode } = await sub.exec(['pg_isready', '-U', user], {
@@ -293,17 +293,17 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             console.log('[pg-dump] dumping database')
             await sub.execFail(
               ['pg_dump', '-U', user, '-Fc', '-f', tmpDumpFile, database],
-              { user: 'postgres', timeoutMs: null },
+              { user: 'postgres', timeout: null },
             )
             console.log('[pg-dump] copying dump to backup target')
             await sub.execFail(['cp', tmpDumpFile, dumpFile], {
               user: 'root',
-              timeoutMs: null,
+              timeout: null,
             })
             console.log('[pg-dump] stopping postgres')
             await sub.execFail(
               ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
-              { user: 'postgres', timeoutMs: null },
+              { user: 'postgres', timeout: null },
             )
             console.log('[pg-dump] complete')
           },
@@ -322,18 +322,18 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             // the comment on `tmpDumpFile` above.
             await sub.execFail(['cp', dumpFile, tmpDumpFile], {
               user: 'root',
-              timeoutMs: null,
+              timeout: null,
             })
             await sub.execFail(['chown', 'postgres:postgres', tmpDumpFile], {
               user: 'root',
             })
             await sub.execFail(
               ['chown', '-R', 'postgres:postgres', mountpoint],
-              { user: 'root', timeoutMs: null },
+              { user: 'root', timeout: null },
             )
             await sub.execFail(
               ['initdb', '-D', pgdata, '-U', user, ...initdbArgs],
-              { user: 'postgres', timeoutMs: null },
+              { user: 'postgres', timeout: null },
             )
             await startPg(sub, 'pg-restore')
             await sub.execFail(['createdb', '-U', user, database], {
@@ -350,7 +350,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 '--no-privileges',
                 tmpDumpFile,
               ],
-              { user: 'postgres', timeoutMs: null },
+              { user: 'postgres', timeout: null },
             )
             if (resolvedPassword !== null) {
               await sub.execFail(
@@ -368,7 +368,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             }
             await sub.execFail(
               ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
-              { user: 'postgres', timeoutMs: null },
+              { user: 'postgres', timeout: null },
             )
           },
         )
@@ -441,7 +441,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               '--bind-address=127.0.0.1',
               ...mysqldOptions,
             ],
-            { user: 'root', timeoutMs: null },
+            { user: 'root', timeout: null },
           )
           .catch(e =>
             console.error('[mysql-backup] mysqld exited unexpectedly:', e),
@@ -456,7 +456,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             '--daemonize',
             ...mysqldOptions,
           ],
-          { user: 'root', timeoutMs: null },
+          { user: 'root', timeout: null },
         )
       }
     }
@@ -483,7 +483,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             'done',
           ].join('\n'),
         ],
-        { user: 'root', timeoutMs: null },
+        { user: 'root', timeout: null },
       )
     }
 
@@ -514,7 +514,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             if (engine === 'mysql') {
               await sub.execFail(['chown', '-R', 'mysql:mysql', datadir], {
                 user: 'root',
-                timeoutMs: null,
+                timeout: null,
               })
             }
             await startMysql(sub)
@@ -529,11 +529,11 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 `--result-file=${tmpDumpFile}`,
                 database,
               ],
-              { user: 'root', timeoutMs: null },
+              { user: 'root', timeout: null },
             )
             await sub.execFail(['cp', tmpDumpFile, dumpFile], {
               user: 'root',
-              timeoutMs: null,
+              timeout: null,
             })
             await stopMysql(sub)
           },
@@ -558,7 +558,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             if (engine === 'mariadb') {
               await sub.execFail(
                 ['mysql_install_db', '--user=mysql', `--datadir=${datadir}`],
-                { user: 'root', timeoutMs: null },
+                { user: 'root', timeout: null },
               )
             } else {
               await sub.execFail(
@@ -568,7 +568,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                   '--user=mysql',
                   `--datadir=${datadir}`,
                 ],
-                { user: 'root', timeoutMs: null },
+                { user: 'root', timeout: null },
               )
             }
             await startMysql(sub)
@@ -592,7 +592,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             // the comment on `tmpDumpFile` above.
             await sub.execFail(['cp', dumpFile, tmpDumpFile], {
               user: 'root',
-              timeoutMs: null,
+              timeout: null,
             })
             // Restore from dump
             await sub.execFail(
@@ -601,7 +601,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 '-c',
                 `mysql -u root ${pw !== null ? `-p'${pw}'` : ''} ${database} < ${tmpDumpFile}`,
               ],
-              { user: 'root', timeoutMs: null },
+              { user: 'root', timeout: null },
             )
             await stopMysql(sub)
           },

--- a/projects/start-sdk/lib/backup/Backups.ts
+++ b/projects/start-sdk/lib/backup/Backups.ts
@@ -12,8 +12,6 @@ import {
 
 const BACKUP_HOST_PATH = '/media/startos/backup'
 const BACKUP_CONTAINER_MOUNT = '/backup-target'
-// these steps can outlast exec's 30 s default
-const NO_TIMEOUT = null
 
 /** A password value, or a function that returns one. Functions are resolved lazily (only during restore). */
 export type LazyPassword = string | (() => string | Promise<string>) | null
@@ -260,8 +258,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
           '-o',
           pgStartOpts,
         ],
-        { user: 'postgres' },
-        NO_TIMEOUT,
+        { user: 'postgres', timeoutMs: null },
       )
       for (let elapsed = 0; elapsed < readyTimeout; elapsed += 1000) {
         const { exitCode } = await sub.exec(['pg_isready', '-U', user], {
@@ -296,20 +293,17 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             console.log('[pg-dump] dumping database')
             await sub.execFail(
               ['pg_dump', '-U', user, '-Fc', '-f', tmpDumpFile, database],
-              { user: 'postgres' },
-              NO_TIMEOUT,
+              { user: 'postgres', timeoutMs: null },
             )
             console.log('[pg-dump] copying dump to backup target')
-            await sub.execFail(
-              ['cp', tmpDumpFile, dumpFile],
-              { user: 'root' },
-              NO_TIMEOUT,
-            )
+            await sub.execFail(['cp', tmpDumpFile, dumpFile], {
+              user: 'root',
+              timeoutMs: null,
+            })
             console.log('[pg-dump] stopping postgres')
             await sub.execFail(
               ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
-              { user: 'postgres' },
-              NO_TIMEOUT,
+              { user: 'postgres', timeoutMs: null },
             )
             console.log('[pg-dump] complete')
           },
@@ -326,23 +320,20 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             await mountBackupTarget(sub.rootfs)
             // Stage the dump off the FUSE before pg_restore reads it — see
             // the comment on `tmpDumpFile` above.
-            await sub.execFail(
-              ['cp', dumpFile, tmpDumpFile],
-              { user: 'root' },
-              NO_TIMEOUT,
-            )
+            await sub.execFail(['cp', dumpFile, tmpDumpFile], {
+              user: 'root',
+              timeoutMs: null,
+            })
             await sub.execFail(['chown', 'postgres:postgres', tmpDumpFile], {
               user: 'root',
             })
             await sub.execFail(
               ['chown', '-R', 'postgres:postgres', mountpoint],
-              { user: 'root' },
-              NO_TIMEOUT,
+              { user: 'root', timeoutMs: null },
             )
             await sub.execFail(
               ['initdb', '-D', pgdata, '-U', user, ...initdbArgs],
-              { user: 'postgres' },
-              NO_TIMEOUT,
+              { user: 'postgres', timeoutMs: null },
             )
             await startPg(sub, 'pg-restore')
             await sub.execFail(['createdb', '-U', user, database], {
@@ -359,8 +350,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 '--no-privileges',
                 tmpDumpFile,
               ],
-              { user: 'postgres' },
-              NO_TIMEOUT,
+              { user: 'postgres', timeoutMs: null },
             )
             if (resolvedPassword !== null) {
               await sub.execFail(
@@ -378,8 +368,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             }
             await sub.execFail(
               ['pg_ctl', 'stop', '-D', pgdata, '-w', '-t', pgCtlTimeout],
-              { user: 'postgres' },
-              NO_TIMEOUT,
+              { user: 'postgres', timeoutMs: null },
             )
           },
         )
@@ -452,8 +441,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               '--bind-address=127.0.0.1',
               ...mysqldOptions,
             ],
-            { user: 'root' },
-            NO_TIMEOUT,
+            { user: 'root', timeoutMs: null },
           )
           .catch(e =>
             console.error('[mysql-backup] mysqld exited unexpectedly:', e),
@@ -468,8 +456,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             '--daemonize',
             ...mysqldOptions,
           ],
-          { user: 'root' },
-          NO_TIMEOUT,
+          { user: 'root', timeoutMs: null },
         )
       }
     }
@@ -496,8 +483,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             'done',
           ].join('\n'),
         ],
-        { user: 'root' },
-        NO_TIMEOUT,
+        { user: 'root', timeoutMs: null },
       )
     }
 
@@ -526,11 +512,10 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
               user: 'root',
             })
             if (engine === 'mysql') {
-              await sub.execFail(
-                ['chown', '-R', 'mysql:mysql', datadir],
-                { user: 'root' },
-                NO_TIMEOUT,
-              )
+              await sub.execFail(['chown', '-R', 'mysql:mysql', datadir], {
+                user: 'root',
+                timeoutMs: null,
+              })
             }
             await startMysql(sub)
             await waitForMysql(sub, readyCmd)
@@ -544,14 +529,12 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 `--result-file=${tmpDumpFile}`,
                 database,
               ],
-              { user: 'root' },
-              NO_TIMEOUT,
+              { user: 'root', timeoutMs: null },
             )
-            await sub.execFail(
-              ['cp', tmpDumpFile, dumpFile],
-              { user: 'root' },
-              NO_TIMEOUT,
-            )
+            await sub.execFail(['cp', tmpDumpFile, dumpFile], {
+              user: 'root',
+              timeoutMs: null,
+            })
             await stopMysql(sub)
           },
         )
@@ -575,8 +558,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             if (engine === 'mariadb') {
               await sub.execFail(
                 ['mysql_install_db', '--user=mysql', `--datadir=${datadir}`],
-                { user: 'root' },
-                NO_TIMEOUT,
+                { user: 'root', timeoutMs: null },
               )
             } else {
               await sub.execFail(
@@ -586,8 +568,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                   '--user=mysql',
                   `--datadir=${datadir}`,
                 ],
-                { user: 'root' },
-                NO_TIMEOUT,
+                { user: 'root', timeoutMs: null },
               )
             }
             await startMysql(sub)
@@ -609,11 +590,10 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
             })
             // Stage the dump off the FUSE before mysql reads it — see
             // the comment on `tmpDumpFile` above.
-            await sub.execFail(
-              ['cp', dumpFile, tmpDumpFile],
-              { user: 'root' },
-              NO_TIMEOUT,
-            )
+            await sub.execFail(['cp', dumpFile, tmpDumpFile], {
+              user: 'root',
+              timeoutMs: null,
+            })
             // Restore from dump
             await sub.execFail(
               [
@@ -621,8 +601,7 @@ export class Backups<M extends T.SDKManifest> implements InitScript {
                 '-c',
                 `mysql -u root ${pw !== null ? `-p'${pw}'` : ''} ${database} < ${tmpDumpFile}`,
               ],
-              { user: 'root' },
-              NO_TIMEOUT,
+              { user: 'root', timeoutMs: null },
             )
             await stopMysql(sub)
           },

--- a/projects/start-sdk/lib/test/exitError.test.ts
+++ b/projects/start-sdk/lib/test/exitError.test.ts
@@ -5,7 +5,7 @@ describe('ExitError', () => {
     const err = new ExitError('pg_dump', {
       exitCode: 1,
       exitSignal: null,
-      timedOutAfterMs: null,
+      timedOutAfter: null,
       stdout: '',
       stderr: 'connection refused',
     })
@@ -18,7 +18,7 @@ describe('ExitError', () => {
     const err = new ExitError('cp', {
       exitCode: null,
       exitSignal: 'SIGKILL',
-      timedOutAfterMs: null,
+      timedOutAfter: null,
       stdout: '',
       stderr: '',
     })
@@ -29,7 +29,7 @@ describe('ExitError', () => {
     const err = new ExitError('cp', {
       exitCode: null,
       exitSignal: 'SIGKILL',
-      timedOutAfterMs: 30000,
+      timedOutAfter: 30000,
       stdout: '',
       stderr: '',
     })

--- a/projects/start-sdk/lib/test/exitError.test.ts
+++ b/projects/start-sdk/lib/test/exitError.test.ts
@@ -1,0 +1,40 @@
+import { ExitError } from '../util/SubContainer'
+
+describe('ExitError', () => {
+  test('a non-zero exit reports the code', () => {
+    const err = new ExitError('pg_dump', {
+      exitCode: 1,
+      exitSignal: null,
+      timedOutAfterMs: null,
+      stdout: '',
+      stderr: 'connection refused',
+    })
+    expect(err.message).toBe(
+      'pg_dump failed with exit code 1: connection refused',
+    )
+  })
+
+  test('a signal we did not send reports the signal', () => {
+    const err = new ExitError('cp', {
+      exitCode: null,
+      exitSignal: 'SIGKILL',
+      timedOutAfterMs: null,
+      stdout: '',
+      stderr: '',
+    })
+    expect(err.message).toBe('cp terminated with signal SIGKILL: ')
+  })
+
+  test('our own timeout kill says so, and says what the limit was', () => {
+    const err = new ExitError('cp', {
+      exitCode: null,
+      exitSignal: 'SIGKILL',
+      timedOutAfterMs: 30000,
+      stdout: '',
+      stderr: '',
+    })
+    expect(err.message).toBe(
+      'cp timed out after 30000ms and was killed with SIGKILL: ',
+    )
+  })
+})

--- a/projects/start-sdk/lib/util/SubContainer.ts
+++ b/projects/start-sdk/lib/util/SubContainer.ts
@@ -13,7 +13,7 @@ const False = () => false
 export type ExecOptions = {
   input?: string | Buffer
   /** How long to wait before SIGKILL, in ms (default 30000). `null` waits as long as the command takes — use it whenever the runtime is set by the size of the data or the speed of a disk. */
-  timeoutMs?: number | null
+  timeout?: number | null
   /** Aborting SIGKILLs the process */
   abort?: AbortController
 }
@@ -177,7 +177,7 @@ export interface SubContainer<
    * @description run a command inside this subcontainer
    * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
    * @param command an array representing the command and args to execute
-   * @param options env, cwd, user, stdin, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options env, cwd, user, stdin, `timeout` (default 30 s, `null` for no timeout), and `abort`
    * @returns
    */
   exec(
@@ -187,7 +187,7 @@ export interface SubContainer<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
-    timedOutAfterMs: number | null
+    timedOutAfter: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }>
@@ -195,7 +195,7 @@ export interface SubContainer<
   /**
    * @description run a command inside this subcontainer, throwing on non-zero exit status
    * @param command an array representing the command and args to execute
-   * @param options env, cwd, user, stdin, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options env, cwd, user, stdin, `timeout` (default 30 s, `null` for no timeout), and `abort`
    * @returns
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
@@ -672,7 +672,7 @@ export class SubContainerEager<
    * Does NOT throw on non-zero exit (see {@link execFail}).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options Optional environment, user, cwd, stdin input, `timeout` (default 30 s, `null` for no timeout), and `abort`
    */
   async exec(
     command: string[],
@@ -681,7 +681,7 @@ export class SubContainerEager<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
-    timedOutAfterMs: number | null
+    timedOutAfter: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
@@ -695,7 +695,7 @@ export class SubContainerEager<
     let extra: string[] = []
     // what's left of `spawnOptions` is forwarded to cp.spawn; copied so the
     // deletes below can't strip the caller's object for its next call
-    const { timeoutMs = 30000, abort, ...spawnOptions } = options ?? {}
+    const { timeout = 30000, abort, ...spawnOptions } = options ?? {}
     let user = imageMeta.user || 'root'
     if (spawnOptions.user) {
       user = spawnOptions.user
@@ -763,11 +763,11 @@ export class SubContainerEager<
       child.on('error', reject)
       let killTimeout: NodeJS.Timeout | undefined
       let timedOut = false
-      if (timeoutMs !== null && child.pid) {
+      if (timeout !== null && child.pid) {
         killTimeout = setTimeout(() => {
           timedOut = true
           child.kill('SIGKILL')
-        }, timeoutMs)
+        }, timeout)
       }
       child.stdout.on('data', appendData(stdout))
       child.stderr.on('data', appendData(stderr))
@@ -777,7 +777,7 @@ export class SubContainerEager<
           exitCode: code,
           exitSignal: signal,
           // the deadline can elapse after something else already killed it
-          timedOutAfterMs: timedOut && signal === 'SIGKILL' ? timeoutMs : null,
+          timedOutAfter: timedOut && signal === 'SIGKILL' ? timeout : null,
           stdout: stdout.data,
           stderr: stderr.data,
         }
@@ -798,7 +798,7 @@ export class SubContainerEager<
    * Run a command inside this subcontainer, throwing on non-zero exit.
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options Optional environment, user, cwd, stdin input, `timeout` (default 30 s, `null` for no timeout), and `abort`
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   async execFail(
@@ -1109,7 +1109,7 @@ export class SubContainerLazy<
    * Does NOT throw on non-zero exit (see {@link execFail}).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options Optional environment, user, cwd, stdin input, `timeout` (default 30 s, `null` for no timeout), and `abort`
    */
   async exec(
     command: string[],
@@ -1118,7 +1118,7 @@ export class SubContainerLazy<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
-    timedOutAfterMs: number | null
+    timedOutAfter: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
@@ -1130,7 +1130,7 @@ export class SubContainerLazy<
    * (materializes on first call).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
+   * @param options Optional environment, user, cwd, stdin input, `timeout` (default 30 s, `null` for no timeout), and `abort`
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   async execFail(
@@ -1259,7 +1259,7 @@ export class ExitError extends Error {
     readonly result: {
       exitCode: number | null
       exitSignal: T.Signals | null
-      timedOutAfterMs: number | null
+      timedOutAfter: number | null
       stdout: string | Buffer
       stderr: string | Buffer
     },
@@ -1267,8 +1267,8 @@ export class ExitError extends Error {
     let message: string
     if (result.exitCode) {
       message = `${command} failed with exit code ${result.exitCode}: ${result.stderr}`
-    } else if (result.timedOutAfterMs !== null) {
-      message = `${command} timed out after ${result.timedOutAfterMs}ms and was killed with ${result.exitSignal}: ${result.stderr}`
+    } else if (result.timedOutAfter !== null) {
+      message = `${command} timed out after ${result.timedOutAfter}ms and was killed with ${result.exitSignal}: ${result.stderr}`
     } else if (result.exitSignal) {
       message = `${command} terminated with signal ${result.exitSignal}: ${result.stderr}`
     } else {

--- a/projects/start-sdk/lib/util/SubContainer.ts
+++ b/projects/start-sdk/lib/util/SubContainer.ts
@@ -174,7 +174,7 @@ export interface SubContainer<
    * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
    * @param command an array representing the command and args to execute
    * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
    * @param abort optional AbortController; aborting SIGKILLs the process
    * @returns
    */
@@ -187,6 +187,7 @@ export interface SubContainer<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
+    timedOutAfterMs: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }>
@@ -195,7 +196,7 @@ export interface SubContainer<
    * @description run a command inside this subcontainer, throwing on non-zero exit status
    * @param command an array representing the command and args to execute
    * @param options
-   * @param timeoutMs how long to wait before killing the command in ms
+   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
    * @param abort optional AbortController; aborting SIGKILLs the process
    * @returns
    * @throws {@link ExitError} on non-zero exit code or signal termination
@@ -688,6 +689,7 @@ export class SubContainerEager<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
+    timedOutAfterMs: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
@@ -765,8 +767,12 @@ export class SubContainerEager<
     return new Promise((resolve, reject) => {
       child.on('error', reject)
       let killTimeout: NodeJS.Timeout | undefined
+      let timedOut = false
       if (timeoutMs !== null && child.pid) {
-        killTimeout = setTimeout(() => child.kill('SIGKILL'), timeoutMs)
+        killTimeout = setTimeout(() => {
+          timedOut = true
+          child.kill('SIGKILL')
+        }, timeoutMs)
       }
       child.stdout.on('data', appendData(stdout))
       child.stderr.on('data', appendData(stderr))
@@ -775,6 +781,8 @@ export class SubContainerEager<
         const result = {
           exitCode: code,
           exitSignal: signal,
+          // the deadline can elapse after something else already killed it
+          timedOutAfterMs: timedOut && signal === 'SIGKILL' ? timeoutMs : null,
           stdout: stdout.data,
           stderr: stderr.data,
         }
@@ -1125,6 +1133,7 @@ export class SubContainerLazy<
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
     exitSignal: NodeJS.Signals | null
+    timedOutAfterMs: number | null
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
@@ -1269,6 +1278,7 @@ export class ExitError extends Error {
     readonly result: {
       exitCode: number | null
       exitSignal: T.Signals | null
+      timedOutAfterMs: number | null
       stdout: string | Buffer
       stderr: string | Buffer
     },
@@ -1276,6 +1286,8 @@ export class ExitError extends Error {
     let message: string
     if (result.exitCode) {
       message = `${command} failed with exit code ${result.exitCode}: ${result.stderr}`
+    } else if (result.timedOutAfterMs !== null) {
+      message = `${command} timed out after ${result.timedOutAfterMs}ms and was killed with ${result.exitSignal}: ${result.stderr}`
     } else if (result.exitSignal) {
       message = `${command} terminated with signal ${result.exitSignal}: ${result.stderr}`
     } else {

--- a/projects/start-sdk/lib/util/SubContainer.ts
+++ b/projects/start-sdk/lib/util/SubContainer.ts
@@ -12,6 +12,10 @@ const False = () => false
 
 export type ExecOptions = {
   input?: string | Buffer
+  /** How long to wait before SIGKILL, in ms (default 30000). `null` waits as long as the command takes — use it whenever the runtime is set by the size of the data or the speed of a disk. */
+  timeoutMs?: number | null
+  /** Aborting SIGKILLs the process */
+  abort?: AbortController
 }
 
 const TIMES_TO_WAIT_FOR_PROC = 100
@@ -173,16 +177,12 @@ export interface SubContainer<
    * @description run a command inside this subcontainer
    * DOES NOT THROW ON NONZERO EXIT CODE (see execFail)
    * @param command an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort optional AbortController; aborting SIGKILLs the process
+   * @param options env, cwd, user, stdin, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    * @returns
    */
   exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs?: number | null,
-    abort?: AbortController,
   ): Promise<{
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
@@ -195,17 +195,13 @@ export interface SubContainer<
   /**
    * @description run a command inside this subcontainer, throwing on non-zero exit status
    * @param command an array representing the command and args to execute
-   * @param options
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort optional AbortController; aborting SIGKILLs the process
+   * @param options env, cwd, user, stdin, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    * @returns
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs?: number | null,
-    abort?: AbortController,
   ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }>
 
   /**
@@ -676,15 +672,11 @@ export class SubContainerEager<
    * Does NOT throw on non-zero exit (see {@link execFail}).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    */
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs: number | null = 30000,
-    abort?: AbortController,
   ): Promise<{
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
@@ -701,18 +693,21 @@ export class SubContainerEager<
       .catch(() => '{}')
       .then(JSON.parse)
     let extra: string[] = []
+    // what's left of `spawnOptions` is forwarded to cp.spawn; copied so the
+    // deletes below can't strip the caller's object for its next call
+    const { timeoutMs = 30000, abort, ...spawnOptions } = options ?? {}
     let user = imageMeta.user || 'root'
-    if (options?.user) {
-      user = options.user
-      delete options.user
+    if (spawnOptions.user) {
+      user = spawnOptions.user
+      delete spawnOptions.user
     }
     let workdir = imageMeta.workdir || '/'
-    if (options?.cwd) {
-      workdir = options.cwd
-      delete options.cwd
+    if (spawnOptions.cwd) {
+      workdir = spawnOptions.cwd
+      delete spawnOptions.cwd
     }
-    if (options?.env) {
-      for (let [k, v] of Object.entries(options.env)) {
+    if (spawnOptions.env) {
+      for (let [k, v] of Object.entries(spawnOptions.env)) {
         extra.push(`--env=${k}=${v}`)
       }
     }
@@ -728,14 +723,14 @@ export class SubContainerEager<
         this.rootfs,
         ...command,
       ],
-      options || {},
+      spawnOptions,
     )
     abort?.signal.addEventListener('abort', () => child.kill('SIGKILL'))
-    if (options?.input) {
+    if (spawnOptions.input) {
       await new Promise<null>((resolve, reject) => {
         try {
           child.stdin.on('error', e => reject(e))
-          child.stdin.write(options.input, e => {
+          child.stdin.write(spawnOptions.input, e => {
             if (e) {
               reject(e)
             } else {
@@ -803,20 +798,14 @@ export class SubContainerEager<
    * Run a command inside this subcontainer, throwing on non-zero exit.
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs?: number | null,
-    abort?: AbortController,
   ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
-    return this.exec(command, options, timeoutMs, abort).then(res =>
-      res.throw(),
-    )
+    return this.exec(command, options).then(res => res.throw())
   }
 
   /**
@@ -1120,15 +1109,11 @@ export class SubContainerLazy<
    * Does NOT throw on non-zero exit (see {@link execFail}).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    */
   async exec(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs: number | null = 30000,
-    abort?: AbortController,
   ): Promise<{
     throw: () => { stdout: string | Buffer; stderr: string | Buffer }
     exitCode: number | null
@@ -1137,7 +1122,7 @@ export class SubContainerLazy<
     stdout: string | Buffer
     stderr: string | Buffer
   }> {
-    return (await this.eager()).exec(command, options, timeoutMs, abort)
+    return (await this.eager()).exec(command, options)
   }
 
   /**
@@ -1145,18 +1130,14 @@ export class SubContainerLazy<
    * (materializes on first call).
    *
    * @param command Argv array representing the command and its arguments
-   * @param options Optional environment, user, cwd, and stdin input
-   * @param timeoutMs How long to wait before SIGKILL (default 30 s, `null` for no timeout)
-   * @param abort Optional AbortController; aborting SIGKILLs the process
+   * @param options Optional environment, user, cwd, stdin input, `timeoutMs` (default 30 s, `null` for no timeout), and `abort`
    * @throws {@link ExitError} on non-zero exit code or signal termination
    */
   async execFail(
     command: string[],
     options?: CommandOptions & ExecOptions,
-    timeoutMs?: number | null,
-    abort?: AbortController,
   ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
-    return (await this.eager()).execFail(command, options, timeoutMs, abort)
+    return (await this.eager()).execFail(command, options)
   }
 
   /**


### PR DESCRIPTION
Fixes #3636.

## The bug

`SubContainer.exec` defaults `timeoutMs` to 30 000 and enforces it with `SIGKILL`. `execFail` declares `timeoutMs` with **no** default and forwards it, so any call site that omits the argument silently inherits 30 s.

`336eda75` (1.5.2) split "`pg_dump` writes onto the backup target" into "`pg_dump` writes to `/tmp`, then `cp` through the FUSE". The explicit `null` stayed on `pg_dump`; the new `cp` — the step whose duration is set by the size of the dump and the speed of the target — got none. Once a dump grew past a thirty-second copy, every backup failed:

```
Failed: Unknown Error: Error: cp terminated with signal SIGKILL:
```

Restore stages the dump off the target through the same kind of copy under the same cap, so a database whose dump took longer than 30 s to copy **could not be restored at all** — discovered during recovery, when the backup is all the user has.

## What changed

**Every step of a dump or restore whose duration follows the data now opts out**, through a named `NO_TIMEOUT` (which also replaces the file's existing bare `null`s, so the opt-out is greppable): both copies, `pg_ctl` start/stop, the recursive `chown`s over the data directory, `initdb`, `mysql_install_db` / `mysqld --initialize-insecure`, and the foreground `mysqld` MariaDB runs for the length of the dump. The steps left at 30 s touch a fixed, tiny number of inodes (`touch`, `mkdir -p`, `rm -f`, single-file `chown`, `createdb`, `psql ALTER USER`) or are already bounded by their own poll loop (`pg_isready`, `mysqladmin ping`).

**`readyTimeout` now reaches `pg_ctl`.** `pg_ctl` bounds itself — `-w` is its default and it gives up after `-t` seconds, 60 by default — so lifting the SDK cap alone would only have moved the ceiling 30 s → 60 s, out of reach of the one knob packages are told to raise for slow clusters. `readyTimeout` now supplies `-t`. Its 60 000 ms default is `pg_ctl`'s own default, so behaviour is unchanged until someone raises it.

**A timeout kill now says it timed out.** The error was built from the signal alone, so the SDK's own timer was indistinguishable from an OOM kill, a cgroup kill, or an operator's `kill -9` — and `cp` writes nothing to stderr when killed, leaving the bare `cp terminated with signal SIGKILL:` above as the entire notification. `exec`'s result now carries `timedOutAfterMs` and the message names the limit:

```
cp timed out after 30000ms and was killed with SIGKILL:
```

The flag is decided in the **exit handler**, not the timer: the deadline can elapse after something else has already killed the process (the `'exit'` event is delivered in the poll phase, after timers), and setting it from the timer reported an external `SIGTERM` as an SDK timeout — the same misattribution inverted. `timedOutAfterMs` is set only when our timer fired *and* the process died of `SIGKILL`.

**Docs.** The packaging guide documented `exec`/`execFail` without ever mentioning the 30 s default — the omission this issue is made of, and its example was a `git clone`. It now documents the third argument. Two TSDoc claims that 1.5.2 falsified are corrected: the dump is staged in `/tmp` rather than "written directly to the backup target — no data duplication on disk", and `withMysqlDump` referred to a `dumpVolume` option that does not exist in `MysqlDumpConfig`.

While in the file, the four hand-rolled structural `sub:` parameter types in `Backups.ts` are replaced with the real `SubContainer<M>` — one of them had to be widened by hand just to accept the new third argument.

## Verification

- `make check`, `make test` (87), `make check-fmt`, repo-root `prettier --check`, `make bundle` — all clean. New `exitError.test.ts` covers the three message branches.
- `pg_ctl`'s self-bounding was measured, not assumed: in `postgres:16-alpine`, a `smart` stop held open by a live client and `PGCTLTIMEOUT=5` returned **exit 1 at exactly 5 s**. So dropping the SDK cap on `pg_ctl` cannot hang a backup — it converts a `SIGKILL` into a real `pg_ctl` error.
- Worth knowing, and not addressed here: the SDK's `SIGKILL` lands on the host-side `start-container subcontainer exec` wrapper. `SIGKILL` cannot be in that wrapper's forwarded-signal set (`FWD_SIGNALS`), and it `setns`es into the subcontainer's PID namespace before spawning the real command, so the `cp` itself is not signalled — it is orphaned until the subcontainer is torn down. That is why the timeout note in the guide describes a timeout as "the SDK stopped waiting", not "the work stopped".

Not verified end-to-end on a server with a multi-gigabyte dump; the failing path is a wall-clock timer, which is impractical to exercise here.
