### PR TITLE
fix(start-os): heal a service whose SSL port took its plaintext port's number

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -15,9 +15,13 @@ file tracks notable changes since the move to the monorepo.
 - **A service that adds an SSL port keeps the address you already had.** When a
   service gained an SSL port alongside a plaintext one it already had, the new
   SSL port took over the existing number and the plaintext port was moved to an
-  arbitrary one — changing an address you may have saved. Each now keeps its
-  own: the port you already had stays where it is, and the one being added takes
-  the port the service asks for.
+  arbitrary one — so the address you had saved started answering over SSL, and
+  the port the service documents for SSL was never used. Services carried
+  forward from 0.3.5.1 hit this most: Electrs served Electrum over SSL on 50001
+  rather than 50002, so a wallet pointed at it could only connect with SSL
+  switched on. Each port now keeps its own — the one you already had stays where
+  it is, the one being added takes the port the service asks for — and a service
+  already on the wrong ports is moved back when you update.
 
 - **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
   0.4.0.1 gave the interface a high-numbered port instead, and nothing answered

--- a/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use exver::VersionRange;
 
 use super::v0_3_5::V0_3_0_COMPAT;
@@ -29,10 +31,13 @@ impl VersionT for Version {
     #[instrument(skip_all)]
     fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
         rehome_admin_ui_port(db);
+        rehome_displaced_ssl_legs(db);
         Ok(Value::Null)
     }
     fn down(self, _db: &mut Value) -> Result<(), Error> {
-        // Every earlier version wants 80 here and keeps the port it finds.
+        // Every earlier version keeps the ports it finds: 80 is what it wants
+        // for the UI, and a rehomed binding holds both legs, the shape the
+        // since-removed `carried` left alone.
         Ok(())
     }
 }
@@ -77,6 +82,124 @@ fn rehome_admin_ui_port(db: &mut Value) {
         available.remove(&InternedString::from_display(&held));
     }
     available.insert(InternedString::from_display(&UI_PORT), Value::Bool(false));
