### PR TITLE
fix(start-os): bundle the tor s9pk from prod, not alpha

### DIFF
--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -383,7 +383,7 @@ mkdir -p /media/startos
 chmod 750 /media/startos
 chown root:startos /media/startos
 
-start-cli --registry=https://alpha-registry-x.start9.com registry package download tor -d /usr/lib/startos/tor_${QEMU_ARCH}.s9pk -a "${QEMU_ARCH}"
+start-cli --registry=https://registry.start9.com registry package download tor -d /usr/lib/startos/tor_${QEMU_ARCH}.s9pk -a "${QEMU_ARCH}"
 
 EOF
 


### PR DESCRIPTION
The image build downloads a Tor s9pk to `/usr/lib/startos/tor_<arch>.s9pk` for the 0.3.5.1 migration to sideload (`version/v0_4_0_alpha_20.rs`), so it is the Tor a migrating server lands on.

It was pulled from **alpha**, which every push to `tor-startos` master publishes to. That put unreleased, untested Tor revisions straight in front of migrating users.

Pull from prod instead.

```diff
-start-cli --registry=https://alpha-registry-x.start9.com registry package download tor …
+start-cli --registry=https://registry.start9.com registry package download tor …
```

No effect today — alpha, beta and prod all currently serve `0.4.9.11:5`. Going forward it means a new Tor reaches migrating servers once it is promoted to prod and an image is built after that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)