### PR TITLE
fix(docs): point the install links at 0.4.0.1, the release that exists

### DIFF
--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -8,7 +8,7 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 ## Download
 
-1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.2) to find the latest version of StartOS.
+1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) to find the latest version of StartOS.
 
 1.  Under "ISO Downloads", select the ISO for your architecture. StartOS is available in x86_64 (AMD64), aarch64 (ARM64), and RISC-V (RVA23). For x86_64 and aarch64, two variants are available:
     - **Standard**: Includes proprietary firmware and drivers for broader hardware compatibility, including display and wireless. Recommended for most users.
@@ -74,7 +74,7 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 A Raspberry Pi does not use the USB installer above. Instead, you flash the StartOS image directly to the Pi's microSD card. This is also how a Raspberry Pi is updated to a new major version of StartOS — it cannot update over the air. If you are updating an existing 0.3.5.1 server, complete the [preparation steps in the update guide](update-040.md#prepare-your-server) before flashing.
 
-1. Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.2) and, from the downloads list, download the **Raspberry Pi `.img.gz`** file.
+1. Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) and, from the downloads list, download the **Raspberry Pi `.img.gz`** file.
 
 1. Verify the SHA256 checksum against the one listed on GitHub (optional but recommended) — see [Download](#download) for the command for your computer. The release lists checksums for both the compressed `.img.gz` you downloaded and the `.img` inside it.
 


### PR DESCRIPTION
Both "Github release page" links in `installing-startos.md` name `start-os/v0.4.0.2`, which has no tag and no release — so the two entry points to downloading StartOS, the USB installer and the Raspberry Pi image, both 404 for anyone following the install guide on docs.start9.com right now.

`0.4.0.2` is the prospective next version, and #3616 carried these links along with the bump. The rest of that bump is right — root `package.json` and the CHANGELOG heading are supposed to name the version being accumulated. A user-facing "find the latest version of StartOS" link is not: it has to name a release that has actually been cut, and that is `start-os/v0.4.0.1` (2026-07-27, currently GitHub's "Latest").

```
$ git ls-remote --tags origin 'refs/tags/start-os/v0.4.0*'
start-os/v0.4.0
start-os/v0.4.0.1          <- newest; no v0.4.0.2 tag exists
```

Two lines, `v0.4.0.2` -> `v0.4.0.1`, restoring the file to exactly what #3564 left behind.

## Verification

`projects/start-docs/build.sh` runs clean across all four published books, and the rendered page carries the corrected link:

```
$ grep -o 'releases/tag/start-os/v0\.4\.0\.[0-9]' docs/start-os/0.4.0.x/installing-startos.html | sort -u
releases/tag/start-os/v0.4.0.1
```

No other `0.4.0.2` reference remains anywhere in the published books (`projects/start-os/docs`, `projects/start-sdk/docs`, `projects/start-tunnel/docs`, `projects/start-docs`).

Merging deploys: the change is under `projects/start-os/docs/**`, so the push to `live-docs` triggers `docs-deploy.yml`, and `docs-backport.yml` lands the same commit on master so the next tag does not revert it.

## Follow-up, not in this PR

These links go stale by construction — they name a specific tag, and a routine version bump on master moves them ahead of reality with nothing to catch it. Worth a guard: the `pre-check` added in #3564 already fails when the `Cargo.toml` label drifts from the version being cut, so it is the natural place to also refuse a docs link naming a version that has no tag. Happy to open that separately.
