### PR TITLE
docs(sdk): action handlers must i18n what they throw

### DIFF
--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -246,7 +246,17 @@ password: Value.text({
 
 Every string that a user will see — action `name`, `description`, `warning`, `reason` on tasks, messages on health checks and action results — must be wrapped in `i18n()`. Raw strings bypass translation and leak English into non-English locales. The existing examples on this page illustrate the pattern: `name: i18n('Configure SMTP')`, not `name: 'Configure SMTP'`.
 
-Thrown errors are the exception. `throw new Error(...)` messages are developer-facing diagnostics that surface in logs and stack traces, not translated UI copy — leave them as plain strings and do **not** wrap them in `i18n()`.
+**That includes what a handler throws.** An error out of an action handler is not a log line the user never sees — StartOS catches it and renders the message as the alert that tells them the action failed, so it is the only feedback they get and it needs a dictionary entry like any other:
+
+```typescript
+if (!apiKey) {
+  throw new Error(i18n('An API key is required. Create one under Settings → API Keys.'))
+}
+```
+
+Wrapping it works because `setupI18n` resolves eagerly against the container's locale and hands back a finished string; StartOS renders an unrecognized string verbatim, so a translated message reaches the user in their language and an untranslated one leaks English into the alert.
+
+Errors thrown outside an action are a different matter. A throw from `setupMain`, `setupInit`, or a migration reaches the user as a **Service Launch Error** — a crash report shown next to Rebuild and Uninstall buttons, not copy anyone composed. Those are diagnostics: leave them as plain strings, and keep them specific enough to debug from.
 
 ### Don't `as const` What the SDK Already Types
 


### PR DESCRIPTION
The `i18n()` convention in `actions.md` carved out thrown errors:

> Thrown errors are the exception. `throw new Error(...)` messages are developer-facing diagnostics that surface in logs and stack traces, not translated UI copy — leave them as plain strings and do **not** wrap them in `i18n()`.

For an action handler the premise is false. `ActionService.execute` catches the error and renders the message straight into an alert dialog labelled "Error" — [`action.service.ts:78-81`](https://github.com/Start9Labs/start-technologies/blob/master/projects/start-os/web/ui/src/app/services/action.service.ts#L78-L81). That alert is the only thing telling the user the action failed, so the guide was directing packagers to leak English into it in every non-default locale. Found while auditing `ppq-private-mode-startos`, whose "An API key is required…" message is exactly this case; the CLI shows the same string (`Action Failed: Error: An API key is required…`).

Wrapping it works end to end, which the old wording also left unclear:

- `setupI18n` resolves eagerly against the container's `LANG` and returns a finished string ([`i18n/index.ts:29,62-64`](https://github.com/Start9Labs/start-technologies/blob/master/projects/start-sdk/lib/i18n/index.ts#L29)), so what crosses the wire is already translated.
- `i18nPipe` looks the string up in `ENGLISH` and falls through to the input verbatim on a miss ([`i18n.pipe.ts:16-18`](https://github.com/Start9Labs/start-technologies/blob/master/shared-libs/ts-modules/shared/src/i18n/i18n.pipe.ts#L16-L18)), so a package-translated message renders as-is rather than as a missing-key artifact.

The exception is real for throws that aren't in an action. `setupMain` / `setupInit` / migration failures land in `statusInfo.error` and render as a **Service Launch Error** card next to Rebuild and Uninstall buttons ([`error.component.ts`](https://github.com/Start9Labs/start-technologies/blob/master/projects/start-os/web/ui/src/app/routes/portal/routes/services/components/error.component.ts)) — a crash report, not copy. So the rule is split by throw site rather than deleted.

`init.md:233`'s plain-string `throw new Error('Bootstrap failed')` sits in `runUntilSuccess` bootstrap and stays correct under the new wording. No other page states the old rule.

Targeting `live-docs` rather than `master`: the wrong sentence is on docs.start9.com now, and what it gets wrong is how shipped StartOS already behaves — not an unreleased SDK surface — so this is a correction to the published site rather than a doc riding along with its code. `docs-backport.yml` pushes the same commit to `master` on merge, so it lands in both without being written twice. No `CHANGELOG.md` entry: book-only, no change to the SDK's shipped surface.
