### PR TITLE
fix(start-registry): make os asset remove reachable from the CLI

### DIFF
--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -13,6 +13,16 @@ or the CLI's externally observable behavior.
 
 ### Fixed
 
+- **`registry os asset remove` can be run.** Its `iso`/`img`/`squashfs` handlers were registered
+  as RPC-only, and — unlike `add`, `sign`, and `get`, which each pair their RPC handlers with a
+  CLI counterpart — nothing was registered in their place. `remove` was left parsing as a leaf
+  that accepts no arguments: it listed under `registry os asset --help` with a blank description,
+  and naming an asset type came back `unexpected argument 'iso' found` with exit 2. The three
+  subcommands now take `<VERSION> <PLATFORM>` and reach the registry directly, mirroring
+  `registry os asset get`, so a single platform's asset can be dropped without removing the whole
+  version and re-adding every other platform. Asking to remove a platform the version has no
+  asset for now says so instead of reporting success.
+
 - **The local authcookie now reaches a registry or tunnel daemon that listens on a
   non-loopback address.** Run on the server itself, the CLI presents the daemon's local
   authcookie as an `Authorization: Bearer` header — but it attached that header only when

--- a/projects/start-cli/man/start-cli-registry-os-asset-remove-img.1
+++ b/projects/start-cli/man/start-cli-registry-os-asset-remove-img.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-registry-os-asset-remove-img 1  "img " 
+.SH NAME
+start\-cli\-registry\-os\-asset\-remove\-img \- Remove IMG file from registry
+.SH SYNOPSIS
+\fBstart\-cli registry os asset remove img\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove IMG file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-cli/man/start-cli-registry-os-asset-remove-iso.1
+++ b/projects/start-cli/man/start-cli-registry-os-asset-remove-iso.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-registry-os-asset-remove-iso 1  "iso " 
+.SH NAME
+start\-cli\-registry\-os\-asset\-remove\-iso \- Remove ISO file from registry
+.SH SYNOPSIS
+\fBstart\-cli registry os asset remove iso\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove ISO file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-cli/man/start-cli-registry-os-asset-remove-squashfs.1
+++ b/projects/start-cli/man/start-cli-registry-os-asset-remove-squashfs.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-cli-registry-os-asset-remove-squashfs 1  "squashfs " 
+.SH NAME
+start\-cli\-registry\-os\-asset\-remove\-squashfs \- Remove squashfs file from registry
+.SH SYNOPSIS
+\fBstart\-cli registry os asset remove squashfs\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove squashfs file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-cli/man/start-cli-registry-os-asset-remove.1
+++ b/projects/start-cli/man/start-cli-registry-os-asset-remove.1
@@ -2,11 +2,22 @@
 .el .ds Aq '
 .TH start-cli-registry-os-asset-remove 1  "remove " 
 .SH NAME
-start\-cli\-registry\-os\-asset\-remove
+start\-cli\-registry\-os\-asset\-remove \- Commands to remove image, iso, or squashfs files
 .SH SYNOPSIS
-\fBstart\-cli registry os asset remove\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBstart\-cli registry os asset remove\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
+Commands to remove image, iso, or squashfs files
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
+.SH SUBCOMMANDS
+.TP
+start\-cli\-registry\-os\-asset\-remove\-img(1)
+Remove IMG file from registry
+.TP
+start\-cli\-registry\-os\-asset\-remove\-iso(1)
+Remove ISO file from registry
+.TP
+start\-cli\-registry\-os\-asset\-remove\-squashfs(1)
+Remove squashfs file from registry

--- a/projects/start-cli/man/start-cli-registry-os-asset.1
+++ b/projects/start-cli/man/start-cli-registry-os-asset.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-cli-registry-os-asset 1  "asset " 
 .SH NAME
-start\-cli\-registry\-os\-asset \- Commands to add, sign, or get registry assets
+start\-cli\-registry\-os\-asset \- Commands to add, sign, remove, or get registry assets
 .SH SYNOPSIS
 \fBstart\-cli registry os asset\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
