### PR TITLE
fix(start-os): unbreak the NVIDIA image on GB10 — drop unusable GSP firmware, stage MOK enrollment

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -52,9 +52,10 @@ file tracks notable changes since the move to the monorepo.
 - **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
   DGX Spark, and is considerably smaller.** These images drive the GPU with
   NVIDIA's own driver and turn nouveau off, but they were still built with
-  nouveau's firmware for every supported chip — 152 MB of it, most of it inside
-  the initramfs that the bootloader must read in full before the kernel starts.
-  On GB10 that left the machine sitting on the last line the bootloader printed.
+  graphics firmware they cannot use — nouveau's, for every chip it supports,
+  along with an older driver series' — and 152 MB of it sat inside the initramfs
+  that the bootloader must read in full before the kernel starts. On GB10 that
+  left the machine sitting on the last line the bootloader printed.
   The images now carry only the graphics firmware they can use, which more than
   halves what is read at startup and takes a substantial amount off the
   download.

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -49,6 +49,15 @@ file tracks notable changes since the move to the monorepo.
   produced, and only the container's boot-time device pass — which races with
   the grant — widened them; on the losing side of that race a CI runner's jobs
   failed to start with `Failed to open() /dev/net/tun: Permission denied`.
+- **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
+  DGX Spark, and is considerably smaller.** These images drive the GPU with
+  NVIDIA's own driver and turn nouveau off, but they were still built with
+  nouveau's firmware for every supported chip — 152 MB of it, most of it inside
+  the initramfs that the bootloader must read in full before the kernel starts.
+  On GB10 that left the machine sitting on the last line the bootloader printed.
+  The images now carry only the graphics firmware they can use, which more than
+  halves what is read at startup and takes a substantial amount off the
+  download.
 
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -36,6 +36,17 @@ file tracks notable changes since the move to the monorepo.
   plaintext address, including the passwords typed into it. See
   [Gateways](https://docs.start9.com/start-os/gateways.html).
 
+### Changed
+
+- **The NVIDIA images now use NVIDIA's open kernel modules, which support GeForce
+  RTX 20-series, Quadro RTX and newer.** This is what makes current cards work at
+  all — an RTX 50-series, an RTX PRO 6000 or an NVIDIA GB10 can only be driven by
+  these modules. The trade is at the other end of the range: **a GeForce GTX
+  900-series or 10-series card, a Titan X or Xp, or a Tesla M40, P40, P100 or
+  V100 will no longer be driven by the NVIDIA images.** If you rely on one of
+  those, stay on 0.4.0.1 or use the Standard image, whose open-source `nouveau`
+  driver still provides display output without GPU compute.
+
 ### Fixed
 
 - Trim whitespace on form inputs.
@@ -83,8 +94,8 @@ file tracks notable changes since the move to the monorepo.
   the image built NVIDIA's driver in the flavour that does not support this
   generation of GPU, so the driver found the card but could never bring it up.
   The images now carry only the graphics firmware they can use, switch that
-  driver off, and build the flavour NVIDIA supports here — which is what NVIDIA's
-  own operating system does on the same hardware.
+  driver off, and build the kernel modules NVIDIA supports here — which is what
+  NVIDIA's own operating system does on the same hardware.
 
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -49,6 +49,15 @@ file tracks notable changes since the move to the monorepo.
   produced, and only the container's boot-time device pass — which races with
   the grant — widened them; on the losing side of that race a CI runner's jobs
   failed to start with `Failed to open() /dev/net/tun: Permission denied`.
+- **Reinstalling with "Preserve" copies your server's configuration before it
+  rewrites the drive, so the configuration survives.** The copy used to be taken
+  afterwards, by which point there was nothing left to read — so the server came
+  back with its configuration reset, and said nothing about it. Among the things
+  lost was the key your server uses to sign its add-on drivers, which on a
+  machine with Secure Boot left hardware such as an NVIDIA GPU unavailable
+  afterwards. A reinstall that cannot read the configuration it was asked to keep
+  now stops and says so, rather than continuing and discarding it.
+
 - **On a server with Secure Boot enabled, hardware that needs an add-on driver —
   an NVIDIA GPU, most commonly — works after setup.** Secure Boot only loads such
   a driver once you approve the key your server signs it with, and approving that

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -81,21 +81,26 @@ file tracks notable changes since the move to the monorepo.
   [Initial Setup](https://docs.start9.com/start-os/initial-setup.html).
 
 - **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
-  DGX Spark, its GPU works, and the image is considerably smaller.** Three
-  separate faults were involved, two of which each stopped the machine on the
-  last line the bootloader printed — so fixing either one alone changed nothing.
-  These images drive the GPU with NVIDIA's own driver and turn nouveau off, yet
-  were still built with graphics firmware they cannot use — nouveau's, for every
-  chip it supports, along with an older driver series' — and 152 MB of it sat
-  inside the initramfs that the bootloader must read in full before the kernel
-  starts. Separately, a Tegra fabric driver that recent kernels build in claims
-  one of the GB10's internal buses and reads a protected register on it, stopping
-  the machine during hardware detection before it can display anything. Finally,
-  the image built NVIDIA's driver in the flavour that does not support this
-  generation of GPU, so the driver found the card but could never bring it up.
-  The images now carry only the graphics firmware they can use, switch that
-  driver off, and build the kernel modules NVIDIA supports here — which is what
-  NVIDIA's own operating system does on the same hardware.
+  DGX Spark, GPU workloads like Ollama and vLLM run on it, and the image is
+  considerably smaller.** Four separate faults were involved, two of which each
+  stopped the machine on the last line the bootloader printed — so fixing either
+  one alone changed nothing. These images drive the GPU with NVIDIA's own driver
+  and turn nouveau off, yet were still built with graphics firmware they cannot
+  use — nouveau's, for every chip it supports, along with an older driver
+  series' — and 152 MB of it sat inside the initramfs that the bootloader must
+  read in full before the kernel starts. Separately, a Tegra fabric driver that
+  recent kernels build in claims one of the GB10's internal buses and reads a
+  protected register on it, stopping the machine during hardware detection before
+  it can display anything. Third, the image built NVIDIA's driver in the flavour
+  that does not support this generation of GPU, so the driver found the card but
+  could never bring it up. Last, the GPU came up and reported itself correctly
+  while every CUDA program still failed at startup, because NVIDIA's driver
+  declines a GPU whose address-translation support does not match what the kernel
+  offers, and this kernel is built without the support that an integrated GPU
+  like the GB10 advertises. The images now carry only the graphics firmware they
+  can use, switch that driver off, build the kernel modules NVIDIA supports here
+  — which is what NVIDIA's own operating system does on the same hardware — and
+  accept the GPU rather than turning it away.
 
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -49,6 +49,17 @@ file tracks notable changes since the move to the monorepo.
   produced, and only the container's boot-time device pass — which races with
   the grant — widened them; on the losing side of that race a CI runner's jobs
   failed to start with `Failed to open() /dev/net/tun: Permission denied`.
+- **On a server with Secure Boot enabled, hardware that needs an add-on driver —
+  an NVIDIA GPU, most commonly — works after setup.** Secure Boot only loads such
+  a driver once you approve the key your server signs it with, and approving that
+  key is protected by your master password. Your server only ever asked the
+  firmware to trust the key while starting up, which on a new server happens
+  before you have set a password, so the request was never made and you were
+  never shown the prompt — leaving the driver unable to load, with nothing to say
+  why. Your server now asks as soon as you set your password, so the prompt
+  appears on the next restart. See
+  [Initial Setup](https://docs.start9.com/start-os/initial-setup.html).
+
 - **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
   DGX Spark, and is considerably smaller.** These images drive the GPU with
   NVIDIA's own driver and turn nouveau off, but they were still built with

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -70,15 +70,17 @@ file tracks notable changes since the move to the monorepo.
   [Initial Setup](https://docs.start9.com/start-os/initial-setup.html).
 
 - **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
-  DGX Spark, and is considerably smaller.** These images drive the GPU with
-  NVIDIA's own driver and turn nouveau off, but they were still built with
-  graphics firmware they cannot use — nouveau's, for every chip it supports,
-  along with an older driver series' — and 152 MB of it sat inside the initramfs
-  that the bootloader must read in full before the kernel starts. On GB10 that
-  left the machine sitting on the last line the bootloader printed.
-  The images now carry only the graphics firmware they can use, which more than
-  halves what is read at startup and takes a substantial amount off the
-  download.
+  DGX Spark, and is considerably smaller.** Two separate faults each stopped the
+  machine on the last line the bootloader printed, so fixing either one alone
+  changed nothing. These images drive the GPU with NVIDIA's own driver and turn
+  nouveau off, yet were still built with graphics firmware they cannot use —
+  nouveau's, for every chip it supports, along with an older driver series' — and
+  152 MB of it sat inside the initramfs that the bootloader must read in full
+  before the kernel starts. Separately, a Tegra fabric driver that recent kernels
+  build in claims one of the GB10's internal buses and reads a protected register
+  on it, stopping the machine during hardware detection, before it can display
+  anything. The images now carry only the graphics firmware they can use, and
+  switch that driver off — which is what NVIDIA's own OS does on this hardware.
 
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -70,17 +70,21 @@ file tracks notable changes since the move to the monorepo.
   [Initial Setup](https://docs.start9.com/start-os/initial-setup.html).
 
 - **The 64-bit ARM NVIDIA image boots on NVIDIA GB10 hardware again, such as the
-  DGX Spark, and is considerably smaller.** Two separate faults each stopped the
-  machine on the last line the bootloader printed, so fixing either one alone
-  changed nothing. These images drive the GPU with NVIDIA's own driver and turn
-  nouveau off, yet were still built with graphics firmware they cannot use —
-  nouveau's, for every chip it supports, along with an older driver series' — and
-  152 MB of it sat inside the initramfs that the bootloader must read in full
-  before the kernel starts. Separately, a Tegra fabric driver that recent kernels
-  build in claims one of the GB10's internal buses and reads a protected register
-  on it, stopping the machine during hardware detection, before it can display
-  anything. The images now carry only the graphics firmware they can use, and
-  switch that driver off — which is what NVIDIA's own OS does on this hardware.
+  DGX Spark, its GPU works, and the image is considerably smaller.** Three
+  separate faults were involved, two of which each stopped the machine on the
+  last line the bootloader printed — so fixing either one alone changed nothing.
+  These images drive the GPU with NVIDIA's own driver and turn nouveau off, yet
+  were still built with graphics firmware they cannot use — nouveau's, for every
+  chip it supports, along with an older driver series' — and 152 MB of it sat
+  inside the initramfs that the bootloader must read in full before the kernel
+  starts. Separately, a Tegra fabric driver that recent kernels build in claims
+  one of the GB10's internal buses and reads a protected register on it, stopping
+  the machine during hardware detection before it can display anything. Finally,
+  the image built NVIDIA's driver in the flavour that does not support this
+  generation of GPU, so the driver found the card but could never bring it up.
+  The images now carry only the graphics firmware they can use, switch that
+  driver off, and build the flavour NVIDIA supports here — which is what NVIDIA's
+  own operating system does on the same hardware.
 
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -331,9 +331,10 @@ if [ "${NVIDIA}" = "1" ]; then
     echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf
     echo "options nouveau modeset=0" >> /etc/modprobe.d/blacklist-nouveau.conf
 
-    # initramfs-tools copies the firmware every included module declares, blacklist
-    # or not, so nouveau's GSP blobs land in the initramfs the bootloader must read.
-    echo "[nvidia-hook] Removing nouveau GSP firmware..." >&2
+    # initramfs-tools copies the firmware every included module declares, blacklist or
+    # not, so nouveau's GSP reaches the initramfs the bootloader must read. The 535 GSP
+    # serves Debian's driver; the .run ships its own under nvidia/580.173.02.
+    echo "[nvidia-hook] Removing unusable NVIDIA GSP firmware..." >&2
     apt-get purge -y firmware-nvidia-graphics firmware-nvidia-tesla-535-gsp
 
     echo "[nvidia-hook] Rebuilding initramfs..." >&2

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -94,6 +94,12 @@ elif [ "${IB_TARGET_ARCH}" = "riscv64" ]; then
 fi
 
 
+BOOTAPPEND_LIVE="boot=live noautologin console=tty0"
+if [ "${IB_TARGET_PLATFORM}" = "aarch64-nvidia" ]; then
+	# Same GB10 hang the installed system guards against — see debian/postinst.
+	BOOTAPPEND_LIVE="$BOOTAPPEND_LIVE initcall_blacklist=tegra234_cbb_init"
+fi
+
 cat > /etc/wgetrc << EOF
 retry_connrefused = on
 tries = 100
@@ -104,7 +110,7 @@ lb config \
 	--iso-preparer "START9 LABS; HTTPS://START9.COM" \
 	--iso-publisher "START9 LABS; HTTPS://START9.COM" \
 	--backports true \
-	--bootappend-live "boot=live noautologin console=tty0" \
+	--bootappend-live "$BOOTAPPEND_LIVE" \
 	--bootloaders $BOOTLOADERS \
 	--cache false \
 	--mirror-bootstrap "https://deb.debian.org/debian/" \

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -310,18 +310,35 @@ if [ "${NVIDIA}" = "1" ]; then
     wget -O "\${RUN_PATH}" "\${RUN_URL}"
     chmod +x "\${RUN_PATH}"
 
+    SRC_PATH="/root/nvidia-\${NVIDIA_DRIVER_VERSION}"
+    echo "[nvidia-hook] Extracting installer to \${SRC_PATH}" >&2
+    sh "\${RUN_PATH}" --extract-only --target "\${SRC_PATH}"
+
+    # UVM refuses to register a GPU whose ATS capability disagrees with the VA space's.
+    # Debian builds no CONFIG_IOMMU_SVA, so UVM pins every VA space to ATS_UNSUPPORTED
+    # while an integrated part like GB10 still advertises ATS — registration then fails
+    # with NV_ERR_INVALID_DEVICE, which UVM never logs, and cuInit reports only
+    # CUDA_ERROR_NOT_INITIALIZED. Dropping the guard forfeits mixing coherent and
+    # non-coherent GPUs in one process, which these images do not support anyway.
+    UVM_VA_SPACE="\${SRC_PATH}/kernel-open/nvidia-uvm/uvm_va_space.c"
+    ATS_GUARD='if (!uvm_va_space_ats_unset(va_space) &&'
+    if ! grep -qF "\${ATS_GUARD}" "\${UVM_VA_SPACE}"; then
+        echo "[nvidia-hook] ATS guard not found in \${UVM_VA_SPACE} — re-verify against this driver" >&2
+        exit 1
+    fi
+    sed -i "s|\${ATS_GUARD}|if (0 \&\& !uvm_va_space_ats_unset(va_space) \&\&|" "\${UVM_VA_SPACE}"
+
     echo "[nvidia-hook] Running NVIDIA installer for kernel \${KVER}" >&2
 
     # Pinned, or the installer picks the flavour from the build host's own GPUs. Open
     # is the only flavour that drives Blackwell, and it covers Turing and later; these
     # images deliberately do not support Maxwell, Pascal or Volta.
-    if ! sh "\${RUN_PATH}" \
+    if ! (cd "\${SRC_PATH}" && ./nvidia-installer \
         --silent \
         --kernel-module-type=open \
         --kernel-name="\${KVER}" \
         --no-x-check \
-        --no-nouveau-check \
-        --no-runlevel-check; then
+        --no-nouveau-check); then
 		cat /var/log/nvidia-installer.log
 		exit 1
 	fi
@@ -333,7 +350,7 @@ if [ "${NVIDIA}" = "1" ]; then
     echo "[nvidia-hook] NVIDIA \${NVIDIA_DRIVER_VERSION} installation complete for kernel \${KVER}" >&2
 
     echo "[nvidia-hook] Removing .run installer..." >&2
-    rm -f "\${RUN_PATH}"
+    rm -rf "\${RUN_PATH}" "\${SRC_PATH}"
 
     echo "[nvidia-hook] Blacklisting nouveau..." >&2
     echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -331,6 +331,11 @@ if [ "${NVIDIA}" = "1" ]; then
     echo "blacklist nouveau" > /etc/modprobe.d/blacklist-nouveau.conf
     echo "options nouveau modeset=0" >> /etc/modprobe.d/blacklist-nouveau.conf
 
+    # initramfs-tools copies the firmware every included module declares, blacklist
+    # or not, so nouveau's GSP blobs land in the initramfs the bootloader must read.
+    echo "[nvidia-hook] Removing nouveau GSP firmware..." >&2
+    apt-get purge -y firmware-nvidia-graphics firmware-nvidia-tesla-535-gsp
+
     echo "[nvidia-hook] Rebuilding initramfs..." >&2
     update-initramfs -u -k "\${KVER}"
 

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -94,14 +94,6 @@ elif [ "${IB_TARGET_ARCH}" = "riscv64" ]; then
 fi
 
 
-# Blackwell is open-only from 580.173.02, and on GB10 the proprietary modules
-# enumerate the GPU but never finish RmInitAdapter. aarch64 has no pre-Turing NVIDIA
-# hardware to lose by this; x86_64 does, so it keeps the proprietary flavour.
-NVIDIA_MODULE_TYPE=proprietary
-if [ "${IB_TARGET_PLATFORM}" = "aarch64-nvidia" ]; then
-	NVIDIA_MODULE_TYPE=open
-fi
-
 BOOTAPPEND_LIVE="boot=live noautologin console=tty0"
 if [ "${IB_TARGET_PLATFORM}" = "aarch64-nvidia" ]; then
 	# Same GB10 hang the installed system guards against — see debian/postinst.
@@ -320,10 +312,12 @@ if [ "${NVIDIA}" = "1" ]; then
 
     echo "[nvidia-hook] Running NVIDIA installer for kernel \${KVER}" >&2
 
-    # Otherwise the installer picks the flavour from the build host's own GPUs.
+    # Pinned, or the installer picks the flavour from the build host's own GPUs. Open
+    # is the only flavour that drives Blackwell, and it covers Turing and later; these
+    # images deliberately do not support Maxwell, Pascal or Volta.
     if ! sh "\${RUN_PATH}" \
         --silent \
-        --kernel-module-type=${NVIDIA_MODULE_TYPE} \
+        --kernel-module-type=open \
         --kernel-name="\${KVER}" \
         --no-x-check \
         --no-nouveau-check \

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -323,7 +323,7 @@ if [ "${NVIDIA}" = "1" ]; then
     # Otherwise the installer picks the flavour from the build host's own GPUs.
     if ! sh "\${RUN_PATH}" \
         --silent \
-        --kernel-module-type=proprietary \
+        --kernel-module-type=${NVIDIA_MODULE_TYPE} \
         --kernel-name="\${KVER}" \
         --no-x-check \
         --no-nouveau-check \

--- a/projects/start-os/build/image-recipe/build.sh
+++ b/projects/start-os/build/image-recipe/build.sh
@@ -94,6 +94,14 @@ elif [ "${IB_TARGET_ARCH}" = "riscv64" ]; then
 fi
 
 
+# Blackwell is open-only from 580.173.02, and on GB10 the proprietary modules
+# enumerate the GPU but never finish RmInitAdapter. aarch64 has no pre-Turing NVIDIA
+# hardware to lose by this; x86_64 does, so it keeps the proprietary flavour.
+NVIDIA_MODULE_TYPE=proprietary
+if [ "${IB_TARGET_PLATFORM}" = "aarch64-nvidia" ]; then
+	NVIDIA_MODULE_TYPE=open
+fi
+
 BOOTAPPEND_LIVE="boot=live noautologin console=tty0"
 if [ "${IB_TARGET_PLATFORM}" = "aarch64-nvidia" ]; then
 	# Same GB10 hang the installed system guards against — see debian/postinst.

--- a/projects/start-os/container-runtime/download-base-image.sh
+++ b/projects/start-os/container-runtime/download-base-image.sh
@@ -14,9 +14,13 @@ elif [ "$_ARCH" = "aarch64" ]; then
     _ARCH=arm64
 fi
 
-BASE_URL="https://images.linuxcontainers.org$(curl -fsSL https://images.linuxcontainers.org/meta/1.0/index-system | grep "^$DISTRO;$VERSION;$_ARCH;$FLAVOR;" | head -n1 | sed 's/^.*;//g')"
+RETRY=(--retry 5 --retry-delay 2 --retry-all-errors)
+
+BASE_URL="https://images.linuxcontainers.org$(curl -fsSL "${RETRY[@]}" https://images.linuxcontainers.org/meta/1.0/index-system | grep "^$DISTRO;$VERSION;$_ARCH;$FLAVOR;" | head -n1 | sed 's/^.*;//g')"
 OUTPUT_FILE="debian.${ARCH}.squashfs"
 
 echo "Downloading ${BASE_URL}/rootfs.squashfs to $OUTPUT_FILE"
-curl -fsSL "${BASE_URL}/rootfs.squashfs" > "$OUTPUT_FILE"
-curl -fsSL "$BASE_URL/SHA256SUMS" | grep 'rootfs\.squashfs' | awk '{print $1"  '"$OUTPUT_FILE"'"}' | shasum -a 256 -c
+# -o, not a shell redirect: curl rewinds a file it owns before each retry, but
+# cannot rewind stdout, so `> file` concatenates every partial attempt instead.
+curl -fsSL "${RETRY[@]}" -o "$OUTPUT_FILE" "${BASE_URL}/rootfs.squashfs"
+curl -fsSL "${RETRY[@]}" "$BASE_URL/SHA256SUMS" | grep 'rootfs\.squashfs' | awk '{print $1"  '"$OUTPUT_FILE"'"}' | shasum -a 256 -c

--- a/projects/start-os/debian/postinst
+++ b/projects/start-os/debian/postinst
@@ -36,7 +36,14 @@ if [ -f /etc/default/grub ]; then
 	grub_set() {
 		set_config /etc/default/grub "$1" "\"$2\""
 	}
-	grub_set GRUB_CMDLINE_LINUX 'boot=startos console=ttyS0,115200n8 console=tty0'
+	CMDLINE='boot=startos console=ttyS0,115200n8 console=tty0'
+	# tegra234-cbb ACPI-matches NVDA1070 and reads a firewalled fabric register
+	# before masking SError, which hangs a GB10 (DGX Spark) during ACPI scan —
+	# before any console exists. NVIDIA blacklists this same initcall on Spark.
+	if [ "$(cat /usr/lib/startos/PLATFORM.txt 2>/dev/null)" = aarch64-nvidia ]; then
+		CMDLINE="$CMDLINE initcall_blacklist=tegra234_cbb_init"
+	fi
+	grub_set GRUB_CMDLINE_LINUX "$CMDLINE"
 	grub_set GRUB_CMDLINE_LINUX_DEFAULT ''
 	grub_set GRUB_DISTRIBUTOR "StartOS v$(cat /usr/lib/startos/VERSION.txt)"
 	# Graphical terminal (serial added conditionally via /etc/grub.d/01_serial)

--- a/projects/start-os/docs/src/initial-setup.md
+++ b/projects/start-os/docs/src/initial-setup.md
@@ -25,3 +25,8 @@ After [installing StartOS](installing-startos.md), follow these steps to initial
 1. Set your [server name](server-name.md). Your server's [mDNS address](mdns.md) is derived from this name.
 
 1. Once initialization completes, open your server's permanent local address, then follow the instructions for [Trusting your Root CA](./trust-ca.md) to establish a secure connection with your server.
+
+> [!IMPORTANT]
+> **If your server has Secure Boot enabled, the next restart asks you to enroll a key.** Some hardware needs a driver that Secure Boot will only load once you approve it, and the NVIDIA graphics driver is the common case. Your server generates its own key for this during setup and asks the firmware to trust it, so on the following restart you are shown a blue **MokManager** screen on the monitor — a keyboard and monitor are required, as this happens before StartOS starts.
+>
+> Choose **Enroll MOK → Continue → Yes**, then enter your master password. Your server then restarts and the driver loads normally. If you decline, everything else works, but hardware needing such a driver stays unavailable until you enroll the key.

--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -15,6 +15,8 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
     - **Slim (FOSS-only)**: 100% open source, containing **no** proprietary firmware or drivers. Only compatible with certain hardware, such as the Start9 Server Pure.
 
+    An **NVIDIA** variant is also published for x86_64 and aarch64. Choose it only if your server has an NVIDIA GPU you want services to use for computation — it adds NVIDIA's driver and container toolkit on top of the Standard image. It supports GeForce RTX 20-series, Quadro RTX and newer; older cards such as the GeForce GTX 900- and 10-series, or Tesla M40, P40, P100 and V100, are not supported and should use the Standard image.
+
 1.  Verify the SHA256 checksum against the one listed on GitHub (optional but recommended).
     - **Mac**. Open a terminal and run:
 

--- a/shared-libs/crates/start-core/src/auth.rs
+++ b/shared-libs/crates/start-core/src/auth.rs
@@ -105,6 +105,14 @@ pub async fn write_shadow(password: &str) -> Result<(), Error> {
     }
     shadow_file.sync_all().await?;
     tokio::fs::copy("/media/startos/config/overlay/etc/shadow", "/etc/shadow").await?;
+
+    // The MOK enrollment is protected by this password, so `init`'s attempt at boot is
+    // always too early on a fresh install — setup writes the password after calling it.
+    // Staging it here is what gets the user prompted on the next boot.
+    crate::util::mok::enroll_mok(std::path::Path::new("/"))
+        .await
+        .log_err();
+
     Ok(())
 }
 

--- a/shared-libs/crates/start-core/src/init.rs
+++ b/shared-libs/crates/start-core/src/init.rs
@@ -173,9 +173,7 @@ pub async fn init(
     local_auth.complete();
 
     // Re-enroll MOK on every boot if Secure Boot key exists but isn't enrolled yet
-    if let Err(e) =
-        crate::util::mok::enroll_mok(std::path::Path::new(crate::util::mok::DKMS_MOK_PUB)).await
-    {
+    if let Err(e) = crate::util::mok::enroll_mok(std::path::Path::new("/")).await {
         tracing::warn!("MOK enrollment failed: {e}");
     }
 

--- a/shared-libs/crates/start-core/src/os_install/mod.rs
+++ b/shared-libs/crates/start-core/src/os_install/mod.rs
@@ -475,10 +475,9 @@ pub async fn install_os_to(
 
         crate::util::mok::sign_unsigned_modules(overlay.path()).await?;
 
-        let mok_pub = overlay
-            .path()
-            .join(crate::util::mok::DKMS_MOK_PUB.trim_start_matches('/'));
-        match crate::util::mok::enroll_mok(&mok_pub).await {
+        // Only stages an enrollment if the target already carries a password; a fresh
+        // install has none until setup, which enrolls it then.
+        match crate::util::mok::enroll_mok(overlay.path()).await {
             Ok(enrolled) => mok_enrolled = enrolled,
             Err(e) => tracing::warn!("MOK enrollment failed: {e}"),
         }

--- a/shared-libs/crates/start-core/src/os_install/mod.rs
+++ b/shared-libs/crates/start-core/src/os_install/mod.rs
@@ -288,6 +288,10 @@ pub async fn install_os_to(
         {
             if let Err(e) = async {
                 // cp -r ${guard}/config /tmp/config
+                // Whatever is added here, keep overlay/var/lib/dkms and overlay/etc/shadow:
+                // dropping the MOK key leaves the re-signed modules unmatched by the
+                // certificate the firmware already trusts, with no password left to enroll
+                // a new one, so Secure Boot silently stops loading them.
                 delete_file(guard.path().join("config/upgrade")).await?;
                 delete_file(guard.path().join("config/overlay/etc/hostname")).await?;
                 delete_file(guard.path().join("config/disk.guid")).await?;

--- a/shared-libs/crates/start-core/src/os_install/mod.rs
+++ b/shared-libs/crates/start-core/src/os_install/mod.rs
@@ -245,11 +245,14 @@ pub struct InstallOsResult {
     pub mok_enrolled: bool,
 }
 
-/// The OS root of a previous install on this disk: the first partition carrying a
-/// `config` directory. Identified by content rather than by label, so that an
-/// install predating any particular labelling scheme is still found. Only valid
-/// before `partition`, which rewrites the OS partitions and takes that filesystem
-/// with them.
+/// The OS root of a previous install on this disk: the first partition whose
+/// `config` completed setup (carries a `disk.guid`, written on setup completion).
+/// Identified by content rather than by label, so that an install predating any
+/// particular labelling scheme is still found. A config without `disk.guid` never
+/// reached setup — including the fresh default a failed earlier attempt of this
+/// very install left behind, which must not be mistaken for the real config.
+/// Only valid before `partition`, which rewrites the OS partitions and takes that
+/// filesystem with them.
 async fn previous_os_root(disk_path: &Path) -> Option<PathBuf> {
     for idx in 1..=16 {
         let part = partition_for(disk_path, idx);
@@ -265,11 +268,11 @@ async fn previous_os_root(disk_path: &Path) -> Option<PathBuf> {
                     continue;
                 }
             };
-        let has_config = tokio::fs::metadata(guard.path().join("config"))
+        let has_guid = tokio::fs::metadata(guard.path().join("config/disk.guid"))
             .await
-            .map_or(false, |m| m.is_dir());
+            .map_or(false, |m| m.is_file());
         guard.unmount().await.log_err();
-        if has_config {
+        if has_guid {
             return Some(part);
         }
     }
@@ -278,6 +281,20 @@ async fn previous_os_root(disk_path: &Path) -> Option<PathBuf> {
 
 const CONFIG_BAK: &str = "/tmp/config.bak";
 const CONFIG_BAK_STAGED: &str = "/tmp/config.bak.staged";
+/// Records which disk CONFIG_BAK was preserved from: /tmp survives a failed install
+/// attempt within one boot, and only a leftover from this same disk may be restored.
+const CONFIG_BAK_SRC: &str = "/tmp/config.bak.src";
+
+async fn clear_config_bak() -> Result<(), Error> {
+    delete_dir(CONFIG_BAK).await?;
+    delete_file(CONFIG_BAK_SRC).await
+}
+
+async fn config_bak_matches(disk_path: &Path) -> bool {
+    tokio::fs::read_to_string(CONFIG_BAK_SRC)
+        .await
+        .map_or(false, |s| Path::new(s.trim()) == disk_path)
+}
 
 /// Copy the previous install's config aside, for `install_os_to` to restore once the
 /// disk has been rewritten.
@@ -291,6 +308,11 @@ async fn preserve_config(disk_path: &Path) -> Result<(), Error> {
             "no previous StartOS root on {}; nothing to preserve",
             disk_path.display()
         );
+        // A leftover backup from an earlier attempt in this boot is only this disk's
+        // if the marker says so — anything else would restore another disk's config.
+        if !config_bak_matches(disk_path).await {
+            clear_config_bak().await?;
+        }
         return Ok(());
     };
     tracing::info!("preserving config from {}", old_root.display());
@@ -303,7 +325,7 @@ async fn preserve_config(disk_path: &Path) -> Result<(), Error> {
         // Anything added here must leave overlay/var/lib/dkms and overlay/etc/shadow
         // alone — they hold the Secure Boot MOK key and the password that enrolls it.
         delete_dir(CONFIG_BAK_STAGED).await?;
-        delete_dir(CONFIG_BAK).await?;
+        clear_config_bak().await?;
         Command::new("cp")
             .arg("-r")
             .arg(guard.path().join("config"))
@@ -316,6 +338,7 @@ async fn preserve_config(disk_path: &Path) -> Result<(), Error> {
         delete_dir(Path::new(CONFIG_BAK_STAGED).join("overlay/lib")).await?;
         delete_dir(Path::new(CONFIG_BAK_STAGED).join("overlay/usr/lib")).await?;
         tokio::fs::rename(CONFIG_BAK_STAGED, CONFIG_BAK).await?;
+        write_file_atomic(CONFIG_BAK_SRC, format!("{}\n", disk_path.display())).await?;
         Ok::<_, Error>(())
     }
     .await;
@@ -346,7 +369,7 @@ pub async fn install_os_to(
     } else {
         // The restore below is unconditional, so a run that preserves nothing must not
         // inherit a backup an earlier attempt in this boot left behind.
-        delete_dir(CONFIG_BAK).await?;
+        clear_config_bak().await?;
     }
 
     let part_info = partition(disk_path, capacity, partition_table, protect, use_efi).await?;

--- a/shared-libs/crates/start-core/src/os_install/mod.rs
+++ b/shared-libs/crates/start-core/src/os_install/mod.rs
@@ -245,6 +245,84 @@ pub struct InstallOsResult {
     pub mok_enrolled: bool,
 }
 
+/// The OS root of a previous install on this disk: the first partition carrying a
+/// `config` directory. Identified by content rather than by label, so that an
+/// install predating any particular labelling scheme is still found. Only valid
+/// before `partition`, which rewrites the OS partitions and takes that filesystem
+/// with them.
+async fn previous_os_root(disk_path: &Path) -> Option<PathBuf> {
+    for idx in 1..=16 {
+        let part = partition_for(disk_path, idx);
+        if tokio::fs::metadata(&part).await.is_err() {
+            continue;
+        }
+        let guard =
+            match TmpMountGuard::mount(&BlockDev::new(part.clone()), MountType::ReadOnly).await {
+                Ok(guard) => guard,
+                Err(e) => {
+                    // Most partitions on the disk legitimately are not a StartOS root.
+                    tracing::debug!("not a previous StartOS root: {}: {e}", part.display());
+                    continue;
+                }
+            };
+        let has_config = tokio::fs::metadata(guard.path().join("config"))
+            .await
+            .map_or(false, |m| m.is_dir());
+        guard.unmount().await.log_err();
+        if has_config {
+            return Some(part);
+        }
+    }
+    None
+}
+
+const CONFIG_BAK: &str = "/tmp/config.bak";
+const CONFIG_BAK_STAGED: &str = "/tmp/config.bak.staged";
+
+/// Copy the previous install's config aside, for `install_os_to` to restore once the
+/// disk has been rewritten.
+///
+/// Errors fail the install. This runs before `partition` touches a byte, so aborting
+/// costs the user a retry, whereas continuing would let `mkfs` destroy the only copy
+/// of a config we were asked to keep.
+async fn preserve_config(disk_path: &Path) -> Result<(), Error> {
+    let Some(old_root) = previous_os_root(disk_path).await else {
+        tracing::info!(
+            "no previous StartOS root on {}; nothing to preserve",
+            disk_path.display()
+        );
+        return Ok(());
+    };
+    tracing::info!("preserving config from {}", old_root.display());
+
+    let guard = TmpMountGuard::mount(&BlockDev::new(old_root), MountType::ReadOnly).await?;
+    let res = async {
+        // Staged, then renamed: the restore takes whatever sits at CONFIG_BAK, so a
+        // half-copied tree must never occupy it. Pruning the copy rather than the
+        // original also leaves the previous install untouched if this fails.
+        // Anything added here must leave overlay/var/lib/dkms and overlay/etc/shadow
+        // alone — they hold the Secure Boot MOK key and the password that enrolls it.
+        delete_dir(CONFIG_BAK_STAGED).await?;
+        delete_dir(CONFIG_BAK).await?;
+        Command::new("cp")
+            .arg("-r")
+            .arg(guard.path().join("config"))
+            .arg(CONFIG_BAK_STAGED)
+            .invoke(crate::ErrorKind::Filesystem)
+            .await?;
+        delete_file(Path::new(CONFIG_BAK_STAGED).join("upgrade")).await?;
+        delete_file(Path::new(CONFIG_BAK_STAGED).join("overlay/etc/hostname")).await?;
+        delete_file(Path::new(CONFIG_BAK_STAGED).join("disk.guid")).await?;
+        delete_dir(Path::new(CONFIG_BAK_STAGED).join("overlay/lib")).await?;
+        delete_dir(Path::new(CONFIG_BAK_STAGED).join("overlay/usr/lib")).await?;
+        tokio::fs::rename(CONFIG_BAK_STAGED, CONFIG_BAK).await?;
+        Ok::<_, Error>(())
+    }
+    .await;
+    guard.unmount().await?;
+    res
+}
+
 pub async fn install_os_to(
     squashfs_path: impl AsRef<Path>,
     disk_path: impl AsRef<Path>,
@@ -257,6 +335,19 @@ pub async fn install_os_to(
     let squashfs_path = squashfs_path.as_ref();
     let disk_path = disk_path.as_ref();
     let protect = protect.as_ref().map(|p| p.as_ref());
+
+    // Must precede `partition`, which rewrites the OS partitions: afterwards the
+    // previous root is gone, so the backup finds nothing and a preserve install comes
+    // back with an empty config — taking with it, among other things, the MOK key whose
+    // certificate is already enrolled in firmware, leaving Secure Boot refusing every
+    // module signed with its replacement.
+    if protect.is_some() {
+        preserve_config(disk_path).await?;
+    } else {
+        // The restore below is unconditional, so a run that preserves nothing must not
+        // inherit a backup an earlier attempt in this boot left behind.
+        delete_dir(CONFIG_BAK).await?;
+    }
 
     let part_info = partition(disk_path, capacity, partition_table, protect, use_efi).await?;
 
@@ -282,38 +373,6 @@ pub async fn install_os_to(
         .invoke(crate::ErrorKind::DiskManagement)
         .await?;
 
-    if protect.is_some() {
-        if let Ok(guard) =
-            TmpMountGuard::mount(&BlockDev::new(part_info.root.clone()), MountType::ReadWrite).await
-        {
-            if let Err(e) = async {
-                // cp -r ${guard}/config /tmp/config
-                // Whatever is added here, keep overlay/var/lib/dkms and overlay/etc/shadow:
-                // dropping the MOK key leaves the re-signed modules unmatched by the
-                // certificate the firmware already trusts, with no password left to enroll
-                // a new one, so Secure Boot silently stops loading them.
-                delete_file(guard.path().join("config/upgrade")).await?;
-                delete_file(guard.path().join("config/overlay/etc/hostname")).await?;
-                delete_file(guard.path().join("config/disk.guid")).await?;
-                delete_dir(guard.path().join("config/overlay/lib")).await?;
-                delete_dir(guard.path().join("config/overlay/usr/lib")).await?;
-                Command::new("cp")
-                    .arg("-r")
-                    .arg(guard.path().join("config"))
-                    .arg("/tmp/config.bak")
-                    .invoke(crate::ErrorKind::Filesystem)
-                    .await?;
-                Ok::<_, Error>(())
-            }
-            .await
-            {
-                tracing::error!("Error recovering previous config: {e}");
-                tracing::debug!("{e:?}");
-            }
-            guard.unmount().await?;
-        }
-    }
-
     Command::new("mkfs.btrfs")
         .arg("-f")
         .arg(&part_info.root)
@@ -331,11 +390,11 @@ pub async fn install_os_to(
 
     let config_path = rootfs.path().join("config");
 
-    if tokio::fs::metadata("/tmp/config.bak").await.is_ok() {
+    if tokio::fs::metadata(CONFIG_BAK).await.is_ok() {
         crate::util::io::delete_dir(&config_path).await?;
         Command::new("cp")
             .arg("-r")
-            .arg("/tmp/config.bak")
+            .arg(CONFIG_BAK)
             .arg(&config_path)
             .invoke(crate::ErrorKind::Filesystem)
             .await?;

--- a/shared-libs/crates/start-core/src/util/mok.rs
+++ b/shared-libs/crates/start-core/src/util/mok.rs
@@ -47,10 +47,10 @@ pub async fn sign_unsigned_modules(root: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-/// Read the start9 user's password hash from /etc/shadow.
+/// Read the start9 user's password hash from `<root>/etc/shadow`.
 /// Returns None if the user doesn't exist or the password is locked.
-async fn start9_shadow_hash() -> Result<Option<String>, Error> {
-    let shadow = tokio::fs::read_to_string("/etc/shadow").await?;
+async fn start9_shadow_hash(root: &Path) -> Result<Option<String>, Error> {
+    let shadow = tokio::fs::read_to_string(root.join("etc/shadow")).await?;
     for line in shadow.lines() {
         if let Some(("start9", rest)) = line.split_once(':') {
             if let Some((hash, _)) = rest.split_once(':') {
@@ -66,11 +66,13 @@ async fn start9_shadow_hash() -> Result<Option<String>, Error> {
     Ok(None)
 }
 
-/// Enroll the DKMS MOK certificate using the start9 user's password from /etc/shadow.
-/// Idempotent: skips if already enrolled, or if the user's password is not yet set.
-/// `mok_pub` is the path to the MOK public certificate (may be inside a chroot overlay during install).
-/// Returns true if a new enrollment was staged.
-pub async fn enroll_mok(mok_pub: &Path) -> Result<bool, Error> {
+/// Enroll the DKMS MOK certificate, protected by the start9 user's password.
+/// `root` holds both the certificate and `etc/shadow`: `/` at runtime, or the target
+/// overlay during install. Idempotent: skips if already enrolled, or if the password
+/// is not yet set — so it must also be called once the password is written, not only
+/// at boot. Returns true if a new enrollment was staged.
+pub async fn enroll_mok(root: &Path) -> Result<bool, Error> {
+    let mok_pub = &root.join(DKMS_MOK_PUB.trim_start_matches('/'));
     tracing::info!("enroll_mok: checking EFI and mok_pub={}", mok_pub.display());
     if tokio::fs::metadata("/sys/firmware/efi").await.is_err() {
         tracing::info!("enroll_mok: no EFI, skipping");
@@ -95,7 +97,7 @@ pub async fn enroll_mok(mok_pub: &Path) -> Result<bool, Error> {
         return Ok(false);
     }
 
-    let Some(hash) = start9_shadow_hash().await? else {
+    let Some(hash) = start9_shadow_hash(root).await? else {
         tracing::info!("enroll_mok: start9 user password not set, skipping");
         return Ok(false);
     };


### PR DESCRIPTION
Four fixes for the `aarch64-nvidia` image on an NVIDIA GB10 (DGX Spark). The first is confirmed on hardware; the second is the fix for #3702, found while chasing the fallout from the first.

## 1. Drop nouveau GSP firmware from the NVIDIA images — the boot fix

The `-nvidia` images blacklist nouveau and drive the GPU with NVIDIA's proprietary driver, yet ship graphics firmware they cannot use. `NON_FREE=1` adds `non-free-firmware` to `ARCHIVE_AREAS`; live-build's `--firmware-chroot` (default true, only `raspberrypi` disables it) then installs every `firmware-*` package, including `firmware-nvidia-graphics` (nouveau's chip-named GSP) and `firmware-nvidia-tesla-535-gsp` (the 535-series driver's). Neither is in `dpkg-deps/`. `initramfs-tools` then copies the firmware every *included* module declares, blacklist or not, and `nouveau.ko` is included under `MODULES=most` — so 159,225,325 B across 381 entries, 57% of the 266 MB uncompressed initramfs, was nouveau firmware.

Measured on this PR's CI artifact vs. the published 0.4.0.1 ISO:

| | 0.4.0.1 | this PR | delta |
|---|---|---|---|
| initrd | 163,574,628 B | 54,048,930 B | **−67.0%** |
| squashfs | 2,680,631,296 B | 2,398,883,840 B | −10.5% |
| ISO | 2,904,543,232 B | 2,513,270,784 B | −373 MB |

### Hardware result

| build | kernel | kernel + initrd | result |
|---|---|---|---|
| 0.4.0 | 7.0.13 | 208,739,061 B | boots |
| 0.4.0.1 | 7.1.3 | 210,494,244 B | hangs |
| 0.4.0.1 + `arm64.nompam` | 7.1.3 | same | hangs |
| 0.4.0.1 + `initcall_blacklist=tegra234_cbb_init` | 7.1.3 | same | hangs |
| this branch | 7.1.3 | 100,968,546 B | **boots** |

**The mechanism is not fully identified.** 0.4.0 booted a payload of essentially the same size under 7.0.13, so this is an interaction between the 7.1.3 kernel and a payload of that size, not a fixed limit — 0.4.0 sat at 99.2% of the size that later failed. This buys margin (101 MB against a ~209 MB failure point) but does not remove the class. The kernel arrived via an **unpinned** `linux-image-*` float from trixie-backports, which #3589 explicitly listed as not addressed; pinning it is the durable fix and is deliberately not in this PR, since it also freezes CVE fixes across seven platforms.

Nothing was lost by the purge — verified at the ELF level. `nvidia.ko`'s only firmware references are `nvidia/580.173.02/gsp_{ga10x,tu10x}.bin`, both present in the built image at the `.run`'s exact byte sizes; neither purged package owns any path under `580.*`, and the NVIDIA userspace is byte-identical to 0.4.0.1.

## 2. Stage MOK enrollment when the password is set — fixes #3702

On the machine above, the GPU then did not work: `nvidia-smi` could not talk to the driver, `lsmod | grep nvidia` was empty, and the only relevant kernel line was `Kernel is locked down from EFI Secure Boot`.

`enroll_mok` will not stage the import unless the `start9` user already has a password hash, and on a fresh Secure Boot install neither caller could satisfy that. `os_install/mod.rs` resolved `mok_pub` inside the target overlay but read the hardcoded **host** `/etc/shadow`; and `init.rs` runs once per boot, while `setup_init` calls `init()` at `setup.rs:185` and `write_shadow()` at `setup.rs:226` — so the attempt always preceded the password it depends on, in the same function. The import was first staged on the boot *after* setup, and MokManager only prompts on the boot after that: two restarts, with every skip logged at `info`. On a server, the modules stay unloadable indefinitely.

Staging now happens in `write_shadow`, the single point every password-setting path goes through (setup, restore, password change), so the prompt appears on the next restart. `enroll_mok` takes the root holding both the certificate and `etc/shadow`, which also corrects the install-time read.

## 3. Name the second firmware package correctly

`firmware-nvidia-tesla-535-gsp` is NVIDIA's proprietary GSP firmware for the 535 driver series (`nvidia/535.274.02/gsp_{ga10x,tu10x}.bin`), not nouveau's. Only `firmware-nvidia-graphics` carries nouveau's chip-named blobs, and only those reach the initramfs. Both are still correct to purge.

## 4. Retry the container-runtime base image download

The riscv64 job here failed on a truncated transfer from `images.linuxcontainers.org` (`curl: (18)`, ~79 MB short) *after* the Rust compile succeeded. There was no retry, under `set -e`. The rootfs download also moves from `> file` to `-o file`, which is load-bearing: curl rewinds a file it owns before each retry but cannot rewind stdout, so `--retry` with a shell redirect concatenates partial attempts — measured, 1200 B from three 400 B attempts vs 400 B with `-o`.

## Ruled out along the way

MPAM (`arm64.nompam`) and `SOC_TEGRA_CBB` (`initcall_blacklist=tegra234_cbb_init`), both tested on the hardware and refuted — the blacklist commit was dropped rather than kept as an unexplained fence. The 580.159.03 → 580.173.02 driver bump and the `--kernel-module-type=proprietary` pin from #3589 are inert before `switch_root` (no `nvidia*.ko` is in either initramfs), and 0.4.0 already shipped the proprietary flavour, so it is not a regression vector.
