### PR TITLE
fix(start-os): serve and sign only for hostnames the server owns

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -10,17 +10,6 @@ file tracks notable changes since the move to the monorepo.
 
 ## [0.4.0.2]
 
-### Security
-
-- **Your server answers only to its own addresses.** Any name that resolved to
-  your server reached your dashboard — a bare hostname, a neighboring machine's
-  name, `www.example.com` — and your server issued that name a certificate
-  signed by its Root CA, which every browser you have set up for it trusts. Each
-  name was also stored permanently, so a stream of requests under new names grew
-  the database until the server ran out of memory. Your server now serves its
-  `.local` address, the domains you have assigned to it, and direct connections
-  to its IP address.
-
 ### Added
 
 - **A service can permanently retire a network host or a port it no longer
@@ -34,6 +23,15 @@ file tracks notable changes since the move to the monorepo.
   assign it to one of the service's current interfaces.
 
 ### Fixed
+
+- **Your server answers to its own addresses and no others.** A name that
+  resolved to your server but was never configured on it — a domain you pointed
+  at its LAN IP, or its `.local` name typed without the `.local` — was served
+  your dashboard, along with a certificate for that name signed by your server's
+  Root CA. Logging in was never possible under those names, so the page could
+  not be used for anything, but it should not have been reachable. Your server
+  now serves its `.local` address, the domains you have assigned to it, and
+  direct connections to its IP address.
 
 - **Image upgrades verify their checksum again.** `upgrade` compared the image's
   blake3 hash only when it was given a second positional argument, which no

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -10,6 +10,17 @@ file tracks notable changes since the move to the monorepo.
 
 ## [0.4.0.2]
 