-Commands to add, sign, or get registry assets
+Commands to add, sign, remove, or get registry assets
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
@@ -20,6 +20,7 @@ start\-cli\-registry\-os\-asset\-get(1)
 Commands to download image, iso, or squashfs files
 .TP
 start\-cli\-registry\-os\-asset\-remove(1)
+Commands to remove image, iso, or squashfs files
 .TP
 start\-cli\-registry\-os\-asset\-sign(1)
 Sign file and add to registry

--- a/projects/start-cli/man/start-cli-registry-os.1
+++ b/projects/start-cli/man/start-cli-registry-os.1
@@ -14,7 +14,7 @@ Print help
 .SH SUBCOMMANDS
 .TP
 start\-cli\-registry\-os\-asset(1)
-Commands to add, sign, or get registry assets
+Commands to add, sign, remove, or get registry assets
 .TP
 start\-cli\-registry\-os\-index(1)
 List OS versions index

--- a/projects/start-os/docs/src/cli-reference.md
+++ b/projects/start-os/docs/src/cli-reference.md
@@ -1013,9 +1013,21 @@ Sign an OS asset and register the signature.
 - `-p, --platform <PLATFORM>` — Target platform (required)
 - `-v, --version <VERSION>` — OS version (required)
 
-### `start-cli registry os asset remove`
+### `start-cli registry os asset remove img <VERSION> <PLATFORM>`
 
-Remove an OS asset.
+Drop one platform's IMG file from a version's index entry. The asset bytes stay
+where they are; this removes the registry's record of them, which is what frees
+the platform slot for a re-index.
+
+### `start-cli registry os asset remove iso <VERSION> <PLATFORM>`
+
+Drop one platform's ISO file from a version's index entry. Same arguments as
+`remove img`.
+
+### `start-cli registry os asset remove squashfs <VERSION> <PLATFORM>`
+
+Drop one platform's squashfs file from a version's index entry. Same arguments
+as `remove img`.
 
 ### `start-cli registry os asset get img <VERSION> <PLATFORM>`
 

--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to `start-registry` (the Start Registry server) are document
 
 ## [1.0.2]
 
+- **`os asset remove` can be run.** Its `iso`/`img`/`squashfs` handlers were registered as
+  RPC-only with no CLI counterpart, so `remove` parsed as a leaf that accepts no arguments — it
+  listed with a blank description and rejected `os asset remove iso 0.4.0 x86_64` as an
+  unexpected argument. The three subcommands now take `<VERSION> <PLATFORM>`, mirroring
+  `os asset get`. Dropping a version's index entry for a single platform no longer requires
+  removing the whole version and re-adding every other platform. Asking to remove a platform the
+  version has no asset for now says so instead of reporting success.
+
 - **`start-registry` works on a registry host that listens on a non-loopback address.** With no
   `--registry`, the CLI derives the registry's address from `registry-listen` and authenticates
   with the local authcookie — but it only sent that token when the derived URL was literally

--- a/projects/start-registry/man/start-registry-os-asset-remove-img.1
+++ b/projects/start-registry/man/start-registry-os-asset-remove-img.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-registry-os-asset-remove-img 1  "img " 
+.SH NAME
+start\-registry\-os\-asset\-remove\-img \- Remove IMG file from registry
+.SH SYNOPSIS
+\fBstart\-registry os asset remove img\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove IMG file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-registry/man/start-registry-os-asset-remove-iso.1
+++ b/projects/start-registry/man/start-registry-os-asset-remove-iso.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-registry-os-asset-remove-iso 1  "iso " 
+.SH NAME
+start\-registry\-os\-asset\-remove\-iso \- Remove ISO file from registry
+.SH SYNOPSIS
+\fBstart\-registry os asset remove iso\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove ISO file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-registry/man/start-registry-os-asset-remove-squashfs.1
+++ b/projects/start-registry/man/start-registry-os-asset-remove-squashfs.1
@@ -1,0 +1,19 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH start-registry-os-asset-remove-squashfs 1  "squashfs " 
+.SH NAME
+start\-registry\-os\-asset\-remove\-squashfs \- Remove squashfs file from registry
+.SH SYNOPSIS
+\fBstart\-registry os asset remove squashfs\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIVERSION\fR> <\fIPLATFORM\fR> 
+.SH DESCRIPTION
+Remove squashfs file from registry
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help
+.TP
+<\fIVERSION\fR>
+StartOS version number
+.TP
+<\fIPLATFORM\fR>
+Target platform identifier