+}
+
+/// The ports a displaced binding should be holding: `(ssl leg's preferred port,
+/// plaintext leg's preferred port, the port the plaintext leg was pushed onto)`.
+/// `None` when the binding's ssl leg is not sitting on the plaintext leg's port.
+fn displaced_ssl_leg(binding: &Value) -> Option<(u64, u64, Option<u64>)> {
+    let options = binding.get("options")?;
+    // Only a binding we terminate TLS for has an ssl port of its own to be
+    // displaced from; one that serves its own TLS has no plaintext leg at all.
+    let ssl_to = options
+        .get("addSsl")?
+        .get("preferredExternalPort")?
+        .as_u64()?;
+    if options["secure"]["ssl"].as_bool().unwrap_or(false) {
+        return None;
+    }
+    let plain_to = options.get("preferredExternalPort")?.as_u64()?;
+    // A package asking for one number on both legs gets what it asked for.
+    if plain_to == ssl_to {
+        return None;
+    }
+    let net = binding.get("net")?;
+    if net.get("assignedSslPort")?.as_u64()? != plain_to {
+        return None;
+    }
+    Some((
+        ssl_to,
+        plain_to,
+        net.get("assignedPort").and_then(|p| p.as_u64()),
+    ))
+}
+
+/// Put each leg of a package binding back on the port its options ask for.
+///
+/// A 0.3.x service whose manifest carried no `lan-config` was migrated as a
+/// single plaintext binding by `SystemForEmbassy::exportNetwork` — electrs,
+/// whose `lan-config` was commented out, is the reported case. Installing the
+/// 0.4 package over it reached `BindInfo::update` on the same host and internal
+/// port, where the since-removed `carried` handed that lone number to the ssl
+/// leg (reclaimed first) and left the plaintext leg on a fresh ephemeral port.
+/// The address wallets connect to then served TLS on the port the package asked
+/// to serve *plaintext* on — electrs answering TLS on 50001 rather than 50002 —
+/// and `update` prefers the port it already holds, so it never healed.
+///
+/// A binding is left alone when its ssl leg's preferred port is held elsewhere,
+/// rather than moved onto a port another binding is serving.
+fn rehome_displaced_ssl_legs(db: &mut Value) {
+    let mut taken: BTreeSet<u64> = db
+        .get("private")
+        .and_then(|p| p.get("availablePorts"))
+        .and_then(|a| a.as_object())
+        .map(|a| a.keys().filter_map(|k| k.parse().ok()).collect())
+        .unwrap_or_default();
+
+    // Deferred so the walk below can hold `packageData` mutably.
+    let mut freed: Vec<u64> = Vec::new();
+    let mut claimed: Vec<(u64, bool)> = Vec::new();
+
+    if let Some(packages) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("packageData"))
+        .and_then(|p| p.as_object_mut())
+    {
+        for (_, package) in packages.iter_mut() {
+            let Some(hosts) = package.get_mut("hosts").and_then(|h| h.as_object_mut()) else {
+                continue;
+            };
+            for (_, host) in hosts.iter_mut() {
+                let Some(bindings) = host.get_mut("bindings").and_then(|b| b.as_object_mut())
+                else {
+                    continue;
+                };
+                for (_, binding) in bindings.iter_mut() {
+                    let Some((ssl_to, plain_to, plain_from)) = displaced_ssl_leg(binding) else {
+                        continue;
+                    };
+                    // `plain_to` is this binding's own ssl hold, so only an outside
+                    // claim on `ssl_to` blocks the move — including one made by a
+                    // binding rehomed earlier in this walk.
+                    if taken.contains(&ssl_to) && Some(ssl_to) != plain_from {
+                        continue;
+                    }
+                    let Some(net) = binding.get_mut("net").and_then(|n| n.as_object_mut()) else {
+                        continue;
+                    };
+                    net.insert("assignedSslPort".into(), Value::from(ssl_to));
+                    net.insert("assignedPort".into(), Value::from(plain_to));
+
+                    if let Some(plain_from) = plain_from {
+                        taken.remove(&plain_from);
+                        freed.push(plain_from);
+                    }
+                    taken.insert(ssl_to);
+                    claimed.push((ssl_to, true));
+                    claimed.push((plain_to, false));
+                }
+            }
+        }
+    }
+
+    if freed.is_empty() && claimed.is_empty() {
+        return;
+    }
+    let Some(available) = db
+        .get_mut("private")
+        .and_then(|p| p.get_mut("availablePorts"))
+        .and_then(|a| a.as_object_mut())
+    else {
+        return;
+    };
+    for port in freed {
+        available.remove(&InternedString::from_display(&port));
+    }
+    // After the frees, so a port one binding released and another claimed lands
+    // claimed.
+    for (port, ssl) in claimed {
+        available.insert(InternedString::from_display(&port), Value::Bool(ssl));
+    }
 }
 
 #[cfg(test)]
