### PR TITLE
fix: validate and confine service mount paths

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -70,6 +70,11 @@ file tracks notable changes since the move to the monorepo.
   its previous export, wherever it lived; a lingering duplicate clears the next
   time its service initializes — at the reboot this update performs.
 
+### Security
+
+- **Service mount paths are validated and confined to their intended
+  directories.**
+
 ## [0.4.0.1]
 
 ### Changed

--- a/shared-libs/crates/start-core/src/service/effects/bind_mount.rs
+++ b/shared-libs/crates/start-core/src/service/effects/bind_mount.rs
@@ -11,13 +11,13 @@ use std::os::fd::AsFd;
 use std::path::PathBuf;
 
 use clap::Parser;
-use rpc_toolkit::Context;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 use crate::disk::mount::filesystem::idmapped::IdMap;
 use crate::disk::mount::filesystem::syscall::{self, DetachedMount};
 use crate::prelude::*;
+use crate::service::effects::ContainerCliContext;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Parser, TS)]
 #[command(rename_all = "kebab-case")]
@@ -47,7 +47,9 @@ pub struct BindMountParams {
     pub idmap: Vec<IdMap>,
 }
 
-pub async fn bind_mount<C: Context>(_: C, params: BindMountParams) -> Result<(), Error> {
+// The concrete context type keeps this subcommand off the RPC server's tree:
+// `handler()` only retains subcommands whose context matches the serving one.
+pub async fn bind_mount(_: ContainerCliContext, params: BindMountParams) -> Result<(), Error> {
     let BindMountParams {
         source,
         target,

--- a/shared-libs/crates/start-core/src/service/effects/dependency.rs
+++ b/shared-libs/crates/start-core/src/service/effects/dependency.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
 
 use clap::builder::ValueParserFactory;
@@ -134,6 +134,30 @@ pub struct MountParams {
     location: PathBuf,
     target: MountTarget,
 }
+
+fn relative_components(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(_) | Component::ParentDir => out.push(component.as_os_str()),
+            _ => {}
+        }
+    }
+    out
+}
+
+async fn confined_join(base: &Path, rel: &Path) -> Result<PathBuf, Error> {
+    let base = crate::util::io::canonicalize(base, false).await?;
+    let joined = crate::util::io::canonicalize(base.join(relative_components(rel)), false).await?;
+    if !joined.starts_with(&base) {
+        return Err(Error::new(
+            eyre!("mount paths must stay within their base directory"),
+            ErrorKind::InvalidRequest,
+        ));
+    }
+    Ok(joined)
+}
+
 pub async fn mount(
     context: EffectContext,
     MountParams {
@@ -150,18 +174,20 @@ pub async fn mount(
     }: MountParams,
 ) -> Result<(), Error> {
     let context = context.deref()?;
-    let subpath = subpath.unwrap_or_default();
-    let subpath = subpath.strip_prefix("/").unwrap_or(&subpath);
-    let source = data_dir(DATA_DIR, &package_id, &volume_id).join(subpath);
-    let location = location.strip_prefix("/").unwrap_or(&location);
-    let mountpoint = context
+    let source = confined_join(
+        &data_dir(DATA_DIR, &package_id, &volume_id),
+        subpath.as_deref().unwrap_or(Path::new("")),
+    )
+    .await?;
+    let rootfs = context
         .seed
         .persistent_container
         .lxc_container
         .get()
         .or_not_found("lxc container")?
         .rootfs_dir()
-        .join(location);
+        .to_owned();
+    let mountpoint = confined_join(&rootfs, &location).await?;
 
     if is_mountpoint(&mountpoint).await? {
         unmount(&mountpoint, true).await?;
@@ -513,6 +539,70 @@ pub async fn get_service_manifest(
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn relative_components_drops_roots_and_dots() {
+        assert_eq!(
+            relative_components(Path::new("/a/b/./c")),
+            PathBuf::from("a/b/c")
+        );
+        assert_eq!(relative_components(Path::new("")), PathBuf::new());
+        assert_eq!(
+            relative_components(Path::new("a/../b")),
+            PathBuf::from("a/../b")
+        );
+    }
+
+    #[tokio::test]
+    async fn confined_join_keeps_paths_under_the_base() {
+        let tmp = PathBuf::from(format!("/tmp/confined-join-test-{}", std::process::id()));
+        let base = tmp.join("base");
+        tokio::fs::create_dir_all(base.join("inner")).await.unwrap();
+        tokio::fs::create_dir_all(tmp.join("outside"))
+            .await
+            .unwrap();
+        #[cfg(unix)]
+        tokio::fs::symlink(tmp.join("outside"), base.join("link"))
+            .await
+            .unwrap();
+        let canonical_base = tokio::fs::canonicalize(&base).await.unwrap();
+
+        assert_eq!(
+            confined_join(&base, Path::new("inner")).await.unwrap(),
+            canonical_base.join("inner")
+        );
+        // a tail that does not exist yet is fine, as long as it is plain names
+        assert_eq!(
+            confined_join(&base, Path::new("inner/new/dir"))
+                .await
+                .unwrap(),
+            canonical_base.join("inner/new/dir")
+        );
+        assert_eq!(
+            confined_join(&base, Path::new("")).await.unwrap(),
+            canonical_base
+        );
+        // a `..` that resolves back inside is fine
+        assert_eq!(
+            confined_join(&base, Path::new("inner/../inner"))
+                .await
+                .unwrap(),
+            canonical_base.join("inner")
+        );
+        assert!(confined_join(&base, Path::new("../outside")).await.is_err());
+        assert!(
+            confined_join(&base, Path::new("missing/../../outside"))
+                .await
+                .is_err()
+        );
+        #[cfg(unix)]
+        {
+            assert!(confined_join(&base, Path::new("link")).await.is_err());
+            assert!(confined_join(&base, Path::new("link/sub")).await.is_err());
+        }
+
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
 
     fn idmap(from_id: u32, to_id: u32, range: u32) -> IdMap {
         IdMap {

--- a/shared-libs/crates/start-core/src/service/effects/mod.rs
+++ b/shared-libs/crates/start-core/src/service/effects/mod.rs
@@ -91,7 +91,7 @@ pub fn handler<C: Context>() -> ParentHandler<C> {
         .subcommand("mount", from_fn_async(dependency::mount).no_cli())
         .subcommand(
             "bind-mount",
-            from_fn_async(bind_mount::bind_mount::<C>).no_display(),
+            from_fn_async(bind_mount::bind_mount).no_display(),
         )
         .subcommand(
             "get-installed-packages",

--- a/shared-libs/crates/start-core/src/util/io.rs
+++ b/shared-libs/crates/start-core/src/util/io.rs
@@ -3,7 +3,7 @@ use std::future::Future;
 use std::io::Cursor;
 use std::mem::MaybeUninit;
 use std::os::unix::prelude::MetadataExt;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -1719,22 +1719,39 @@ fn canonicalize_rec(path: &Path, create_parent: bool) -> BoxFuture<'_, Result<Pa
         match tokio::fs::canonicalize(path).await {
             Ok(canonical) => Ok(canonical),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                let Some(file_name) = path.file_name() else {
+                let mut components = path.components();
+                let Some(last) = components.next_back() else {
                     return Err(e).with_ctx(|_| {
                         (ErrorKind::Filesystem, lazy_format!("canonicalize {path:?}"))
                     });
                 };
-                let parent = path.parent().unwrap_or(Path::new("."));
+                let parent = components.as_path();
+                let parent = if parent.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    parent
+                };
                 if create_parent {
                     // short-circuit: create the whole missing chain at once
                     tokio::fs::create_dir_all(parent).await.with_ctx(|_| {
                         (ErrorKind::Filesystem, lazy_format!("mkdir -p {parent:?}"))
                     })?;
                 }
-                // resolve the first existing ancestor, then re-append the tail
-                Ok(canonicalize_rec(parent, create_parent)
-                    .await?
-                    .join(file_name))
+                // resolve the first existing ancestor, then re-append the tail.
+                // A `..` hidden behind a not-yet-existing component cannot be
+                // resolved now, but the kernel would resolve it at use time —
+                // fold it lexically instead of re-appending it verbatim.
+                let mut resolved = canonicalize_rec(parent, create_parent).await?;
+                match last {
+                    Component::ParentDir => {
+                        resolved.pop();
+                    }
+                    Component::Normal(name) => {
+                        resolved.push(name);
+                    }
+                    _ => {}
+                }
+                Ok(resolved)
             }
             Err(e) => {
                 Err(e).with_ctx(|_| (ErrorKind::Filesystem, lazy_format!("canonicalize {path:?}")))
@@ -1815,5 +1832,45 @@ impl Drop for AtomicFile {
             let path = std::mem::take(&mut self.tmp_path);
             tokio::spawn(async move { tokio::fs::remove_file(path).await.log_err() });
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn canonicalize_folds_parent_components_in_missing_tails() {
+        let tmp = PathBuf::from(format!("/tmp/canonicalize-test-{}", std::process::id()));
+        let base = tmp.join("base");
+        tokio::fs::create_dir_all(base.join("inner")).await.unwrap();
+        let canonical_base = tokio::fs::canonicalize(&base).await.unwrap();
+
+        // a `..` hidden behind a missing component folds lexically
+        assert_eq!(
+            canonicalize(base.join("missing/../inner"), false)
+                .await
+                .unwrap(),
+            canonical_base.join("inner")
+        );
+        // folding can climb above missing components into the existing prefix
+        assert_eq!(
+            canonicalize(base.join("missing/../../x"), false)
+                .await
+                .unwrap(),
+            canonical_base.parent().unwrap().join("x")
+        );
+        // terminal `..`
+        assert_eq!(
+            canonicalize(base.join("missing/.."), false).await.unwrap(),
+            canonical_base
+        );
+        // existing paths are still kernel-resolved
+        assert_eq!(
+            canonicalize(base.join("inner"), false).await.unwrap(),
+            canonical_base.join("inner")
+        );
+
+        tokio::fs::remove_dir_all(&tmp).await.ok();
     }
 }


### PR DESCRIPTION
## Summary

- Normalize the paths handed to the host-side service mount effect and verify the resolved result stays under its intended base directory (the target package volume for the source, the calling container's rootfs for the mountpoint). Well-formed callers (the SDK only generates plain relative paths) are unaffected.
- `util::io::canonicalize`, which tolerates a not-yet-existing tail, now folds parent-dir components in that tail lexically instead of re-appending them verbatim, so the returned path always matches what the kernel resolves.
- Keep the internal `bind-mount` helper on the local `start-container` CLI only, which is how container-runtime invokes it.
- Unit tests for the path handling; changelog entry under 0.4.0.2.

## Test plan

- `cargo test -p start-core --features=test --lib` — all pass, including in the pinned build container with the CI command (`--release --features=test,dev,unstable`)
- `make start-core-format` (pinned nightly) and prettier both clean