--- a/projects/start-registry/man/start-registry-os-asset-remove.1
+++ b/projects/start-registry/man/start-registry-os-asset-remove.1
@@ -2,11 +2,22 @@
 .el .ds Aq '
 .TH start-registry-os-asset-remove 1  "remove " 
 .SH NAME
-start\-registry\-os\-asset\-remove
+start\-registry\-os\-asset\-remove \- Commands to remove image, iso, or squashfs files
 .SH SYNOPSIS
-\fBstart\-registry os asset remove\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBstart\-registry os asset remove\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
+Commands to remove image, iso, or squashfs files
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
 Print help
+.SH SUBCOMMANDS
+.TP
+start\-registry\-os\-asset\-remove\-img(1)
+Remove IMG file from registry
+.TP
+start\-registry\-os\-asset\-remove\-iso(1)
+Remove ISO file from registry
+.TP
+start\-registry\-os\-asset\-remove\-squashfs(1)
+Remove squashfs file from registry

--- a/projects/start-registry/man/start-registry-os-asset.1
+++ b/projects/start-registry/man/start-registry-os-asset.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH start-registry-os-asset 1  "asset " 
 .SH NAME
-start\-registry\-os\-asset \- Commands to add, sign, or get registry assets
+start\-registry\-os\-asset \- Commands to add, sign, remove, or get registry assets
 .SH SYNOPSIS
 \fBstart\-registry os asset\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
-Commands to add, sign, or get registry assets
+Commands to add, sign, remove, or get registry assets
 .SH OPTIONS
 .TP
 \fB\-h\fR, \fB\-\-help\fR
@@ -20,6 +20,7 @@ start\-registry\-os\-asset\-get(1)
 Commands to download image, iso, or squashfs files
 .TP
 start\-registry\-os\-asset\-remove(1)
+Commands to remove image, iso, or squashfs files
 .TP
 start\-registry\-os\-asset\-sign(1)
 Sign file and add to registry

--- a/projects/start-registry/man/start-registry-os.1
+++ b/projects/start-registry/man/start-registry-os.1
@@ -14,7 +14,7 @@ Print help
 .SH SUBCOMMANDS
 .TP
 start\-registry\-os\-asset(1)
-Commands to add, sign, or get registry assets
+Commands to add, sign, remove, or get registry assets
 .TP
 start\-registry\-os\-index(1)
 List OS versions index

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -2134,6 +2134,20 @@ registry.os.asset.signer-not-authorized:
   fr_FR: "Le signataire %{guid} n'est pas autorisé"
   pl_PL: "Sygnatariusz %{guid} nie jest autoryzowany"
 
+registry.os.asset.missing-signer:
+  en_US: "Missing signer"
+  de_DE: "Fehlender Unterzeichner"
+  es_ES: "Falta firmante"
+  fr_FR: "Signataire manquant"
+  pl_PL: "Brak sygnatariusza"
+
+registry.os.asset.remove-not-exist:
+  en_US: "v%{version} has no asset indexed for %{platform}, so nothing was removed"
+  de_DE: "Für v%{version} ist kein Asset für %{platform} indiziert, daher wurde nichts entfernt"
+  es_ES: "v%{version} no tiene ningún activo indexado para %{platform}, por lo que no se eliminó nada"
+  fr_FR: "v%{version} n'a aucun actif indexé pour %{platform}, donc rien n'a été supprimé"
+  pl_PL: "v%{version} nie ma zasobu zaindeksowanego dla %{platform}, więc nic nie usunięto"
+
 # registry/os/version/signer.rs
 registry.os.version.signer-not-authorized:
   en_US: "Signer %{signer} is not authorized to sign for v%{version}"
