### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,13 @@ This file covers what is **common to the whole monorepo** — the shared toolcha
 
 ## Documentation
 
-The repo root's docs split across four files:
+The repo root's docs split across five files:
 
 - `README.md` — what this is
 - `ARCHITECTURE.md` — how it's built (the monorepo layout)
 - `CONTRIBUTING.md` — this file; how to contribute
 - `AGENTS.md` — AI-developer/agent operating rules (`CLAUDE.md` is a one-line `@AGENTS.md` import)
+- `SECURITY.md` — how to report a vulnerability, and what is in scope
 
 **These docs must be kept up to date.** When you change project structure, conventions, build process, or product context, update the relevant file(s) in the same change — do not defer. Each product and shared library keeps its own `README.md`/`ARCHITECTURE.md`/`AGENTS.md` for what is specific to it (most still carry a `CONTRIBUTING.md` too, which is being folded into that scope's `AGENTS.md` — see [`AGENTS.md`](AGENTS.md)) — see `projects/*/`, `shared-libs/crates/start-core/`, `shared-libs/ts-modules/`, and `projects/start-os/container-runtime/`.
 
@@ -26,7 +27,7 @@ To fix something that is _already published_ — a typo, a broken link, a wrong 
 ## Collaboration
 
 - [Matrix](https://matrix.to/#/#dev-startos:matrix.start9labs.com)
-- Security issues: [security@start9.com](mailto:security@start9.com)
+- Security issues: [security@start9.com](mailto:security@start9.com) — see [SECURITY.md](SECURITY.md)
 
 ## Environment Setup
 

--- a/README.md
+++ b/README.md
@@ -88,12 +88,13 @@ StartOS is the flagship, but it shares this repo with the rest of the Start9 sta
 - [ARCHITECTURE.md](ARCHITECTURE.md) — how the monorepo fits together
 - [CONTRIBUTING.md](CONTRIBUTING.md) — environment setup, build, test, and format workflow
 - [AGENTS.md](AGENTS.md) — AI-developer/agent operating rules (`CLAUDE.md` is a one-line `@AGENTS.md` import)
+- [SECURITY.md](SECURITY.md) — how to report a vulnerability, and what is in scope
 
 ## Contributing
 
 There are multiple ways to contribute: work directly on a product in this repo, package a service for the marketplace, or help with documentation and guides. See [CONTRIBUTING.md](CONTRIBUTING.md) or visit [start9.com/contribute](https://start9.com/contribute/).
 
-To report security issues, email [security@start9.com](mailto:security@start9.com).
+To report security issues, email [security@start9.com](mailto:security@start9.com). See [SECURITY.md](SECURITY.md) for what is in scope and what happens next.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,21 +16,26 @@ Include:
 - The git hash, if you tested a build from `master`. Every `master` build of a product publishes under the same version number, so the hash is the only thing that identifies it. StartOS shows it in the web UI under the server's About dialog, next to the version.
 - What an attacker gains, and what access they need to start.
 - Steps to reproduce, ideally from a clean install.
-- A proof of concept, if you have one. It saves everyone time. If you would rather keep an exploit off email, the GitHub advisory form holds the report privately between you and the maintainers.
+- A proof of concept, if you have one. It saves everyone time. To keep an exploit out of plaintext mail, encrypt it to the key below, or use the GitHub advisory form.
 - Whether you want credit in the release notes, and the name to use.
 
 Machine-readable contact details are at <https://start9.com/.well-known/security.txt>, per RFC 9116.
 
 ### Our OpenPGP key
 
-`security@start9.com` shares an OpenPGP key with the rest of Start9:
+Encrypt your report to this key, or use it to check a Start9 signature:
 
 ```
 Start9 <security@start9.com>
 5456 DBFF 1B9D F905 041F  A776 5259 ADFC 2D63 C217
 ```
 
-It is in this repository as [`apt/start9.gpg`](apt/start9.gpg), and published at <https://start9.com/start9.gpg> and on <https://keys.openpgp.org>. It is the key that signs the `stable` suite of Start9's Debian repository ([`apt/start9.list`](apt/start9.list)), so a machine that already installs Start9 packages carries a copy you can compare the fingerprint against. Use it to check a Start9 signature. To send a report confidentially, use the GitHub advisory form above.
+```
+gpg --fetch-keys https://start9.com/start9.gpg
+gpg --encrypt --armor --recipient security@start9.com report.txt
+```
+
+The key is also in this repository as [`apt/start9.gpg`](apt/start9.gpg) and on <https://keys.openpgp.org>. The same key signs the `stable` suite of Start9's Debian repository ([`apt/start9.list`](apt/start9.list)), so a machine that already installs Start9 packages carries a copy you can compare the fingerprint against.
 
 ## What happens next
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,83 @@
+# Security Policy
+
+Start9's vulnerability disclosure policy is published at <https://start9.com/security>. That page is authoritative. This file says how it applies to this repository.
+
+## Reporting a vulnerability
+
+Email [security@start9.com](mailto:security@start9.com), or file privately on GitHub through the [draft advisory form](https://github.com/Start9Labs/start-technologies/security/advisories/new) — private vulnerability reporting is enabled on this repository. Use one of those two channels rather than a public issue, the forum, or a Matrix room.
+
+Please give us a chance to fix the problem before you publish. We will not ask you to stay quiet indefinitely, and we will not ask you to sign anything. If you have a date in mind, say so in your report and we will work to it.
+
+If you are unsure whether something is in bounds, ask at [security@start9.com](mailto:security@start9.com) first. We would rather answer the question than argue about it afterwards.
+
+Include:
+
+- The product and version you tested, and how it was installed (Start9 hardware, your own hardware, or a virtual machine). Quote the version exactly as the server reports it — StartOS versions may carry a fourth revision segment, as in `0.4.0.1`.
+- The git hash, if you tested a build from `master`. Every `master` build of a product publishes under the same version number, so the hash is the only thing that identifies it. StartOS shows it in the web UI under the server's About dialog, next to the version.
+- What an attacker gains, and what access they need to start.
+- Steps to reproduce, ideally from a clean install.
+- A proof of concept, if you have one. It saves everyone time. If you would rather keep an exploit off email, the GitHub advisory form holds the report privately between you and the maintainers.
+- Whether you want credit in the release notes, and the name to use.
+
+Machine-readable contact details are at <https://start9.com/.well-known/security.txt>, per RFC 9116.
+
+### Our OpenPGP key
+
+`security@start9.com` shares an OpenPGP key with the rest of Start9:
+
+```
+Start9 <security@start9.com>
+5456 DBFF 1B9D F905 041F  A776 5259 ADFC 2D63 C217
+```
+
+It is in this repository as [`apt/start9.gpg`](apt/start9.gpg), and published at <https://start9.com/start9.gpg> and on <https://keys.openpgp.org>. It is the key that signs the `stable` suite of Start9's Debian repository ([`apt/start9.list`](apt/start9.list)), so a machine that already installs Start9 packages carries a copy you can compare the fingerprint against. Use it to check a Start9 signature. To send a report confidentially, use the GitHub advisory form above.
+
+## What happens next
+
+Per the published policy, we will:
+
+- Acknowledge your report within 5 business days.
+- Tell you whether we consider it a vulnerability, and why.
+- Keep you updated while we work on it, and tell you when the fix ships.
+- Credit you in the release notes if you want the credit, and leave you out of them if you don't.
+
+<https://start9.com/security> carries a safe harbour clause for research done in good faith and reported through this process; read it there for the terms themselves. Good faith means working only against your own devices and accounts, not accessing, modifying, or destroying anyone else's data, not degrading our services for other people, and stopping as soon as you have proved the point.
+
+Fixes are described in the affected product's changelog under a `### Security` heading, for example [`projects/start-os/CHANGELOG.md`](projects/start-os/CHANGELOG.md).
+
+## Scope
+
+This repository holds six independently released products. A vulnerability in any of them belongs here:
+
+| Directory                 | Product                                    |
+| ------------------------- | ------------------------------------------ |
+| `projects/start-os`       | StartOS, the server operating system       |
+| `projects/start-wrt`      | StartWRT, the router OS                    |
+| `projects/start-tunnel`   | StartTunnel                                |
+| `projects/start-cli`      | `start-cli`                                |
+| `projects/start-sdk`      | `@start9labs/start-sdk`, the packaging SDK |
+| `projects/start-registry` | The registry server                        |
+
+The shared code under [`shared-libs/`](shared-libs/) is part of those products and is in scope — `start-core` is the entire Rust backend. So are [`projects/start-docs`](projects/start-docs/) and [`projects/brochure-marketplace`](projects/brochure-marketplace/), which build Start9 websites, and the reusable CI in [`.github/workflows/`](.github/workflows/) that external service-package repositories call.
+
+The registries Start9 operates and Start9's websites are in scope for the published policy. A flaw in a running service — a misconfiguration, an exposed endpoint, something you can only see from outside — goes to [security@start9.com](mailto:security@start9.com). A flaw in the code behind it belongs here: the registry server is [`projects/start-registry`](projects/start-registry/), and marketplace.start9.com and docs.start9.com are built from [`projects/brochure-marketplace`](projects/brochure-marketplace/) and [`projects/start-docs`](projects/start-docs/).
+
+### Service packages live in their own repositories
+
+Each service in the marketplace is packaged in its own `*-startos` repository, separate from this monorepo — Bitcoin Core is [`bitcoin-core-startos`](https://github.com/Start9Labs/bitcoin-core-startos), and the rest are listed under [Start9Labs](https://github.com/Start9Labs) and, for community packages, [Start9-Community](https://github.com/Start9-Community):
+
+- **A flaw in the packaged application itself** goes to that application's upstream project. They can fix it and we cannot.
+- **A flaw in the packaging** — the manifest, the health checks, the interfaces a package exposes, the credentials it generates — goes to [security@start9.com](mailto:security@start9.com) if an attacker could exploit it, or to the advisory form above with the package named. An issue opened on a `*-startos` repository is a public disclosure. Packaging bugs with no security impact are welcome there; if you are not sure which side of that line yours falls on, ask us first.
+- **Tell us as well** at [security@start9.com](mailto:security@start9.com) if a Start9 packaging decision makes an upstream vulnerability worse, or if you think a package should be pulled from a registry.
+
+The Community Registry distributes software written by other people, and the same split applies to it.
+
+### Support questions are not vulnerability reports
+
+A server that will not start, a service that will not connect, a lost password, or a backup that will not restore is a support question. Those get faster answers in the community channels listed on <https://start9.com/contact>. Use the security channels for a defect an attacker could exploit.
+
+## Versions
+
+Fixes land on `master` before they are released, and `master` is public — so a fix is readable in the commit history, and testable in the alpha builds of the products that publish there, ahead of the release that carries it. Merging and releasing are separate events, and the first one is public. Tell us if that timing matters to your disclosure plan.
+
+Each product versions and tags independently as `<product>/v<version>`, and the git tags on this repository are the source of truth for what has shipped — a version number in a changelog heading or a manifest is the prospective next release, not a released one. Report against the latest release of the affected product where you can.

--- a/projects/start-os/CONTRIBUTING.md
+++ b/projects/start-os/CONTRIBUTING.md
@@ -13,7 +13,7 @@ User-facing changes (UI, CLI, install/setup flow) must update the end-user docs 
 ## Collaboration
 
 - [Matrix](https://matrix.to/#/#dev-startos:matrix.start9labs.com)
-- Security issues: [security@start9.com](mailto:security@start9.com)
+- Security issues: [security@start9.com](mailto:security@start9.com) — see [SECURITY.md](../../SECURITY.md)
 
 ## Prerequisites
 

--- a/projects/start-os/README.md
+++ b/projects/start-os/README.md
@@ -87,4 +87,4 @@ test suite.
   [install guide](https://docs.start9.com/start-os/installing-startos.html).
 - Browse services on the [Start9 Marketplace](https://marketplace.start9.com/).
 
-To report security issues, email [security@start9.com](mailto:security@start9.com).
+To report security issues, email [security@start9.com](mailto:security@start9.com). See [SECURITY.md](../../SECURITY.md) for what is in scope and what happens next.


### PR DESCRIPTION
The repo had no security policy, so GitHub showed no "Report a vulnerability" entry in the issue chooser and the only pointer anywhere was a bare `security@start9.com` line in README and CONTRIBUTING.

Start9 already publishes a full policy at <https://start9.com/security> plus an RFC 9116 `security.txt`, so this file does not invent a second one. It applies that policy to this repository:

- **Two private channels** — `security@start9.com`, or GitHub's advisory form (private vulnerability reporting is enabled here, verified `{"enabled":true}`).
- **The OpenPGP key** for `security@start9.com`, fingerprint `5456 DBFF 1B9D F905 041F A776 5259 ADFC 2D63 C217` — the same key as `apt/start9.gpg`, which I confirmed is byte-identical to <https://start9.com/start9.gpg> and is served by keys.openpgp.org under both UIDs.
- **Scope** — the six released products in this repo, the shared libs, the two website projects, and the reusable CI; versus the separate `*-startos` package repos, where an issue is a public disclosure.
- **What is not a vulnerability report** — support questions.

Legal text (safe harbour) is linked, not restated, so the repo and the website cannot drift. The operational commitments (5 business days, credit) are quoted and attributed.

`CONTRIBUTING.md` says the root's docs are exactly four files and must be updated in the same change, so that list goes to five; README's Documentation list and the two `projects/start-os/` security lines are wired up the same way.

## Two things worth your attention

**1. `security.txt` advertises a key that cannot encrypt.** The file has `Encryption: https://start9.com/start9.gpg`, which under RFC 9116 §2.5 means "encrypt your report to this key". But the key is `scaSCA` — sign/certify/authenticate, no encryption subkey:

```
$ gpg --encrypt -r security@start9.com
gpg: security@start9.com: skipped: Unusable public key
```

So a researcher who does the responsible thing and encrypts the exploit hits an unexplained failure. Worse, `apt/start9-alpha.gpg` *does* carry a cv25519 `[E]` subkey and encrypts fine, so someone troubleshooting can find a Start9 key that "works" and encrypt to the CI key.

I wrote the key section around what the key provably does (checking a Start9 signature, and giving an independent copy of the fingerprint to compare against start9.com and keys.openpgp.org) and route confidentiality to the advisory form. The real fix is on the website — drop the `Encryption:` field, or add an encryption subkey. Say which and I will match the wording.

**2. `start-cli -H <host> git-info` reports the client's build, not the server's.** I had drafted that as the way to identify an alpha build; it is wrong. `git-info` is registered at `shared-libs/crates/start-core/src/lib.rs:142` as `from_fn(|_: C| version::git_info())` with no `.with_call_remote::<CliContext>()` — unlike `echo` and `state` directly below it — and `git_info()` returns the `include_str!`-baked `COMMIT_HASH` of the running binary. `-H` is parsed and ignored, so you get the hash of whatever start-cli the reporter has installed.

SECURITY.md now points at the About dialog instead. But **the same wrong invocation is in `AGENTS.md:98` and `.github/ISSUE_TEMPLATE/1-bug-start-os.yml`** ("From a client, `start-cli -H https://<your-server> git-info` prints the exact build") — so bug reports are being filed with the wrong hash today. I left those alone to keep this PR docs-only. Want a follow-up fixing both, or a `.with_call_remote::<CliContext>()` on line 143 to make the documented behaviour real?

## Open questions for you

- **Supported versions.** I deliberately omitted a version table — nothing published states whether StartOS 0.3.5.x still gets security fixes. Worth stating if there is an answer.
- **Org-wide default.** No repo in either org has a SECURITY.md. A `Start9Labs/.github/SECURITY.md` would cover all ~130 repos including the `*-startos` packages, which is where package reports actually land.

Verification: prettier clean; every relative link resolves; every external URL fetched (start9.com 404s properly on bogus paths, so `/security` and `/.well-known/security.txt` are real pages, not soft-404s).