+### Security
+
+- **Your server answers only to its own addresses.** Any name that resolved to
+  your server reached your dashboard — a bare hostname, a neighboring machine's
+  name, `www.example.com` — and your server issued that name a certificate
+  signed by its Root CA, which every browser you have set up for it trusts. Each
+  name was also stored permanently, so a stream of requests under new names grew
+  the database until the server ran out of memory. Your server now serves its
+  `.local` address, the domains you have assigned to it, and direct connections
+  to its IP address.
+
 ### Added
 
 - **A service can permanently retire a network host or a port it no longer

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -111,6 +111,7 @@ impl NetController {
         let hostname = peek.as_public().as_server_info().as_hostname().de()?;
         drop(peek);
         let branding = crate::net::ssl::CertBranding::start_os(&hostname);
+        let mdns_hostname = crate::hostname::ServerHostname::new(hostname)?.local_domain_name();
         // One PortMapController shared by the forward and vhost controllers so a
         // single query answers "is this port automatically forwarded?".
         let port_map = PortMapController::new(net_iface.watcher.subscribe());
@@ -140,6 +141,7 @@ impl NetController {
                 net_iface.clone(),
                 crypto_provider.clone(),
                 branding,
+                mdns_hostname,
                 passthroughs,
                 max_proxy_conns_per_target,
                 port_map.clone(),

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -111,7 +111,6 @@ impl NetController {
         let hostname = peek.as_public().as_server_info().as_hostname().de()?;
         drop(peek);
         let branding = crate::net::ssl::CertBranding::start_os(&hostname);
-        let mdns_hostname = crate::hostname::ServerHostname::new(hostname)?.local_domain_name();
         // One PortMapController shared by the forward and vhost controllers so a
         // single query answers "is this port automatically forwarded?".
         let port_map = PortMapController::new(net_iface.watcher.subscribe());
@@ -141,7 +140,6 @@ impl NetController {
                 net_iface.clone(),
                 crypto_provider.clone(),
                 branding,
-                mdns_hostname,
                 passthroughs,
                 max_proxy_conns_per_target,
                 port_map.clone(),
@@ -485,11 +483,16 @@ impl NetServiceData {
                     );
                 }
 
-                // Domain vhosts: group by (domain, ssl_port), merge public/private
+                // Named vhosts: group by (hostname, ssl_port), merge public/private
                 // sets. Terminating when we hold the TLS (add_ssl); an SNI
                 // passthrough to the container's own TLS otherwise. Either way the
-                // domain entry carries its own gateways, so a public domain accepts
-                // WAN even where the bare IP is disabled.
+                // entry carries its own gateways, so a public domain accepts WAN
+                // even where the bare IP is disabled.
+                //
+                // The mDNS name is registered here like any other: the vhost
+                // controller serves a name only if it has an entry, and this is
+                // where the set of names a host answers to is decided. It is never
+                // public, so it contributes no upstream port map.
                 let passthrough = bind.options.add_ssl.is_none();
                 for addr_info in &enabled_addresses {
                     if !addr_info.ssl {
@@ -497,7 +500,8 @@ impl NetServiceData {
                     }
                     match &addr_info.metadata {
                         HostnameMetadata::PublicDomain { .. }
-                        | HostnameMetadata::PrivateDomain { .. } => {}
+                        | HostnameMetadata::PrivateDomain { .. }
+                        | HostnameMetadata::Mdns { .. } => {}
                         _ => continue,
                     }
                     let domain = &addr_info.hostname;

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -257,8 +257,6 @@ pub struct VHostController {
     crypto_provider: Arc<CryptoProvider>,
     acme_cache: AcmeTlsAlpnCache,
     branding: CertBranding,
-    /// The box's own `<hostname>.local` — see [`serves_sni`].
-    mdns_hostname: InternedString,
     max_proxy_conns_per_target: usize,
     servers: SyncMutex<BTreeMap<u16, VHostServer<VHostBindListener>>>,
     passthrough_handles: SyncMutex<BTreeMap<(InternedString, u16), PassthroughHandle>>,
@@ -278,7 +276,6 @@ impl VHostController {
         interfaces: Arc<NetworkInterfaceController>,
         crypto_provider: Arc<CryptoProvider>,
         branding: CertBranding,
-        mdns_hostname: InternedString,
         passthroughs: Vec<PassthroughInfo>,
         max_proxy_conns_per_target: usize,
         port_map: PortMapController,
@@ -289,7 +286,6 @@ impl VHostController {
             crypto_provider,
             acme_cache: Arc::new(SyncMutex::new(BTreeMap::new())),
             branding,
-            mdns_hostname,
             max_proxy_conns_per_target,
             servers: SyncMutex::new(BTreeMap::new()),
             passthrough_handles: SyncMutex::new(BTreeMap::new()),
@@ -343,7 +339,6 @@ impl VHostController {
             self.db.clone(),
             self.crypto_provider.clone(),
             self.branding.clone(),
-            self.mdns_hostname.clone(),
             self.acme_cache.clone(),
         )
     }
@@ -1470,20 +1465,17 @@ fn cancel_dead<A: Accept + 'static>(targets: &mut InOMap<DynVHostTarget<A>, Targ
 
 type Mapping<A> = BTreeMap<Option<InternedString>, InOMap<DynVHostTarget<A>, TargetEntry>>;
 
-/// Whether this box answers to the name the client asked for.
+/// The [`Mapping`] key for a connection's SNI.
 ///
-/// The `None` key is the bare-IP catch-all, which `get_config` falls back to
-/// when nothing matches the SNI. Left ungated that fallback serves — and has
-/// the root CA mint a leaf for — any name that happens to resolve here, so an
-/// unrecognized SNI is refused instead. `None` is a dial with no SNI at all
-/// (what browsers send for `https://<ip>`), and the server's own host carries
-/// no domains, so its `<hostname>.local` has to be admitted explicitly.
-fn serves_sni<V>(
-    mapping: &BTreeMap<Option<InternedString>, V>,
-    mdns_hostname: &InternedString,
-    sni: &Option<InternedString>,
-) -> bool {
-    sni.is_none() || sni.as_ref() == Some(mdns_hostname) || mapping.contains_key(sni)
+/// `None` is a connection that named no host — no SNI, or an SNI carrying an IP
+/// literal, which RFC 6066 forbids but clients send anyway — and is served by
+/// the bare-IP entry. A name is served only if it has an entry of its own: the
+/// lookup has no fallback, so a host answers to the names it was given and
+/// nothing else.
+fn host_key(server_name: Option<&str>) -> Option<InternedString> {
+    server_name
+        .filter(|name| name.parse::<IpAddr>().is_err())
+        .map(InternedString::from)
 }
 
 pub struct GetVHostAcmeProvider<A: Accept + 'static>(pub Watch<Mapping<A>>);
@@ -1560,7 +1552,6 @@ pub struct VHostTlsHandler<I, A: Accept + 'static> {
     inner: I,
     crypto_provider: Arc<CryptoProvider>,
     mapping: Watch<Mapping<A>>,
-    mdns_hostname: InternedString,
     preprocessed: Option<Preprocessed<A>>,
 }
 impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
@@ -1569,7 +1560,6 @@ impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
             inner: self.inner.clone(),
             crypto_provider: self.crypto_provider.clone(),
             mapping: self.mapping.clone(),
-            mdns_hostname: self.mdns_hostname.clone(),
             // Per-connection state — never carried across clones; each
             // accepted connection clones the handler before populating it.
             preprocessed: None,
@@ -1589,18 +1579,10 @@ where
         hello: &'a ClientHello<'a>,
         metadata: &'a <A as Accept>::Metadata,
     ) -> Option<TlsHandlerAction> {
-        let sni = hello.server_name().map(InternedString::from);
-
-        if !self
-            .mapping
-            .peek(|m| serves_sni(m, &self.mdns_hostname, &sni))
-        {
-            return None;
-        }
+        let sni = host_key(hello.server_name());
 
         let routed = self.mapping.peek(|m| {
             m.get(&sni)
-                .or_else(|| m.get(&None))
                 .into_iter()
                 .flatten()
                 .filter(|(_, e)| e.alive())
@@ -1608,33 +1590,30 @@ where
                 .map(|(t, e)| (t.clone(), e.ctx.clone()))
         });
 
-        let acme_alpn = hello
-            .alpn()
-            .into_iter()
-            .flatten()
-            .any(|a| a == ACME_TLS_ALPN_NAME);
+        let Some((target, ctx)) = routed else {
+            return None;
+        };
 
         // Passthroughs should not intermediate ACME challenges — the
         // backend is the ACME client and holds the challenge cert.
-        if let Some((target, ctx)) = routed.as_ref().filter(|(t, _)| t.0.is_passthrough()) {
+        if target.0.is_passthrough() {
             let stub = passthrough_stub_config(&self.crypto_provider).log_err()?;
-            let (_, store) = target
-                .clone()
-                .into_preprocessed(ctx.clone(), stub, hello, metadata)
-                .await?;
+            let (_, store) = target.into_preprocessed(ctx, stub, hello, metadata).await?;
             self.preprocessed = Some(store);
             return Some(TlsHandlerAction::Passthrough);
         }
 
-        // ACME challenge for a terminating target (or for one with no
-        // explicit vhost mapping): answer locally from the inner chain.
-        if acme_alpn {
+        // ACME challenge for a terminating target: answer locally from the inner
+        // chain. Reached only for a host we serve, so a challenge for anything
+        // else is refused above rather than answered with a fresh leaf.
+        if hello
+            .alpn()
+            .into_iter()
+            .flatten()
+            .any(|a| a == ACME_TLS_ALPN_NAME)
+        {
             return self.inner.get_config(hello, metadata).await;
         }
-
-        let Some((target, ctx)) = routed else {
-            return None;
-        };
 
         let action = self.inner.get_config(hello, metadata).await?;
         let cfg = match action {
@@ -1761,7 +1740,6 @@ impl<A: Accept> VHostServer<A> {
         db: TypedPatchDb<M>,
         crypto_provider: Arc<CryptoProvider>,
         branding: CertBranding,
-        mdns_hostname: InternedString,
         acme_cache: AcmeTlsAlpnCache,
     ) -> Self
     where
@@ -1804,7 +1782,6 @@ impl<A: Accept> VHostServer<A> {
                         ),
                         crypto_provider,
                         mapping,
-                        mdns_hostname,
                         preprocessed: None,
                     },
                 ));
@@ -1948,48 +1925,34 @@ async fn copy_bidirectional_hangs_without_keepalive_when_peer_idle() {
 }
 
 #[cfg(test)]
-mod sni_tests {
+mod host_key_tests {
     use super::*;
 
-    fn s(name: &str) -> InternedString {
-        InternedString::intern(name)
-    }
-
-    fn mapping(keys: &[Option<&str>]) -> BTreeMap<Option<InternedString>, ()> {
-        keys.iter().map(|k| (k.map(s), ())).collect()
+    /// A dial that names no host is the bare-IP case the `None` entry serves.
+    #[test]
+    fn an_ip_literal_sni_is_the_same_as_no_sni() {
+        assert_eq!(host_key(None), None);
+        assert_eq!(host_key(Some("192.168.1.5")), None);
+        assert_eq!(host_key(Some("::1")), None);
+        assert_eq!(host_key(Some("fd00:3::1")), None);
     }
 
     #[test]
-    fn a_name_the_box_does_not_serve_is_refused() {
-        // The catch-all is present, as it is on any box reachable by bare IP.
-        let m = mapping(&[None]);
-        let mdns = s("server-name.local");
-
-        assert!(!serves_sni(&m, &mdns, &Some(s("server-name"))));
-        assert!(!serves_sni(&m, &mdns, &Some(s("www.google.com"))));
-        // A near-miss in the mDNS namespace is still not ours.
-        assert!(!serves_sni(&m, &mdns, &Some(s("other-box.local"))));
-    }
-
-    #[test]
-    fn bare_ip_and_the_boxs_own_names_are_served() {
-        let m = mapping(&[None, Some("example.com")]);
-        let mdns = s("server-name.local");
-
-        // No SNI: a `https://<ip>` dial, which the catch-all exists for.
-        assert!(serves_sni(&m, &mdns, &None));
-        assert!(serves_sni(&m, &mdns, &Some(s("server-name.local"))));
-        assert!(serves_sni(&m, &mdns, &Some(s("example.com"))));
-    }
-
-    /// A box with no catch-all registered still serves its configured domains.
-    #[test]
-    fn a_mapped_domain_does_not_depend_on_the_catch_all() {
-        let m = mapping(&[Some("example.com")]);
-        let mdns = s("server-name.local");
-
-        assert!(serves_sni(&m, &mdns, &Some(s("example.com"))));
-        assert!(!serves_sni(&m, &mdns, &Some(s("evil.example.com"))));
+    fn a_name_keys_to_itself() {
+        assert_eq!(
+            host_key(Some("server-name.local")),
+            Some(InternedString::intern("server-name.local"))
+        );
+        assert_eq!(
+            host_key(Some("example.com")),
+            Some(InternedString::intern("example.com"))
+        );
+        // Not an IP, so it keys like any other name — and nothing registers it,
+        // so the lookup misses and the connection is refused.
+        assert_eq!(
+            host_key(Some("server-name")),
+            Some(InternedString::intern("server-name"))
+        );
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -257,6 +257,8 @@ pub struct VHostController {
     crypto_provider: Arc<CryptoProvider>,
     acme_cache: AcmeTlsAlpnCache,
     branding: CertBranding,
+    /// The box's own `<hostname>.local` — see [`serves_sni`].
+    mdns_hostname: InternedString,
     max_proxy_conns_per_target: usize,
     servers: SyncMutex<BTreeMap<u16, VHostServer<VHostBindListener>>>,
     passthrough_handles: SyncMutex<BTreeMap<(InternedString, u16), PassthroughHandle>>,
@@ -276,6 +278,7 @@ impl VHostController {
         interfaces: Arc<NetworkInterfaceController>,
         crypto_provider: Arc<CryptoProvider>,
         branding: CertBranding,
+        mdns_hostname: InternedString,
         passthroughs: Vec<PassthroughInfo>,
         max_proxy_conns_per_target: usize,
         port_map: PortMapController,
@@ -286,6 +289,7 @@ impl VHostController {
             crypto_provider,
             acme_cache: Arc::new(SyncMutex::new(BTreeMap::new())),
             branding,
+            mdns_hostname,
             max_proxy_conns_per_target,
             servers: SyncMutex::new(BTreeMap::new()),
             passthrough_handles: SyncMutex::new(BTreeMap::new()),
@@ -339,6 +343,7 @@ impl VHostController {
             self.db.clone(),
             self.crypto_provider.clone(),
             self.branding.clone(),
+            self.mdns_hostname.clone(),
             self.acme_cache.clone(),
         )
     }
@@ -1465,6 +1470,22 @@ fn cancel_dead<A: Accept + 'static>(targets: &mut InOMap<DynVHostTarget<A>, Targ
 
 type Mapping<A> = BTreeMap<Option<InternedString>, InOMap<DynVHostTarget<A>, TargetEntry>>;
 
+/// Whether this box answers to the name the client asked for.
+///
+/// The `None` key is the bare-IP catch-all, which `get_config` falls back to
+/// when nothing matches the SNI. Left ungated that fallback serves — and has
+/// the root CA mint a leaf for — any name that happens to resolve here, so an
+/// unrecognized SNI is refused instead. `None` is a dial with no SNI at all
+/// (what browsers send for `https://<ip>`), and the server's own host carries
+/// no domains, so its `<hostname>.local` has to be admitted explicitly.
+fn serves_sni<V>(
+    mapping: &BTreeMap<Option<InternedString>, V>,
+    mdns_hostname: &InternedString,
+    sni: &Option<InternedString>,
+) -> bool {
+    sni.is_none() || sni.as_ref() == Some(mdns_hostname) || mapping.contains_key(sni)
+}
+
 pub struct GetVHostAcmeProvider<A: Accept + 'static>(pub Watch<Mapping<A>>);
 impl<A: Accept + 'static> Clone for GetVHostAcmeProvider<A> {
     fn clone(&self) -> Self {
@@ -1539,6 +1560,7 @@ pub struct VHostTlsHandler<I, A: Accept + 'static> {
     inner: I,
     crypto_provider: Arc<CryptoProvider>,
     mapping: Watch<Mapping<A>>,
+    mdns_hostname: InternedString,
     preprocessed: Option<Preprocessed<A>>,
 }
 impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
@@ -1547,6 +1569,7 @@ impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
             inner: self.inner.clone(),
             crypto_provider: self.crypto_provider.clone(),
             mapping: self.mapping.clone(),
+            mdns_hostname: self.mdns_hostname.clone(),
             // Per-connection state — never carried across clones; each
             // accepted connection clones the handler before populating it.
             preprocessed: None,
@@ -1566,8 +1589,17 @@ where
         hello: &'a ClientHello<'a>,
         metadata: &'a <A as Accept>::Metadata,
     ) -> Option<TlsHandlerAction> {
+        let sni = hello.server_name().map(InternedString::from);
+
+        if !self
+            .mapping
+            .peek(|m| serves_sni(m, &self.mdns_hostname, &sni))
+        {
+            return None;
+        }
+
         let routed = self.mapping.peek(|m| {
-            m.get(&hello.server_name().map(InternedString::from))
+            m.get(&sni)
                 .or_else(|| m.get(&None))
                 .into_iter()
                 .flatten()
@@ -1729,6 +1761,7 @@ impl<A: Accept> VHostServer<A> {
         db: TypedPatchDb<M>,
         crypto_provider: Arc<CryptoProvider>,
         branding: CertBranding,
+        mdns_hostname: InternedString,
         acme_cache: AcmeTlsAlpnCache,
     ) -> Self
     where
@@ -1771,6 +1804,7 @@ impl<A: Accept> VHostServer<A> {
                         ),
                         crypto_provider,
                         mapping,
+                        mdns_hostname,
                         preprocessed: None,
                     },
                 ));
@@ -1911,6 +1945,52 @@ async fn copy_bidirectional_hangs_without_keepalive_when_peer_idle() {
     );
 
     proxy.abort();
+}
+
+#[cfg(test)]
+mod sni_tests {
+    use super::*;
+
+    fn s(name: &str) -> InternedString {
+        InternedString::intern(name)
+    }
+
+    fn mapping(keys: &[Option<&str>]) -> BTreeMap<Option<InternedString>, ()> {
+        keys.iter().map(|k| (k.map(s), ())).collect()
+    }
+
+    #[test]
+    fn a_name_the_box_does_not_serve_is_refused() {
+        // The catch-all is present, as it is on any box reachable by bare IP.
+        let m = mapping(&[None]);
+        let mdns = s("server-name.local");
+
+        assert!(!serves_sni(&m, &mdns, &Some(s("server-name"))));
+        assert!(!serves_sni(&m, &mdns, &Some(s("www.google.com"))));
+        // A near-miss in the mDNS namespace is still not ours.
+        assert!(!serves_sni(&m, &mdns, &Some(s("other-box.local"))));
+    }
+
+    #[test]
+    fn bare_ip_and_the_boxs_own_names_are_served() {
+        let m = mapping(&[None, Some("example.com")]);
+        let mdns = s("server-name.local");
+
+        // No SNI: a `https://<ip>` dial, which the catch-all exists for.
+        assert!(serves_sni(&m, &mdns, &None));
+        assert!(serves_sni(&m, &mdns, &Some(s("server-name.local"))));
+        assert!(serves_sni(&m, &mdns, &Some(s("example.com"))));
+    }
+
+    /// A box with no catch-all registered still serves its configured domains.
+    #[test]
+    fn a_mapped_domain_does_not_depend_on_the_catch_all() {
+        let m = mapping(&[Some("example.com")]);
+        let mdns = s("server-name.local");
+
+        assert!(serves_sni(&m, &mdns, &Some(s("example.com"))));
+        assert!(!serves_sni(&m, &mdns, &Some(s("evil.example.com"))));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Part of #3628 — case 1 (a domain never configured on the server is still served). Reported independently by @MattDHill for the narrower case of the server's own `.local` name typed without the `.local`.

Cases 2 and 3 of that issue (an address toggled off on the Interfaces page, and every row on a gateway disabled, both still served) are **not** fixed here — those go through the address enable/disable state in `host/binding.rs` (`addresses.disabled`), which never reaches the SNI path this touches. Leaving #3628 open for them.

## What was happening

`VHostTlsHandler::get_config` looked the SNI up in the vhost mapping and fell back to the `None` key on a miss. That key is the bare-IP catch-all — the entry that makes `https://<lan-ip>` work — so any name that resolved to the box was served the dashboard. `RootCaTlsHandler` then passed the same unvalidated SNI to `CertStore::cert_for`, whose doc comment is explicit:

> This function will grant any cert for any domain. It is up to the *caller* to ensure that the calling service has permission to sign a cert for the requested domain

No caller did, so the box minted a leaf for whatever name was asked for:

```
$ openssl s_client -connect <box>:443 -servername www.google.com
subject=CN=www.google.com, O=Start9, OU=StartOS
issuer=CN=StartOS Local Intermediate CA, O=Start9, OU=StartOS

$ curl -k --resolve www.google.com:443:<box> https://www.google.com/
http_code=200   # byte-identical to the real dashboard
```

Per @dr-bonez on #3628 this is confusion rather than a vulnerability — the address is one the server is already configured to listen on, and the signature binding makes logging in under an unknown name impossible regardless. The changelog entry is under `Fixed` accordingly.

One measurement worth recording separately, since it isn't in #3628: `cert_for` persists a keypair plus two certs per distinct hostname set, keyed on that set, and nothing prunes them — `leaves` is only ever cleared on account reset. So each new name cost permanent patch-db state, and repeating the handshake under fresh names grew it without bound:

| | database | `startd` RSS |
|---|---|---|
| baseline | 29 KB | 87 MB |
| +2,300 handshakes, distinct names | 4.6 MB | 95 MB |

~2 KB per handshake from a single `openssl` loop, surviving reboot. The `acme-tls/1` ALPN branch reaches the same code (`ChainedHandler` falls through to `RootCaTlsHandler` when the ACME handler declines), so it grew the database just as well — gating only the routing lookup would have left that path open, which is why the check runs ahead of both. Happy to be told this is equally a non-issue; it's the reason the fix is placed where it is rather than in the routing lookup alone.

## The fix

Per @dr-bonez's review, `None` in the vhost mapping now means *a connection that named no host* rather than *a fallback for names that matched nothing*:

- no SNI, or an SNI carrying an IP literal (RFC 6066 forbids it; clients send it anyway) keys to `None` and is served by the bare-IP entry;
- a name is served only if it has an entry of its own. The lookup has no `.or_else(|| m.get(&None))`, so a host answers to the names it was given and nothing else.

`NetService` registers the mDNS name in the same loop as public and private domains — it is already the source of truth for what a host is served under, so the TLS handler needs no knowledge of hostnames at all. The mDNS address is `public: false`, so it lands in the target's `private` set and contributes no upstream port map (`reconcile_port_maps` derives those from `public_v4`/`public_v6` only). This covers packages for free: a package's LAN address is the server's `.local` on the package's own port.

Unwrapping `routed` before the passthrough and ACME branches also drops a clone and gates ACME on a matched target, so a challenge for a name we do not serve is refused rather than answered with a fresh leaf.

## Verification

Unit tests cover the predicate. For the end-to-end behavior I built `startbox` from this branch and pushed it to a VM with `make start-os-update-startbox`:

```
SERVED   no SNI (bare-IP dial)                -> CN=localhost   (IP SANs)
SERVED   own mDNS name (helix-master.local)   -> CN=helix-master.local
SERVED   IP literal as SNI (192.168.122.50)   -> CN=localhost   (IP SANs)
REFUSED  BARE hostname (helix-master)
REFUSED  www.google.com
REFUSED  other-box.local
REFUSED  acme ALPN + bogus SNI
```

The `.local` name is served by its own entry now, not a fallback — `start-cli net vhost dump-table` on that box shows it registered beside the bare-IP one, with the empty public sets that keep it out of the port mapper:

```
| *:443                  | ProxyTarget { public_v4: {}, public_v6: {},
|                        |   private: {10.0.3.1, 127.0.0.1, 192.168.122.50, ::1, fd00:3::1, fe80::...} }
| helix-master.local:443 | ProxyTarget { public_v4: {}, public_v6: {},
|                        |   private: {192.168.122.50, fe80::...} }
```

Dashboard returns 200 over both `.local` and bare IP (identical bodies), and 300 flood handshakes (150 plain + 150 `acme-tls/1`) left the database byte-identical at 26,424 bytes with zero attacker-supplied names stored. `cargo test -p start-core --lib net::` is green (213 passed).

## Worth a reviewer's opinion

- **`RootCaTlsHandler` is still unguarded on its own.** It is unreachable with an arbitrary SNI now that the gate sits ahead of it, so this is defence in depth rather than a live hole — but the contract in `cert_for`'s doc comment is still only satisfied by its caller. Happy to also constrain the handler itself if you want the invariant enforced where it is documented.
- Nothing validates the HTTP `Host` header anywhere, on 443 or on plain 80.