@@ -4855,12 +4869,12 @@ about.commands-add-remove-list-versions:
   fr_FR: "Commandes pour ajouter, supprimer ou lister les versions ou signataires de versions"
   pl_PL: "Polecenia dodania, usunięcia lub wyświetlenia wersji lub sygnatariuszy wersji"
 
-about.commands-add-sign-get-assets:
-  en_US: "Commands to add, sign, or get registry assets"
-  de_DE: "Befehle zum Hinzufügen, Signieren oder Abrufen von Registry-Assets"
-  es_ES: "Comandos para agregar, firmar u obtener activos del registro"
-  fr_FR: "Commandes pour ajouter, signer ou obtenir des actifs du registre"
-  pl_PL: "Polecenia dodania, podpisania lub pobrania zasobów rejestru"
+about.commands-add-sign-remove-get-assets:
+  en_US: "Commands to add, sign, remove, or get registry assets"
+  de_DE: "Befehle zum Hinzufügen, Signieren, Entfernen oder Abrufen von Registry-Assets"
+  es_ES: "Comandos para agregar, firmar, eliminar u obtener activos del registro"
+  fr_FR: "Commandes pour ajouter, signer, supprimer ou obtenir des actifs du registre"
+  pl_PL: "Polecenia dodania, podpisania, usunięcia lub pobrania zasobów rejestru"
 
 about.commands-authentication:
   en_US: "Commands related to Authentication i.e. login, logout"
@@ -5092,6 +5106,13 @@ about.commands-registry-info:
   es_ES: "Ver o editar información del registro"
   fr_FR: "Afficher ou modifier les informations du registre"
   pl_PL: "Wyświetl lub edytuj informacje rejestru"
+
+about.commands-remove-assets:
+  en_US: "Commands to remove image, iso, or squashfs files"
+  de_DE: "Befehle zum Entfernen von Image-, ISO- oder Squashfs-Dateien"
+  es_ES: "Comandos para eliminar archivos de imagen, iso o squashfs"
+  fr_FR: "Commandes pour supprimer des fichiers image, iso ou squashfs"
+  pl_PL: "Polecenia usuwania plików obrazu, iso lub squashfs"
 
 about.commands-restore-backup:
   en_US: "Commands for restoring package(s) from backup"
@@ -6004,6 +6025,20 @@ about.remove-existing-backup-target:
   fr_FR: "Supprimer la cible de sauvegarde existante"
   pl_PL: "Usuń istniejący cel kopii zapasowej"
 
+about.remove-img-registry:
+  en_US: "Remove IMG file from registry"
+  de_DE: "IMG-Datei aus der Registry entfernen"
+  es_ES: "Eliminar archivo IMG del registro"
+  fr_FR: "Supprimer le fichier IMG du registre"
+  pl_PL: "Usuń plik IMG z rejestru"
+
+about.remove-iso-registry:
+  en_US: "Remove ISO file from registry"
+  de_DE: "ISO-Datei aus der Registry entfernen"
+  es_ES: "Eliminar archivo ISO del registro"
+  fr_FR: "Supprimer le fichier ISO du registre"
+  pl_PL: "Usuń plik ISO z rejestru"
+
 about.remove-mirror-package:
   en_US: "Remove mirror package"
   de_DE: "Mirror-Paket entfernen"
@@ -6066,6 +6101,13 @@ about.remove-signer:
   es_ES: "Eliminar firmante y todas sus autorizaciones"
   fr_FR: "Supprimer le signataire et toutes ses autorisations"
   pl_PL: "Usuń sygnatariusza i wszystkie jego autoryzacje"
+
+about.remove-squashfs-registry:
+  en_US: "Remove squashfs file from registry"
+  de_DE: "Squashfs-Datei aus der Registry entfernen"
+  es_ES: "Eliminar archivo squashfs del registro"
+  fr_FR: "Supprimer le fichier squashfs du registre"
+  pl_PL: "Usuń plik squashfs z rejestru"
 
 about.remove-pinhole:
   en_US: "Remove IPv6 pinhole"