@@ -160,6 +283,174 @@ mod test {
         let mut db = json!({ "public": { "serverInfo": {} }, "private": {} });
         let before = db.clone();
         rehome_admin_ui_port(&mut db);
+        assert_eq!(db, before);
+    }
+
+    fn pkg_db(package_data: Value, available_ports: Value) -> Value {
+        json!({
+            "public": {
+                "serverInfo": { "network": { "host": { "bindings": {} } } },
+                "packageData": package_data,
+            },
+            "private": { "availablePorts": available_ports }
+        })
+    }
+
+    /// One package, one host, one binding — the electrs shape: plaintext
+    /// preferred on 50001, the OS terminating TLS on 50002.
+    fn electrum_pkg(id: &str, plain: u64, net: Value) -> Value {
+        json!({ id: { "hosts": { "electrum": { "bindings": { plain.to_string(): {
+            "options": {
+                "preferredExternalPort": plain,
+                "addSsl": { "preferredExternalPort": 50002 },
+                "secure": null,
+            },
+            "net": net,
+        } } } } } })
+    }
+
+    fn net_at(db: &Value, id: &str, internal_port: &str) -> Value {
+        db["public"]["packageData"][id]["hosts"]["electrum"]["bindings"][internal_port]["net"]
+            .clone()
+    }
+
+    // The reported case: a 0.3.5.1 box whose electrs binding came through the
+    // v1 compat shim as plaintext-only, then had the 0.4 package installed over
+    // it — TLS answering on 50001, plaintext pushed to an ephemeral port.
+    #[test]
+    fn rehomes_an_ssl_leg_off_the_plaintext_legs_number() {
+        let mut db = pkg_db(
+            electrum_pkg(
+                "electrs",
+                50001,
+                json!({ "assignedPort": 52981, "assignedSslPort": 50001 }),
+            ),
+            json!({ "50001": true, "52981": false }),
+        );
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(
+            net_at(&db, "electrs", "50001"),
+            json!({ "assignedPort": 50001, "assignedSslPort": 50002 })
+        );
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "50001": false, "50002": true })
+        );
+    }
+
+    #[test]
+    fn leaves_a_binding_on_its_preferred_ports_alone() {
+        let mut db = pkg_db(
+            electrum_pkg(
+                "electrs",
+                50001,
+                json!({ "assignedPort": 50001, "assignedSslPort": 50002 }),
+            ),
+            json!({ "50001": false, "50002": true }),
+        );
+        let before = db.clone();
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    // A binding we rewrap has no plaintext leg, so its ssl port sitting on
+    // `preferredExternalPort` is the number it legitimately carried over from
+    // serving its own TLS there — not a displaced leg.
+    #[test]
+    fn leaves_a_rewrapped_binding_that_kept_its_number() {
+        let mut db = pkg_db(
+            json!({ "svc": { "hosts": { "electrum": { "bindings": { "8080": {
+                "options": {
+                    "preferredExternalPort": 8080,
+                    "addSsl": { "preferredExternalPort": 8443 },
+                    "secure": { "ssl": true },
+                },
+                "net": { "assignedPort": null, "assignedSslPort": 8080 },
+            } } } } } }),
+            json!({ "8080": true }),
+        );
+        let before = db.clone();
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    #[test]
+    fn leaves_a_binding_alone_when_its_ssl_port_is_held_elsewhere() {
+        let mut db = pkg_db(
+            electrum_pkg(
+                "electrs",
+                50001,
+                json!({ "assignedPort": 52981, "assignedSslPort": 50001 }),
+            ),
+            json!({ "50001": true, "50002": true, "52981": false }),
+        );
+        let before = db.clone();
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    // Two Electrum servers both prefer 50002; the second keeps what it has
+    // rather than being moved onto the port the first just claimed.
+    #[test]
+    fn only_one_of_two_displaced_bindings_takes_the_contested_port() {
+        let mut package_data = electrum_pkg(
+            "electrs",
+            50001,
+            json!({ "assignedPort": 52981, "assignedSslPort": 50001 }),
+        );
+        let fulcrum = electrum_pkg(
+            "fulcrum",
+            50011,
+            json!({ "assignedPort": 52990, "assignedSslPort": 50011 }),
+        );
+        package_data["fulcrum"] = fulcrum["fulcrum"].clone();
+        let mut db = pkg_db(
+            package_data,
+            json!({ "50001": true, "50011": true, "52981": false, "52990": false }),
+        );
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(
+            net_at(&db, "electrs", "50001"),
+            json!({ "assignedPort": 50001, "assignedSslPort": 50002 })
+        );
+        assert_eq!(
+            net_at(&db, "fulcrum", "50011"),
+            json!({ "assignedPort": 52990, "assignedSslPort": 50011 })
+        );
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "50001": false, "50002": true, "50011": true, "52990": false })
+        );
+    }
+
+    // `alloc` draws from 49152 up, so the displaced plaintext leg can land on
+    // the ssl leg's preferred port. Only this binding is then in the way.
+    #[test]
+    fn rehomes_when_the_plaintext_leg_drifted_onto_the_ssl_port() {
+        let mut db = pkg_db(
+            electrum_pkg(
+                "electrs",
+                50001,
+                json!({ "assignedPort": 50002, "assignedSslPort": 50001 }),
+            ),
+            json!({ "50001": true, "50002": false }),
+        );
+        rehome_displaced_ssl_legs(&mut db);
+        assert_eq!(
+            net_at(&db, "electrs", "50001"),
+            json!({ "assignedPort": 50001, "assignedSslPort": 50002 })
+        );
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "50001": false, "50002": true })
+        );
+    }
+
+    #[test]
+    fn tolerates_a_db_without_package_data() {
+        let mut db = json!({ "public": { "serverInfo": {} }, "private": {} });
+        let before = db.clone();
+        rehome_displaced_ssl_legs(&mut db);
         assert_eq!(db, before);
     }
 }


