### PR TITLE
feat(sdk): add uses to daemon/oneshot entries for Daemons.dynamic

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -40,17 +40,17 @@
 
 ### Added
 
-- **`addDaemon()` / `addOneshot()` accept a `hashExtra` value that
+- **`addDaemon()` / `addOneshot()` accept a `uses` value that
   `Daemons.dynamic` folds into the entry's `configHash`.** The reconciler's
   diff key covers only structural fields; closures (`exec.fn`, `ready.fn`,
   `ready.trigger`) and pre-built `Daemon` instances are invisible to it, so a
   value captured by a closure could change without the reconciler restarting
-  the daemon. Pass the value as `hashExtra` and any change restarts the
+  the daemon. Declare the value as `uses` and any change restarts the
   daemon/oneshot on the next reconcile. Only JSON-serializable values are
   useful, and anything else normalizes rather than failing a reconcile:
-  functions, symbols, `undefined` and cycles hash as `null` (so a change
-  visible only there triggers no restart), and BigInts hash as their decimal
-  string
+  functions, symbols and cycles hash as an `UNSERIALIZABLE:*` sentinel,
+  `undefined` hashes as `null` (so a change visible only there triggers no
+  restart), and BigInts hash as their decimal string
 
 - **`MultiHost.retire()` and `MultiHost.retirePort()` permanently remove a host
   or a binding.** `setupInterfaces` ends each pass by

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -40,6 +40,17 @@
 
 ### Added
 
+- **`addDaemon()` / `addOneshot()` accept a `hashExtra` value that
+  `Daemons.dynamic` folds into the entry's `configHash`.** The reconciler's
+  diff key covers only structural fields; closures (`exec.fn`, `ready.fn`,
+  `ready.trigger`) and pre-built `Daemon` instances are invisible to it, so a
+  value captured by a closure could change without the reconciler restarting
+  the daemon. Pass the value as `hashExtra` and any change restarts the
+  daemon/oneshot on the next reconcile. Only JSON-serializable values are
+  useful: functions, symbols and `undefined` normalize to `null` (never
+  triggering a restart), and a value JSON cannot represent at all (circular
+  structure, BigInt) throws a descriptive error at reconcile time
+
 - **`MultiHost.retire()` and `MultiHost.retirePort()` permanently remove a host
   or a binding.** `setupInterfaces` ends each pass by
   _disabling_ whatever it did not declare, which keeps the row, the external

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -48,8 +48,8 @@
   the daemon. Declare the value as `uses` and any change restarts the
   daemon/oneshot on the next reconcile. Only JSON-serializable values are
   useful, and anything else normalizes rather than failing a reconcile:
-  functions, symbols and cycles hash as an `UNSERIALIZABLE:*` sentinel,
-  `undefined` hashes as `null` (so a change visible only there triggers no
+  functions, symbols, cycles and `undefined` hash as distinct
+  `UNSERIALIZABLE:*` sentinels (so a change visible only there triggers no
   restart), and BigInts hash as their decimal string
 
 - **`MultiHost.retire()` and `MultiHost.retirePort()` permanently remove a host

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -50,7 +50,12 @@
   useful, and anything else normalizes rather than failing a reconcile:
   functions, symbols, cycles and `undefined` hash as distinct
   `UNSERIALIZABLE:*` sentinels (so a change visible only there triggers no
-  restart), and BigInts hash as their decimal string
+  restart), and BigInts hash as their decimal string. The `exec` options
+  object is now canonicalized in full rather than whitelisted, so a
+  fn-form exec's `sigtermTimeout` and a command exec's `onStdout`/`onStderr`
+  callbacks participate in the hash (the callbacks themselves hash as
+  constant sentinels — added or removed restarts, one closure swapped for
+  another does not)
 
 - **`MultiHost.retire()` and `MultiHost.retirePort()` permanently remove a host
   or a binding.** `setupInterfaces` ends each pass by

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -47,9 +47,10 @@
   value captured by a closure could change without the reconciler restarting
   the daemon. Pass the value as `hashExtra` and any change restarts the
   daemon/oneshot on the next reconcile. Only JSON-serializable values are
-  useful: functions, symbols and `undefined` normalize to `null` (never
-  triggering a restart), and a value JSON cannot represent at all (circular
-  structure, BigInt) throws a descriptive error at reconcile time
+  useful, and anything else normalizes rather than failing a reconcile:
+  functions, symbols, `undefined` and cycles hash as `null` (so a change
+  visible only there triggers no restart), and BigInts hash as their decimal
+  string
 
 - **`MultiHost.retire()` and `MultiHost.retirePort()` permanently remove a host
   or a binding.** `setupInterfaces` ends each pass by

--- a/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
+++ b/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
@@ -46,7 +46,7 @@ On each run the reconciler diffs entries by `id` and a `configHash` of their str
 - **same `configHash`** — leave it running, untouched
 - **different `configHash`** — restart it
 
-Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `uses`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `uses` values are useful — functions, symbols and cycles normalize to an `UNSERIALIZABLE:*` sentinel and `undefined` to `null`, so a change only visible there never triggers a restart, and BigInts hash as their decimal string.
+Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `uses`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `uses` values are useful — functions, symbols, cycles and `undefined` normalize to distinct `UNSERIALIZABLE:*` sentinels, so a change only visible there never triggers a restart, and BigInts hash as their decimal string.
 
 **Reference:** [Main](main.md) · [Actions](actions.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
+++ b/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
@@ -46,7 +46,7 @@ On each run the reconciler diffs entries by `id` and a `configHash` of their str
 - **same `configHash`** — leave it running, untouched
 - **different `configHash`** — restart it
 
-Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `hashExtra`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `hashExtra` values are useful — functions, symbols and `undefined` normalize to `null` and never trigger a restart, and a value JSON cannot represent at all (circular structure, BigInt) throws at reconcile time.
+Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `hashExtra`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `hashExtra` values are useful — functions, symbols, `undefined` and cycles normalize to `null` and never trigger a restart, and BigInts hash as their decimal string.
 
 **Reference:** [Main](main.md) · [Actions](actions.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
+++ b/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
@@ -46,7 +46,7 @@ On each run the reconciler diffs entries by `id` and a `configHash` of their str
 - **same `configHash`** — leave it running, untouched
 - **different `configHash`** — restart it
 
-Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `hashExtra`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `hashExtra` values are useful — functions, symbols, `undefined` and cycles normalize to `null` and never trigger a restart, and BigInts hash as their decimal string.
+Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `uses`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `uses` values are useful — functions, symbols and cycles normalize to an `UNSERIALIZABLE:*` sentinel and `undefined` to `null`, so a change only visible there never triggers a restart, and BigInts hash as their decimal string.
 
 **Reference:** [Main](main.md) · [Actions](actions.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
+++ b/projects/start-sdk/docs/src/recipe-dynamic-daemons.md
@@ -46,7 +46,7 @@ On each run the reconciler diffs entries by `id` and a `configHash` of their str
 - **same `configHash`** — leave it running, untouched
 - **different `configHash`** — restart it
 
-Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash, so surface anything the reconciler must react to through one of the hashed fields.
+Dependents (via `requires`) of any restarted or stopped daemon restart too, so the wiring stays consistent. Closures — `ready.fn`, `ready.trigger`, a function-form `exec.fn` — are **not** part of the hash. If such a closure captures a value the reconciler must react to (say, a host the `exec.fn` reads before building its command), pass that value as the entry's `hashExtra`; any change to it restarts the daemon on the next reconcile. Only JSON-serializable `hashExtra` values are useful — functions, symbols and `undefined` normalize to `null` and never trigger a restart, and a value JSON cannot represent at all (circular structure, BigInt) throws at reconcile time.
 
 **Reference:** [Main](main.md) · [Actions](actions.md) · [File Models](file-models.md)
 

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -333,14 +333,14 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * `requires` wiring stays consistent. Re-runs are coalesced.
    *
    * The diff key (`configHash`) covers the subcontainer descriptor
-   * (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec
-   * (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`),
-   * `requires` (sorted), the structural parts of `ready` (`display`,
-   * `gracePeriod`), and the entry's `uses`. Closures (`ready.fn`,
-   * `ready.trigger`) and pre-built `Daemon` instances are intentionally
-   * excluded — surface a value through one of the hashed fields, or
-   * declare it in `uses`, if you want the reconciler to react to it
-   * changing.
+   * (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), the
+   * whole `exec` options object, `requires` (sorted), the structural
+   * parts of `ready` (`display`, `gracePeriod`), and the entry's
+   * `uses`. Function values inside them (`exec.fn`, `exec.onStdout`,
+   * `ready.fn`, `ready.trigger`) hash as constant sentinels — their
+   * contents are intentionally invisible — as is any pre-built `Daemon`
+   * instance: declare a captured value in `uses` if you want the
+   * reconciler to react to it changing.
    *
    * **Use lazy SubContainers** ({@link SubContainer.of}) for daemons under
    * `Daemons.dynamic`. Eager handles created inside `fn` are wasted on
@@ -836,13 +836,16 @@ function validateEntries<M extends T.SDKManifest>(
  * running across re-runs. Any difference triggers a restart.
  *
  * Hashed fields: kind, id, sorted requires, subcontainer descriptor
- * (`imageId`, `sharedRun`, `name`, `mounts.build()`), exec (`command`,
- * `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), ready's
- * structural parts (`display`, `gracePeriod`), and `uses`.
+ * (`imageId`, `sharedRun`, `name`, `mounts.build()`), the whole `exec`
+ * options object, ready's structural parts (`display`, `gracePeriod`),
+ * and `uses`.
  *
- * NOT hashed: `ready.fn`, `ready.trigger`, function-form `exec.fn`, and
- * any pre-built `daemon` instance. `uses` is the escape hatch for
- * values only visible inside those closures.
+ * Function values (`exec.fn`, `exec.onStdout`, `ready.fn`,
+ * `ready.trigger`) hash as constant `UNSERIALIZABLE:FUNCTION`
+ * sentinels — two different closures hash alike, so their contents
+ * never trigger a restart — and a pre-built `daemon` instance is not
+ * hashed at all. `uses` is the escape hatch for values only visible
+ * inside those closures.
  *
  * `uses` is canonicalized like every other hashed field, and never
  * throws: functions, symbols, cycles and `undefined` normalize to an
@@ -881,7 +884,7 @@ export function configHash<M extends T.SDKManifest>(
     id: entry.id,
     requires: [...entry.requires].sort(),
     sub: subHash,
-    exec: normalizeExec(entry.exec),
+    exec: entry.exec,
     uses: entry.uses,
     ready:
       entry.kind === 'daemon'
@@ -891,29 +894,6 @@ export function configHash<M extends T.SDKManifest>(
           }
         : null,
   })
-}
-
-function normalizeExec(exec: unknown): unknown {
-  if (!exec || typeof exec !== 'object') return null
-  if ('fn' in (exec as object)) return { __fn: true }
-  const e = exec as ExecCommandOptions
-  return {
-    command: normalizeCommand(e.command),
-    env: e.env ?? null,
-    cwd: e.cwd ?? null,
-    user: e.user ?? null,
-    runAsInit: e.runAsInit ?? false,
-    sigtermTimeout: e.sigtermTimeout ?? null,
-  }
-}
-
-function normalizeCommand(c: T.CommandType): unknown {
-  if (typeof c === 'string') return { kind: 'string', value: c }
-  if (Array.isArray(c)) return { kind: 'argv', value: [...c] }
-  if (T.isUseEntrypoint(c)) {
-    return { kind: 'entrypoint', value: c.overridCmd ?? null }
-  }
-  return null
 }
 
 function stableStringify(v: unknown): string {

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -175,10 +175,10 @@ type NewDaemonParams<
    * (`exec.fn`, `ready.fn`) are invisible to the hash, so anything they
    * capture that the reconciler should react to must be listed here.
    *
-   * Only JSON-serializable values are useful here — functions, symbols
-   * and cycles normalize to an `UNSERIALIZABLE:*` sentinel and
-   * `undefined` to `null`, so a change only visible there triggers no
-   * restart; BigInts hash as their decimal string.
+   * Only JSON-serializable values are useful here — functions, symbols,
+   * cycles and `undefined` normalize to an `UNSERIALIZABLE:*` sentinel,
+   * so a change only visible there triggers no restart; BigInts hash as
+   * their decimal string.
    */
   uses?: unknown
 }
@@ -845,10 +845,9 @@ function validateEntries<M extends T.SDKManifest>(
  * values only visible inside those closures.
  *
  * `uses` is canonicalized like every other hashed field, and never
- * throws: functions, symbols and cycles normalize to an
- * `UNSERIALIZABLE:*` sentinel and `undefined` to `null` (so changes
- * only visible there trigger no restart), and BigInts hash as their
- * decimal string.
+ * throws: functions, symbols, cycles and `undefined` normalize to an
+ * `UNSERIALIZABLE:*` sentinel (so changes only visible there trigger
+ * no restart), and BigInts hash as their decimal string.
  *
  * @param entry A recorded {@link Daemons} entry (`Daemons.entries[i]`)
  * @returns A canonical JSON string suitable for equality comparison
@@ -922,7 +921,8 @@ function stableStringify(v: unknown): string {
 }
 
 function canonicalize(v: unknown, ancestors: Set<object> = new Set()): unknown {
-  if (v === undefined || v === null) return null
+  if (v === undefined) return 'UNSERIALIZABLE:UNDEFINED'
+  if (v === null) return null
   if (typeof v === 'bigint') return v.toString()
   if (typeof v === 'function') return 'UNSERIALIZABLE:FUNCTION'
   if (typeof v === 'symbol') return 'UNSERIALIZABLE:SYMBOL'

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -169,16 +169,18 @@ type NewDaemonParams<
   /** The subcontainer in which the daemon runs */
   subcontainer: C
   /**
-   * Arbitrary value folded into this entry's `configHash` under
-   * `Daemons.dynamic`: when it changes between reconciliations, the
-   * daemon/oneshot is restarted. Use it to surface values a closure
-   * captures (`exec.fn`, `ready.fn`), which the hash cannot see.
+   * Values this daemon/oneshot's closures use, folded into the entry's
+   * `configHash` under `Daemons.dynamic`: when they change between
+   * reconciliations, the daemon/oneshot is restarted. Closures
+   * (`exec.fn`, `ready.fn`) are invisible to the hash, so anything they
+   * capture that the reconciler should react to must be listed here.
    *
-   * Only JSON-serializable values are useful here — functions, symbols,
-   * `undefined` and cycles normalize to `null` and never trigger a
+   * Only JSON-serializable values are useful here — functions, symbols
+   * and cycles normalize to an `UNSERIALIZABLE:*` sentinel and
+   * `undefined` to `null`, so a change only visible there triggers no
    * restart; BigInts hash as their decimal string.
    */
-  hashExtra?: unknown
+  uses?: unknown
 }
 
 type OptionalParamSync<T> = T | (() => T | null)
@@ -198,12 +200,12 @@ type AddDaemonParams<
    */
   requires: Exclude<Ids, Id>[]
   /**
-   * Arbitrary value folded into this entry's `configHash` under
-   * `Daemons.dynamic` — see {@link NewDaemonParams.hashExtra}. This is the
-   * only way to make the reconciler react to a change inside a pre-built
-   * `{ daemon }`, which is otherwise entirely opaque to the hash.
+   * Values this daemon uses — see {@link NewDaemonParams.uses}. This is
+   * the only way to make the reconciler react to a change inside a
+   * pre-built `{ daemon }`, which is otherwise entirely opaque to the
+   * hash.
    */
-  hashExtra?: unknown
+  uses?: unknown
 }
 
 type AddOneshotParams<
@@ -239,7 +241,7 @@ type DaemonEntry<M extends T.SDKManifest> =
       exec: DaemonCommandType<M, SubContainer<M> | null>
       ready: Ready
       requires: ReadonlyArray<string>
-      hashExtra: unknown
+      uses: unknown
       /** If supplied via the `{ daemon: ... }` form, pre-built daemon. */
       prebuiltDaemon: Daemon<M> | null
     }
@@ -249,7 +251,7 @@ type DaemonEntry<M extends T.SDKManifest> =
       subcontainer: SubContainer<M> | null
       exec: DaemonCommandType<M, SubContainer<M> | null>
       requires: ReadonlyArray<string>
-      hashExtra: unknown
+      uses: unknown
     }
   | {
       kind: 'health'
@@ -334,10 +336,10 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec
    * (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`),
    * `requires` (sorted), the structural parts of `ready` (`display`,
-   * `gracePeriod`), and the entry's `hashExtra`. Closures (`ready.fn`,
+   * `gracePeriod`), and the entry's `uses`. Closures (`ready.fn`,
    * `ready.trigger`) and pre-built `Daemon` instances are intentionally
-   * excluded — surface a value through one of the hashed fields, or pass
-   * it as `hashExtra`, if you want the reconciler to react to it
+   * excluded — surface a value through one of the hashed fields, or
+   * declare it in `uses`, if you want the reconciler to react to it
    * changing.
    *
    * **Use lazy SubContainers** ({@link SubContainer.of}) for daemons under
@@ -430,7 +432,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
               >),
         ready: opts.ready,
         requires: opts.requires as string[],
-        hashExtra: opts.hashExtra,
+        uses: opts.uses,
         prebuiltDaemon:
           'daemon' in opts ? (opts.daemon as Daemon<Manifest>) : null,
       }
@@ -487,7 +489,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
           SubContainer<Manifest> | null
         >,
         requires: opts.requires as string[],
-        hashExtra: opts.hashExtra,
+        uses: opts.uses,
       }
       return prev.appendEntry(entry)
     }
@@ -836,16 +838,17 @@ function validateEntries<M extends T.SDKManifest>(
  * Hashed fields: kind, id, sorted requires, subcontainer descriptor
  * (`imageId`, `sharedRun`, `name`, `mounts.build()`), exec (`command`,
  * `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), ready's
- * structural parts (`display`, `gracePeriod`), and `hashExtra`.
+ * structural parts (`display`, `gracePeriod`), and `uses`.
  *
  * NOT hashed: `ready.fn`, `ready.trigger`, function-form `exec.fn`, and
- * any pre-built `daemon` instance. `hashExtra` is the escape hatch for
+ * any pre-built `daemon` instance. `uses` is the escape hatch for
  * values only visible inside those closures.
  *
- * `hashExtra` is canonicalized like every other hashed field, and never
- * throws: functions, symbols, `undefined` and cycles normalize to
- * `null` (so changes only visible there trigger no restart), and
- * BigInts hash as their decimal string.
+ * `uses` is canonicalized like every other hashed field, and never
+ * throws: functions, symbols and cycles normalize to an
+ * `UNSERIALIZABLE:*` sentinel and `undefined` to `null` (so changes
+ * only visible there trigger no restart), and BigInts hash as their
+ * decimal string.
  *
  * @param entry A recorded {@link Daemons} entry (`Daemons.entries[i]`)
  * @returns A canonical JSON string suitable for equality comparison
@@ -880,7 +883,7 @@ export function configHash<M extends T.SDKManifest>(
     requires: [...entry.requires].sort(),
     sub: subHash,
     exec: normalizeExec(entry.exec),
-    hashExtra: entry.hashExtra,
+    uses: entry.uses,
     ready:
       entry.kind === 'daemon'
         ? {
@@ -921,9 +924,10 @@ function stableStringify(v: unknown): string {
 function canonicalize(v: unknown, ancestors: Set<object> = new Set()): unknown {
   if (v === undefined || v === null) return null
   if (typeof v === 'bigint') return v.toString()
-  if (typeof v === 'function' || typeof v === 'symbol') return null
+  if (typeof v === 'function') return 'UNSERIALIZABLE:FUNCTION'
+  if (typeof v === 'symbol') return 'UNSERIALIZABLE:SYMBOL'
   if (typeof v !== 'object') return v
-  if (ancestors.has(v)) return null
+  if (ancestors.has(v)) return 'UNSERIALIZABLE:CIRCULAR'
   ancestors.add(v)
   let out: unknown
   if (Array.isArray(v)) {

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -175,8 +175,8 @@ type NewDaemonParams<
    * captures (`exec.fn`, `ready.fn`), which the hash cannot see.
    *
    * Only JSON-serializable values are useful here — functions, symbols,
-   * and `undefined` normalize to `null` and never trigger a restart.
-   * Circular structures and BigInts throw at reconcile time.
+   * `undefined` and cycles normalize to `null` and never trigger a
+   * restart; BigInts hash as their decimal string.
    */
   hashExtra?: unknown
 }
@@ -842,10 +842,10 @@ function validateEntries<M extends T.SDKManifest>(
  * any pre-built `daemon` instance. `hashExtra` is the escape hatch for
  * values only visible inside those closures.
  *
- * `hashExtra` is canonicalized like every other hashed field: only
- * JSON-serializable values are useful (functions/symbols/`undefined`
- * normalize to `null`), and a value JSON cannot represent at all
- * (circular structure, BigInt) throws, naming the offending entry.
+ * `hashExtra` is canonicalized like every other hashed field, and never
+ * throws: functions, symbols, `undefined` and cycles normalize to
+ * `null` (so changes only visible there trigger no restart), and
+ * BigInts hash as their decimal string.
  *
  * @param entry A recorded {@link Daemons} entry (`Daemons.entries[i]`)
  * @returns A canonical JSON string suitable for equality comparison
@@ -880,7 +880,7 @@ export function configHash<M extends T.SDKManifest>(
     requires: [...entry.requires].sort(),
     sub: subHash,
     exec: normalizeExec(entry.exec),
-    hashExtra: canonicalizeExtra(entry.id, entry.hashExtra),
+    hashExtra: entry.hashExtra,
     ready:
       entry.kind === 'daemon'
         ? {
@@ -918,31 +918,24 @@ function stableStringify(v: unknown): string {
   return JSON.stringify(canonicalize(v))
 }
 
-function canonicalizeExtra(id: string, v: unknown): unknown {
-  if (v === undefined) return null
-  try {
-    const out = canonicalize(v)
-    JSON.stringify(out)
-    return out
-  } catch {
-    throw new Error(
-      `Daemons: hashExtra for entry '${id}' must be JSON-serializable`,
-    )
-  }
-}
-
-function canonicalize(v: unknown): unknown {
+function canonicalize(v: unknown, ancestors: Set<object> = new Set()): unknown {
   if (v === undefined || v === null) return null
-  if (Array.isArray(v)) return v.map(canonicalize)
-  if (typeof v === 'object') {
-    const keys = Object.keys(v as object).sort()
-    const out: Record<string, unknown> = {}
-    for (const k of keys)
-      out[k] = canonicalize((v as Record<string, unknown>)[k])
-    return out
+  if (typeof v === 'bigint') return v.toString()
+  if (typeof v === 'function' || typeof v === 'symbol') return null
+  if (typeof v !== 'object') return v
+  if (ancestors.has(v)) return null
+  ancestors.add(v)
+  let out: unknown
+  if (Array.isArray(v)) {
+    out = v.map(el => canonicalize(el, ancestors))
+  } else {
+    const obj: Record<string, unknown> = {}
+    for (const k of Object.keys(v).sort())
+      obj[k] = canonicalize((v as Record<string, unknown>)[k], ancestors)
+    out = obj
   }
-  if (typeof v === 'function') return null
-  return v
+  ancestors.delete(v)
+  return out
 }
 
 type RunningEntry<M extends T.SDKManifest> = {

--- a/projects/start-sdk/lib/mainFn/Daemons.ts
+++ b/projects/start-sdk/lib/mainFn/Daemons.ts
@@ -168,6 +168,17 @@ type NewDaemonParams<
   exec: DaemonCommandType<Manifest, C>
   /** The subcontainer in which the daemon runs */
   subcontainer: C
+  /**
+   * Arbitrary value folded into this entry's `configHash` under
+   * `Daemons.dynamic`: when it changes between reconciliations, the
+   * daemon/oneshot is restarted. Use it to surface values a closure
+   * captures (`exec.fn`, `ready.fn`), which the hash cannot see.
+   *
+   * Only JSON-serializable values are useful here — functions, symbols,
+   * and `undefined` normalize to `null` and never trigger a restart.
+   * Circular structures and BigInts throw at reconcile time.
+   */
+  hashExtra?: unknown
 }
 
 type OptionalParamSync<T> = T | (() => T | null)
@@ -186,6 +197,13 @@ type AddDaemonParams<
    * this daemon starts. Enforces startup ordering in the daemon chain.
    */
   requires: Exclude<Ids, Id>[]
+  /**
+   * Arbitrary value folded into this entry's `configHash` under
+   * `Daemons.dynamic` — see {@link NewDaemonParams.hashExtra}. This is the
+   * only way to make the reconciler react to a change inside a pre-built
+   * `{ daemon }`, which is otherwise entirely opaque to the hash.
+   */
+  hashExtra?: unknown
 }
 
 type AddOneshotParams<
@@ -221,6 +239,7 @@ type DaemonEntry<M extends T.SDKManifest> =
       exec: DaemonCommandType<M, SubContainer<M> | null>
       ready: Ready
       requires: ReadonlyArray<string>
+      hashExtra: unknown
       /** If supplied via the `{ daemon: ... }` form, pre-built daemon. */
       prebuiltDaemon: Daemon<M> | null
     }
@@ -230,6 +249,7 @@ type DaemonEntry<M extends T.SDKManifest> =
       subcontainer: SubContainer<M> | null
       exec: DaemonCommandType<M, SubContainer<M> | null>
       requires: ReadonlyArray<string>
+      hashExtra: unknown
     }
   | {
       kind: 'health'
@@ -313,11 +333,12 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
    * The diff key (`configHash`) covers the subcontainer descriptor
    * (`imageId`, `sharedRun`, `name`, structural `mounts.build()`), exec
    * (`command`, `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`),
-   * `requires` (sorted), and the structural parts of `ready` (`display`,
-   * `gracePeriod`). Closures (`ready.fn`, `ready.trigger`) and pre-built
-   * `Daemon` instances are intentionally excluded — surface a value
-   * through one of the hashed fields if you want the reconciler to react
-   * to it changing.
+   * `requires` (sorted), the structural parts of `ready` (`display`,
+   * `gracePeriod`), and the entry's `hashExtra`. Closures (`ready.fn`,
+   * `ready.trigger`) and pre-built `Daemon` instances are intentionally
+   * excluded — surface a value through one of the hashed fields, or pass
+   * it as `hashExtra`, if you want the reconciler to react to it
+   * changing.
    *
    * **Use lazy SubContainers** ({@link SubContainer.of}) for daemons under
    * `Daemons.dynamic`. Eager handles created inside `fn` are wasted on
@@ -409,6 +430,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
               >),
         ready: opts.ready,
         requires: opts.requires as string[],
+        hashExtra: opts.hashExtra,
         prebuiltDaemon:
           'daemon' in opts ? (opts.daemon as Daemon<Manifest>) : null,
       }
@@ -465,6 +487,7 @@ export class Daemons<Manifest extends T.SDKManifest, Ids extends string>
           SubContainer<Manifest> | null
         >,
         requires: opts.requires as string[],
+        hashExtra: opts.hashExtra,
       }
       return prev.appendEntry(entry)
     }
@@ -812,11 +835,17 @@ function validateEntries<M extends T.SDKManifest>(
  *
  * Hashed fields: kind, id, sorted requires, subcontainer descriptor
  * (`imageId`, `sharedRun`, `name`, `mounts.build()`), exec (`command`,
- * `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), and ready's
- * structural parts (`display`, `gracePeriod`).
+ * `env`, `cwd`, `user`, `runAsInit`, `sigtermTimeout`), ready's
+ * structural parts (`display`, `gracePeriod`), and `hashExtra`.
  *
  * NOT hashed: `ready.fn`, `ready.trigger`, function-form `exec.fn`, and
- * any pre-built `daemon` instance.
+ * any pre-built `daemon` instance. `hashExtra` is the escape hatch for
+ * values only visible inside those closures.
+ *
+ * `hashExtra` is canonicalized like every other hashed field: only
+ * JSON-serializable values are useful (functions/symbols/`undefined`
+ * normalize to `null`), and a value JSON cannot represent at all
+ * (circular structure, BigInt) throws, naming the offending entry.
  *
  * @param entry A recorded {@link Daemons} entry (`Daemons.entries[i]`)
  * @returns A canonical JSON string suitable for equality comparison
@@ -851,6 +880,7 @@ export function configHash<M extends T.SDKManifest>(
     requires: [...entry.requires].sort(),
     sub: subHash,
     exec: normalizeExec(entry.exec),
+    hashExtra: canonicalizeExtra(entry.id, entry.hashExtra),
     ready:
       entry.kind === 'daemon'
         ? {
@@ -886,6 +916,19 @@ function normalizeCommand(c: T.CommandType): unknown {
 
 function stableStringify(v: unknown): string {
   return JSON.stringify(canonicalize(v))
+}
+
+function canonicalizeExtra(id: string, v: unknown): unknown {
+  if (v === undefined) return null
+  try {
+    const out = canonicalize(v)
+    JSON.stringify(out)
+    return out
+  } catch {
+    throw new Error(
+      `Daemons: hashExtra for entry '${id}' must be JSON-serializable`,
+    )
+  }
 }
 
 function canonicalize(v: unknown): unknown {

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -322,6 +322,44 @@ describe('configHash', () => {
     expect(configHash(a.entries[1])).not.toEqual(configHash(b.entries[1]))
   })
 
+  it("changes when a fn-form exec's sigtermTimeout changes", () => {
+    const e = fakeEffects()
+    const make = (sigtermTimeout?: number) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { fn: async () => null, sigtermTimeout },
+        ready: baseReady,
+        requires: [],
+      }).entries[0]
+    expect(configHash(make(5000))).not.toEqual(configHash(make(6000)))
+    // different fn closures still hash alike — their contents are invisible
+    expect(configHash(make(5000))).toEqual(
+      configHash(
+        Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+          subcontainer: lazy(e),
+          exec: { fn: async () => null, sigtermTimeout: 5000 },
+          ready: baseReady,
+          requires: [],
+        }).entries[0],
+      ),
+    )
+  })
+
+  it('changes when an output callback is added to a command exec', () => {
+    const e = fakeEffects()
+    const make = (withCallback: boolean) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: {
+          command: ['cmd'],
+          ...(withCallback ? { onStdout: () => {} } : {}),
+        },
+        ready: baseReady,
+        requires: [],
+      }).entries[0]
+    expect(configHash(make(true))).not.toEqual(configHash(make(false)))
+  })
+
   it('is order-independent for requires (sorted before hash)', () => {
     const e = fakeEffects()
     const a = Daemons.of<Manifest>({ effects: e })

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -134,6 +134,70 @@ describe('configHash', () => {
     expect(configHash(a)).not.toEqual(configHash(b))
   })
 
+  it('changes when hashExtra changes', () => {
+    const e = fakeEffects()
+    const make = (hashExtra: unknown) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        ready: baseReady,
+        requires: [],
+        hashExtra,
+      }).entries[0]
+    expect(configHash(make({ port: 5959 }))).not.toEqual(
+      configHash(make({ port: 5960 })),
+    )
+    expect(configHash(make({ port: 5959 }))).toEqual(
+      configHash(make({ port: 5959 })),
+    )
+    // key order is irrelevant (canonicalized)
+    expect(configHash(make({ a: 1, b: 2 }))).toEqual(
+      configHash(make({ b: 2, a: 1 })),
+    )
+  })
+
+  it('hashExtra participates for oneshots', () => {
+    const e = fakeEffects()
+    const oneshot = (hashExtra: unknown) =>
+      Daemons.of<Manifest>({ effects: e }).addOneshot('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        requires: [],
+        hashExtra,
+      }).entries[0]
+    expect(configHash(oneshot('x'))).not.toEqual(configHash(oneshot('y')))
+  })
+
+  it('normalizes non-JSON hashExtra values to null instead of restarting', () => {
+    const e = fakeEffects()
+    const make = (hashExtra: unknown) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        ready: baseReady,
+        requires: [],
+        hashExtra,
+      }).entries[0]
+    expect(configHash(make(() => 1))).toEqual(configHash(make(undefined)))
+    expect(configHash(make(undefined))).toEqual(configHash(make(null as any)))
+  })
+
+  it('throws a descriptive error for an unserializable hashExtra', () => {
+    const e = fakeEffects()
+    const circular: any = {}
+    circular.self = circular
+    const entry = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+      subcontainer: lazy(e),
+      exec: { command: ['cmd'] },
+      ready: baseReady,
+      requires: [],
+      hashExtra: circular,
+    }).entries[0]
+    expect(() => configHash(entry)).toThrow(
+      "hashExtra for entry 'a' must be JSON-serializable",
+    )
+  })
+
   it('changes when command changes', () => {
     const e = fakeEffects()
     const a = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -134,15 +134,15 @@ describe('configHash', () => {
     expect(configHash(a)).not.toEqual(configHash(b))
   })
 
-  it('changes when hashExtra changes', () => {
+  it('changes when uses changes', () => {
     const e = fakeEffects()
-    const make = (hashExtra: unknown) =>
+    const make = (uses: unknown) =>
       Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
         subcontainer: lazy(e),
         exec: { command: ['cmd'] },
         ready: baseReady,
         requires: [],
-        hashExtra,
+        uses,
       }).entries[0]
     expect(configHash(make({ port: 5959 }))).not.toEqual(
       configHash(make({ port: 5960 })),
@@ -156,42 +156,46 @@ describe('configHash', () => {
     )
   })
 
-  it('hashExtra participates for oneshots', () => {
+  it('uses participates for oneshots', () => {
     const e = fakeEffects()
-    const oneshot = (hashExtra: unknown) =>
+    const oneshot = (uses: unknown) =>
       Daemons.of<Manifest>({ effects: e }).addOneshot('a', {
         subcontainer: lazy(e),
         exec: { command: ['cmd'] },
         requires: [],
-        hashExtra,
+        uses,
       }).entries[0]
     expect(configHash(oneshot('x'))).not.toEqual(configHash(oneshot('y')))
   })
 
-  it('normalizes non-JSON hashExtra values to null instead of restarting', () => {
+  it('normalizes non-JSON uses values to distinct sentinels instead of restarting', () => {
     const e = fakeEffects()
-    const make = (hashExtra: unknown) =>
+    const make = (uses: unknown) =>
       Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
         subcontainer: lazy(e),
         exec: { command: ['cmd'] },
         ready: baseReady,
         requires: [],
-        hashExtra,
+        uses,
       }).entries[0]
-    expect(configHash(make(() => 1))).toEqual(configHash(make(undefined)))
+    // unserializable kinds get their own sentinel, distinct from null and
+    // from each other — but two values of the same kind hash alike, so a
+    // change only visible there still triggers no restart
+    expect(configHash(make(() => 1))).not.toEqual(configHash(make(undefined)))
+    expect(configHash(make(() => 1))).not.toEqual(configHash(make(Symbol('x'))))
+    expect(configHash(make(() => 1))).toEqual(configHash(make(() => 2)))
     expect(configHash(make(undefined))).toEqual(configHash(make(null as any)))
-    expect(configHash(make(Symbol('x')))).toEqual(configHash(make(undefined)))
   })
 
-  it('normalizes a circular hashExtra instead of throwing', () => {
+  it('normalizes a circular uses instead of throwing', () => {
     const e = fakeEffects()
-    const make = (hashExtra: unknown) =>
+    const make = (uses: unknown) =>
       Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
         subcontainer: lazy(e),
         exec: { command: ['cmd'] },
         ready: baseReady,
         requires: [],
-        hashExtra,
+        uses,
       }).entries[0]
     const circular = (port: number) => {
       const o: any = { port }
@@ -202,21 +206,21 @@ describe('configHash', () => {
     expect(configHash(make(circular(5959)))).toEqual(
       configHash(make(circular(5959))),
     )
-    // the cycle collapses to null, the rest of the value still hashes
+    // the cycle collapses to a sentinel, the rest of the value still hashes
     expect(configHash(make(circular(5959)))).not.toEqual(
       configHash(make(circular(5960))),
     )
   })
 
-  it('hashes a bigint hashExtra by value instead of throwing', () => {
+  it('hashes a bigint uses by value instead of throwing', () => {
     const e = fakeEffects()
-    const make = (hashExtra: unknown) =>
+    const make = (uses: unknown) =>
       Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
         subcontainer: lazy(e),
         exec: { command: ['cmd'] },
         ready: baseReady,
         requires: [],
-        hashExtra,
+        uses,
       }).entries[0]
     expect(() => configHash(make({ n: 1n }))).not.toThrow()
     expect(configHash(make({ n: 1n }))).toEqual(configHash(make({ n: 1n })))

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -180,22 +180,47 @@ describe('configHash', () => {
       }).entries[0]
     expect(configHash(make(() => 1))).toEqual(configHash(make(undefined)))
     expect(configHash(make(undefined))).toEqual(configHash(make(null as any)))
+    expect(configHash(make(Symbol('x')))).toEqual(configHash(make(undefined)))
   })
 
-  it('throws a descriptive error for an unserializable hashExtra', () => {
+  it('normalizes a circular hashExtra instead of throwing', () => {
     const e = fakeEffects()
-    const circular: any = {}
-    circular.self = circular
-    const entry = Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
-      subcontainer: lazy(e),
-      exec: { command: ['cmd'] },
-      ready: baseReady,
-      requires: [],
-      hashExtra: circular,
-    }).entries[0]
-    expect(() => configHash(entry)).toThrow(
-      "hashExtra for entry 'a' must be JSON-serializable",
+    const make = (hashExtra: unknown) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        ready: baseReady,
+        requires: [],
+        hashExtra,
+      }).entries[0]
+    const circular = (port: number) => {
+      const o: any = { port }
+      o.self = o
+      return o
+    }
+    expect(() => configHash(make(circular(5959)))).not.toThrow()
+    expect(configHash(make(circular(5959)))).toEqual(
+      configHash(make(circular(5959))),
     )
+    // the cycle collapses to null, the rest of the value still hashes
+    expect(configHash(make(circular(5959)))).not.toEqual(
+      configHash(make(circular(5960))),
+    )
+  })
+
+  it('hashes a bigint hashExtra by value instead of throwing', () => {
+    const e = fakeEffects()
+    const make = (hashExtra: unknown) =>
+      Daemons.of<Manifest>({ effects: e }).addDaemon('a', {
+        subcontainer: lazy(e),
+        exec: { command: ['cmd'] },
+        ready: baseReady,
+        requires: [],
+        hashExtra,
+      }).entries[0]
+    expect(() => configHash(make({ n: 1n }))).not.toThrow()
+    expect(configHash(make({ n: 1n }))).toEqual(configHash(make({ n: 1n })))
+    expect(configHash(make({ n: 1n }))).not.toEqual(configHash(make({ n: 2n })))
   })
 
   it('changes when command changes', () => {

--- a/projects/start-sdk/lib/test/Daemons.test.ts
+++ b/projects/start-sdk/lib/test/Daemons.test.ts
@@ -184,7 +184,10 @@ describe('configHash', () => {
     expect(configHash(make(() => 1))).not.toEqual(configHash(make(undefined)))
     expect(configHash(make(() => 1))).not.toEqual(configHash(make(Symbol('x'))))
     expect(configHash(make(() => 1))).toEqual(configHash(make(() => 2)))
-    expect(configHash(make(undefined))).toEqual(configHash(make(null as any)))
+    expect(configHash(make(undefined))).not.toEqual(
+      configHash(make(null as any)),
+    )
+    expect(configHash(make(undefined))).toEqual(configHash(make(undefined)))
   })
 
   it('normalizes a circular uses instead of throwing', () => {


### PR DESCRIPTION
Surfaced by the lnd-startos#178 review: an import daemon's `exec.fn` captured the origin host/password at builder time, and because `configHash` reduces function-form execs to `{__fn: true}`, a rebuilt chain with corrected credentials diffed to "leave alone" — the running daemon kept retrying with the old password.

`configHash` can't see closures (JS offers no introspection), so this adds the explicit escape hatch the `Daemons.dynamic` docstring already alludes to: an optional `uses` on `addDaemon()`/`addOneshot()` (including the pre-built `{ daemon }` form, which is otherwise entirely opaque to the hash). The field declares the values a daemon's closures use; any change to them restarts the entry on the next reconcile.

Only JSON-serializable values are useful, and the API says so at every touchpoint (field docstring, `configHash` docstring, changelog, packaging recipe). Normalization never throws — `configHash` runs inside the reconciler, so throwing would turn a packager's mistake into a failed reconcile:

- functions, symbols, cycles and `undefined` hash as distinct `UNSERIALIZABLE:*` sentinels — recognizable in the hash, and different kinds don't collide (two values of the same unserializable kind still hash alike: no restart, matching the JSON-only contract)
- BigInts hash as their decimal string, so they still signal a change

- `lib/mainFn/Daemons.ts`: `uses` on `NewDaemonParams` + the `addDaemon` intersection, recorded on the entry, canonicalized into `configHash`. The `exec` options object is now canonicalized in full (the old whitelist dropped a fn-form's `sigtermTimeout` and all `onStdout`/`onStderr` callbacks); function values hash as constant sentinels, so closure contents stay invisible and `uses` remains the escape hatch
- `lib/test/Daemons.test.ts`: hash changes on value change, key-order-independent, participates for oneshots, unserializable kinds get distinct sentinels, circular values hash stably while sibling fields still signal
- CHANGELOG entry under the unreleased 2.0.10; `recipe-dynamic-daemons.md` updated in the same change

`tsc --noEmit` + full jest suite (96 tests) green.