--- a/shared-libs/crates/start-core/src/registry/os/asset/add.rs
+++ b/shared-libs/crates/start-core/src/registry/os/asset/add.rs
@@ -57,19 +57,25 @@ pub fn remove_api<C: Context>() -> ParentHandler<C> {
             "iso",
             from_fn_async(remove_iso)
                 .with_metadata("get_signer", Value::Bool(true))
-                .no_cli(),
+                .with_custom_display_fn(|args, removed| warn_if_absent(&args.params, removed))
+                .with_about("about.remove-iso-registry")
+                .with_call_remote::<CliContext>(),
         )
         .subcommand(
             "img",
             from_fn_async(remove_img)
                 .with_metadata("get_signer", Value::Bool(true))
-                .no_cli(),
+                .with_custom_display_fn(|args, removed| warn_if_absent(&args.params, removed))
+                .with_about("about.remove-img-registry")
+                .with_call_remote::<CliContext>(),
         )
         .subcommand(
             "squashfs",
             from_fn_async(remove_squashfs)
                 .with_metadata("get_signer", Value::Bool(true))
-                .no_cli(),
+                .with_custom_display_fn(|args, removed| warn_if_absent(&args.params, removed))
+                .with_about("about.remove-squashfs-registry")
+                .with_call_remote::<CliContext>(),
         )
 }
 
@@ -289,17 +295,36 @@ pub async fn cli_add_asset(
     Ok(())
 }
 