### PR DESCRIPTION
Stacked on #3638. That PR stops a binding's ssl leg taking the plaintext leg's number; this one repairs the servers where it already happened.

## The reported symptom

A user who migrated from 0.3.5.1 found Electrs healthy and fully synced, its Interfaces page showing `192.168.x.x:50001`, and Sparrow unable to connect over either that address or the onion. `nc` reached 50001; `openssl s_client` against 50001 came back with the StartOS chain. Turning Sparrow's SSL toggle on connected immediately, to `electrs/0.11.1`, protocol 1.4.

So the binding was answering TLS on the port the package asks to serve *plaintext* on, and 50002 — the port the package asks for SSL, and the one its instructions name — was never allocated.

## Why 50001

The 0.3.x electrs manifest bound one port and had `lan-config` commented out:

```yaml
interfaces:
  electrum:
    tor-config:
      port-mapping:
        50001: "50001"
    # lan-config:
    #   443:
    #     ssl: true
    #     internal: 50001
```

`SystemForEmbassy::exportNetwork` maps that to `{preferredExternalPort: 50001, addSsl: null}` (`SystemForEmbassy/index.ts:528` — `addSsl` is set only from `lan-config`), so `BindInfo::new` gave the binding `assignedPort: 50001, assignedSslPort: None`.

The 0.4 package uses the same host id (`electrum`) and the same internal port, so installing it reached `BindInfo::update`, not `new`. There `carried` moved the lone held number to whichever leg reclaimed first — the ssl leg:

```
before: {assigned_port: 50001, assigned_ssl_port: None}
after:  {assigned_port: <ephemeral>, assigned_ssl_port: 50001}
```

`update` then prefers the port it already holds, so every later rebind kept it. Same shape #3638 measured from the admin binding's side, reached from the other direction.

Any 0.3.x service that bound over Tor only and whose 0.4 package adds `addSsl` lands here; electrs is the one that was reported.

## What this adds

`v0_4_0_2::up` already re-homes the admin binding. It now also walks `packageData.*.hosts.*.bindings.*` and puts both legs of a displaced binding back on their preferred ports.

A binding is displaced when it has `addSsl`, is not one we rewrap (`secure.ssl`), and its `assignedSslPort` equals `options.preferredExternalPort` while `addSsl.preferredExternalPort` is some other number. That last clause is what keeps a package that deliberately asks for one number on both legs out of scope.

`availablePorts` moves with it: the freed ephemeral port is dropped, the reclaimed number flips to non-ssl, and the ssl leg's preferred port is added. A binding whose ssl leg's preferred port is held by anything else is left alone rather than moved onto a port another binding is serving — including a port claimed by a binding re-homed earlier in the same walk, which is what two Electrum servers both preferring 50002 would hit.

## Effect on saved addresses

An affected service's endpoint moves from `:50001` to `:50002`. It has to: the plaintext leg is not published on an insecure LAN gateway for a `secure: null` binding (`net/host/mod.rs:148`), so `:50001` was the only address shown, and it was the wrong one. Wallets pinned to `:50001` need repointing once — but they needed SSL switched on to work there at all, so no configuration that was working stops working.

No `down` step: earlier versions reclaim the two ports a re-homed binding holds rather than carrying either, which is the shape `carried` left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)