-#[derive(Debug, Deserialize, Serialize, TS)]
+#[derive(Debug, Deserialize, Serialize, Parser, TS)]
+#[group(skip)]
+#[command(rename_all = "kebab-case")]
 #[serde(rename_all = "camelCase")]
 #[ts(export)]
 pub struct RemoveAssetParams {
     #[ts(type = "string")]
+    #[arg(help = "help.arg.os-version")]
     pub version: Version,
     #[ts(type = "string")]
+    #[arg(help = "help.arg.platform")]
     pub platform: InternedString,
     #[serde(rename = "__Auth_signer")]
     #[ts(skip)]
-    pub signer: AnyVerifyingKey,
+    #[arg(skip)]
+    pub signer: Option<AnyVerifyingKey>,
+}
+
+fn warn_if_absent(params: &RemoveAssetParams, removed: bool) -> Result<(), Error> {
+    if !removed {
+        tracing::warn!(
+            "{}",
+            t!(
+                "registry.os.asset.remove-not-exist",
+                version = params.version,
+                platform = params.platform
+            )
+        );
+    }
+    Ok(())
 }
 
 async fn remove_asset(
@@ -314,7 +339,13 @@ async fn remove_asset(
     ) -> &mut Model<BTreeMap<InternedString, RegistryAsset<Blake3Commitment>>>
     + UnwindSafe
     + Send,
-) -> Result<(), Error> {
+) -> Result<bool, Error> {
+    let signer = signer.ok_or_else(|| {
+        Error::new(
+            eyre!("{}", t!("registry.os.asset.missing-signer")),
+            ErrorKind::InvalidRequest,
+        )
+    })?;
     ctx.db
         .mutate(|db| {
             let signer_guid = db.as_index().as_signers().get_signer(&signer)?;
@@ -329,15 +360,15 @@ async fn remove_asset(
                 .contains(&signer_guid)
                 || db.as_admins().de()?.contains(&signer_guid)
             {
-                accessor(
+                Ok(accessor(
                     db.as_index_mut()
                         .as_os_mut()
                         .as_versions_mut()
                         .as_idx_mut(&version)
                         .or_not_found(&version)?,
                 )
-                .remove(&platform)?;
-                Ok(())
+                .remove(&platform)?
+                .is_some())
             } else {
                 Err(Error::new(
                     eyre!("{}", t!("registry.os.asset.unauthorized")),
@@ -346,19 +377,20 @@ async fn remove_asset(
             }
         })
         .await
-        .result?;
-
-    Ok(())
+        .result
 }
 
-pub async fn remove_iso(ctx: RegistryContext, params: RemoveAssetParams) -> Result<(), Error> {
+pub async fn remove_iso(ctx: RegistryContext, params: RemoveAssetParams) -> Result<bool, Error> {
     remove_asset(ctx, params, |m| m.as_iso_mut()).await
 }
 
-pub async fn remove_img(ctx: RegistryContext, params: RemoveAssetParams) -> Result<(), Error> {
+pub async fn remove_img(ctx: RegistryContext, params: RemoveAssetParams) -> Result<bool, Error> {
     remove_asset(ctx, params, |m| m.as_img_mut()).await
 }
 
-pub async fn remove_squashfs(ctx: RegistryContext, params: RemoveAssetParams) -> Result<(), Error> {
+pub async fn remove_squashfs(
+    ctx: RegistryContext,
+    params: RemoveAssetParams,
+) -> Result<bool, Error> {
     remove_asset(ctx, params, |m| m.as_squashfs_mut()).await
 }

--- a/shared-libs/crates/start-core/src/registry/os/asset/mod.rs
+++ b/shared-libs/crates/start-core/src/registry/os/asset/mod.rs
@@ -13,7 +13,10 @@ pub fn asset_api<C: Context>() -> ParentHandler<C> {
                 .no_display()
                 .with_about("about.add-asset-registry"),
         )
-        .subcommand("remove", add::remove_api::<C>())
+        .subcommand(
+            "remove",
+            add::remove_api::<C>().with_about("about.commands-remove-assets"),
+        )
         .subcommand("sign", sign::sign_api::<C>())
         .subcommand(
             "sign",

--- a/shared-libs/crates/start-core/src/registry/os/mod.rs
+++ b/shared-libs/crates/start-core/src/registry/os/mod.rs
@@ -23,7 +23,7 @@ pub fn os_api<C: Context>() -> ParentHandler<C> {
         )
         .subcommand(
             "asset",
-            asset::asset_api::<C>().with_about("about.commands-add-sign-get-assets"),
+            asset::asset_api::<C>().with_about("about.commands-add-sign-remove-get-assets"),
         )
         .subcommand(
             "version",


### PR DESCRIPTION
## The bug

`registry os asset remove` cannot be run. Its `iso`/`img`/`squashfs` handlers are registered `.no_cli()`, and — unlike `add`, `sign`, and `get`, which each pair their RPC handlers with a CLI counterpart — nothing is registered in their place. `remove_api` has no root handler, so `ParentHandler::cli_command` gives it `subcommand_required(true)` with zero subcommands registered: a node that demands a subcommand while offering none.

```
$ start-cli registry os asset --help
  remove                                    # ← blank description (no .with_about())

$ start-cli registry os asset remove --help
Usage: start-cli registry os asset remove   # ← no Commands:, no args

$ start-cli registry os asset remove iso 0.4.0 x86_64
error: unexpected argument 'iso' found      # exit 2
```

The RPC route was always fine — `registry.os.asset.remove.{iso,img,squashfs}` works over JSON-RPC. Only the CLI was unreachable, on both `start-cli registry` and the standalone `start-registry` binary, which builds its CLI from the same `registry_api()`.

Both defects date to 5c473eb9c, where `remove_api` was copied from `add_api` directly above it. `.no_cli()` is correct there — `add` does local blake3 hashing, signing and URL verification in a hand-written `cli_add_asset` — but `remove` does no local work at all, so the sibling was never written and nothing replaced it. `git log -S` confirms neither `cli_remove_asset` nor `with_call_remote` has ever existed in that directory: never a regression, never written.

## Why it matters

Per-platform asset removal is the primitive both deploy jobs wanted. They drop the whole version entry to re-index one, and 7695ab1ff records the cost:

> Removing the version drops _every_ platform indexed under it, so this is gated to full-matrix deploys. A dispatch naming a single platform deliberately skips it rather than silently wiping the other eight; if that version already holds a build, the index step below fails on the commitment mismatch, which is the honest outcome.

`projects/start-os/docs/src/cli-reference.md` also documented the command as if it worked.

## The fix

The three subcommands now take `<VERSION> <PLATFORM>` and call the registry directly, mirroring `registry os asset get` at the same tree depth:

```
$ start-cli registry os asset remove --help
Commands to remove image, iso, or squashfs files

Commands:
  img       Remove IMG file from registry
  iso       Remove ISO file from registry
  squashfs  Remove squashfs file from registry

$ start-cli registry os asset remove iso --help
Usage: start-cli registry os asset remove iso <VERSION> <PLATFORM>
```

This follows `registry package remove`, which is already `get_signer` + `with_custom_display_fn` + `with_call_remote::<CliContext>()` and whose params struct is a field-for-field template. Notes:

- `RemoveAssetParams` gains `Parser`; `signer` becomes `Option` because `#[arg(skip)]` requires `Default`, which `AnyVerifyingKey` does not implement. A missing `__Auth_signer` now fails as `InvalidRequest` ("Missing signer") instead of a serde error.
- Removing a platform a version holds no asset for warned nothing and reported success — `Model::remove` returns `Ok(None)` for an absent key. The handlers now return whether anything was removed and warn when nothing was, as `registry package remove` does. The call stays idempotent, so the deploy jobs' `|| echo "::notice::"` idiom is unaffected.
- The parent `asset` about key is renamed (`about.commands-add-sign-get-assets` → `…-add-sign-remove-get-assets`) rather than edited in place, so the key id keeps describing its contents. Its sole call site moved with it; the old key has no other references.
- Wire change: `os.asset.remove.{iso,img,squashfs}` now returns `true`/`false` instead of `null`. No TS binding changes (`signer` is `#[ts(skip)]`, so `RemoveAssetParams.ts` is byte-identical).

## Verification

- `cargo build -p start-cli --bin start-cli` and `-p start-registry --bin registrybox`, both clean; `--help` output above captured from the built binaries, and the "before" reproduction from a build of `origin/master`.
- `make start-core-test` — 302 passed, 0 failed, including `no_shadowed_args_start_cli`/`_start_registry`.
- `make manpages-check` passes on the committed tree. Man pages regenerated for **both** products (start-cli and start-registry).
- TS bindings regenerated + prettier: zero diff against the committed state.
- `cargo fmt --all --check` clean; prettier clean on every markdown file touched.
- Grepped the regenerated roff for raw `about.`/`help.arg.` keys — none, so all five locales resolve. (`about.*`/`help.arg.*` are runtime-translated by `translate_cli`, not compile-checked, so a missing key would render literally in `--help` and in the committed man page.)

## Noted, deliberately not fixed here

- **The same defect shape exists in four other places**, each needing a different judgement call: `start-cli setup cifs` (its `verify` child is genuinely UI-only, so the fix is either an about + CLI path or not mounting the parent at all), and `start-container notification` / `plugin url`, which look like SDK-effect residue. Happy to take any of these in a follow-up.
- **`registry package remove`-style commands fail under on-host local auth.** `Auth::process_rpc_request` returns on the first successful middleware, and `LocalAuth` runs before `SignatureAuth` — which is the only thing that sets `__Auth_signer`. Run on the registry host with no `--registry`, `os asset remove` will report "Missing signer"; with an explicit remote `--registry` (the CI path) it works. Pre-existing and wider than this command — `registry package remove` and `remove-mirror` have the same shape — so I left it alone, but flagging it so the new error message isn't mistaken for a regression. Verified by reading the middleware chain, not against a live registry.
- **Moving `remove_api`/`remove_asset` out of `add.rs`** into a `remove.rs` (so `mod.rs` stops reading `add::remove_api`). `sign.rs`/`get.rs` do establish one-file-per-verb, but it is ~100 lines of churn git won't see as a rename, on top of a targeted bug fix. Say the word and I'll split it out.
