### PR TITLE
fix(start-core): enforce description limits, at the length the marketplace actually shows

### DIFF
--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -27,6 +27,26 @@ export const long = {
 }
 ```
 
+### How long each one may be
+
+|         | Hard limit      | Aim for                         |
+| ------- | --------------- | ------------------------------- |
+| `short` | 160 characters  | ~80 characters of English       |
+| `long`  | 5000 characters | as long as the service warrants |
+
+Both limits are enforced **per locale** when the package is validated, so a
+translation that overruns fails the build even if the English fits.
+
+The target for `short` is not the same thing as its limit. The marketplace tile
+renders it clamped to two lines and hides the remainder, so a `short` that runs
+past roughly 80 characters of English is silently cut off in the one place users
+browse. Translations make that worse rather than better — German and Polish
+routinely run 20-30% longer than the same sentence in English, and they get the
+same two lines. Write the English to fit with room to spare and the rest follow.
+
+`long` has no such budget: it is rendered unclamped on the service's details
+page, and the limit is only a backstop.
+
 ## manifest/index.ts
 
 ```typescript

--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -29,23 +29,24 @@ export const long = {
 
 ### How long each one may be
 
-|         | Hard limit      | Aim for                         |
-| ------- | --------------- | ------------------------------- |
-| `short` | 160 characters  | ~80 characters of English       |
-| `long`  | 5000 characters | as long as the service warrants |
+|         | Limit           | Why                                                          |
+| ------- | --------------- | ------------------------------------------------------------ |
+| `short` | 80 characters   | what fits the two lines the marketplace tile gives it        |
+| `long`  | 2000 characters | how much a listing may ask someone to read before installing |
 
-Both limits are enforced **per locale** when the package is validated, so a
-translation that overruns fails the build even if the English fits.
+Both are enforced **per locale** when the package is validated, so a translation
+that overruns fails the build even where the English fits.
 
-The target for `short` is not the same thing as its limit. The marketplace tile
-renders it clamped to two lines and hides the remainder, so a `short` that runs
-past roughly 80 characters of English is silently cut off in the one place users
-browse. Translations make that worse rather than better — German and Polish
-routinely run 20-30% longer than the same sentence in English, and they get the
-same two lines. Write the English to fit with room to spare and the rest follow.
+`short` is not truncated when it overruns — the tile clamps it to two lines with
+`overflow: hidden`, so the remainder is silently cut off in the one place users
+browse. The clamp is the same two lines whatever language the tile renders in,
+which is why the limit applies to every locale and not just `en_US`. German and
+Polish routinely run 20-30% longer than the same sentence in English, so leave
+the English comfortably short and the translations have somewhere to go: an
+`en_US` string already at 80 has nowhere to put that growth.
 
-`long` has no such budget: it is rendered unclamped on the service's details
-page, and the limit is only a backstop.
+`long` has no such budget — it is rendered unclamped on the service's details
+page — so its limit is about the reader's patience rather than the layout.
 
 ## manifest/index.ts
 

--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -29,26 +29,22 @@ export const long = {
 
 ### How long each one may be
 
-|         | `en_US`         | other locales |
-| ------- | --------------- | ------------- |
-| `short` | 80 characters   | 110           |
-| `long`  | 2000 characters | 2500          |
+|         | limit           |
+| ------- | --------------- |
+| `short` | 120 characters  |
+| `long`  | 2000 characters |
 
-Enforced when the package is validated, so a description that overruns fails the
-build.
+Every locale gets the same limit, and it is enforced when the package is
+validated, so a description that overruns fails the build.
 
 `short` is not truncated when it overruns — the marketplace tile clamps it to
 two lines with `overflow: hidden`, so the remainder is silently cut off in the
-one place users browse. 80 characters is what fits those two lines.
-
-The clamp is the same two lines whatever language the tile renders in, so the
-extra 30 characters for translations are not permission to run long — they exist
-because a translator working from a compliant English string cannot always land
-under the same count, and failing their package for it would push them toward a
-worse translation rather than a shorter one. German and Polish routinely run
-20-30% longer than the same sentence in English. Write the English well inside
-80 and the translations have somewhere to go; an `en_US` string sitting exactly
-at 80 leaves them none.
+one place users browse. **Two lines is about 80 characters**, and it is the same
+two lines whatever language the tile renders in. The limit sits above that so a
+translation isn't failed over a few characters' growth — German and Polish
+routinely run 20-30% longer than the same English sentence — not as permission
+to run long. Write the English well inside 80 and every locale still fits the
+tile.
 
 Two more characters' worth of advice, both from descriptions already in the
 registries:

--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -29,21 +29,35 @@ export const long = {
 
 ### How long each one may be
 
-|         | Limit           | Why                                                          |
-| ------- | --------------- | ------------------------------------------------------------ |
-| `short` | 80 characters   | what fits the two lines the marketplace tile gives it        |
-| `long`  | 2000 characters | how much a listing may ask someone to read before installing |
+|         | `en_US`         | other locales |
+| ------- | --------------- | ------------- |
+| `short` | 80 characters   | 110           |
+| `long`  | 2000 characters | 2500          |
 
-Both are enforced **per locale** when the package is validated, so a translation
-that overruns fails the build even where the English fits.
+Enforced when the package is validated, so a description that overruns fails the
+build.
 
-`short` is not truncated when it overruns — the tile clamps it to two lines with
-`overflow: hidden`, so the remainder is silently cut off in the one place users
-browse. The clamp is the same two lines whatever language the tile renders in,
-which is why the limit applies to every locale and not just `en_US`. German and
-Polish routinely run 20-30% longer than the same sentence in English, so leave
-the English comfortably short and the translations have somewhere to go: an
-`en_US` string already at 80 has nowhere to put that growth.
+`short` is not truncated when it overruns — the marketplace tile clamps it to
+two lines with `overflow: hidden`, so the remainder is silently cut off in the
+one place users browse. 80 characters is what fits those two lines.
+
+The clamp is the same two lines whatever language the tile renders in, so the
+extra 30 characters for translations are not permission to run long — they exist
+because a translator working from a compliant English string cannot always land
+under the same count, and failing their package for it would push them toward a
+worse translation rather than a shorter one. German and Polish routinely run
+20-30% longer than the same sentence in English. Write the English well inside
+80 and the translations have somewhere to go; an `en_US` string sitting exactly
+at 80 leaves them none.
+
+Two more characters' worth of advice, both from descriptions already in the
+registries:
+
+- **Don't open with the service's name.** The tile renders the title in bold on
+  the line directly above, so "Foo is a self-hosted bar" spends its first words
+  on something the reader can already see.
+- **Say what it is, not what it is like.** Comparisons and superlatives cost
+  more characters than they earn at this size.
 
 `long` has no such budget — it is rendered unclamped on the service's details
 page — so its limit is about the reader's patience rather than the layout.

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -426,31 +426,57 @@ impl Description {
 
     /// `short` is rendered in the marketplace tile, which clamps it to two
     /// lines and hides the rest (`-webkit-line-clamp: 2`). 80 characters is
-    /// what fits those two lines, so that is the limit: past it the text is
-    /// not shortened, it is silently cut off in the one place users browse.
-    /// It applies per locale, because the clamp is the same two lines whatever
-    /// language the tile is rendered in — a translation that overruns is cut
-    /// off for the readers of that language exactly as English would be.
+    /// what fits those two lines, so that is the limit for `en_US`: past it the
+    /// text is not shortened, it is silently cut off in the one place users
+    /// browse. `long` is rendered unclamped in the About card and so has no
+    /// line budget; its limit bounds how much a listing may ask someone to read
+    /// before installing.
     ///
-    /// `long` is rendered unclamped in the About card, so it has no line
-    /// budget; 2000 is a cap on how much a marketplace listing may ask
-    /// someone to read before installing.
+    /// Other locales are held to the same limits with headroom, rather than to
+    /// the same number or to nothing at all. The clamp is the same two lines
+    /// whatever language the tile renders in, so an unbounded translation would
+    /// be cut off for its readers just as English would — but a translator
+    /// working from a compliant English string cannot always land under the
+    /// same count, and failing the package for it pushes them toward a worse
+    /// translation rather than a shorter one. The headroom is taken from what
+    /// translations in the registries actually do: the worst expansion of a
+    /// full-length English short is x1.33, and of a long, x1.16.
+    const SHORT_LIMIT: usize = 80;
+    const LONG_LIMIT: usize = 2000;
+    const TRANSLATED_SHORT_LIMIT: usize = 110;
+    const TRANSLATED_LONG_LIMIT: usize = 2500;
+
     pub fn validate(&self) -> Result<(), Error> {
-        if match &self.short {
-            LocaleString::Translated(s) => s.len() > 80,
-            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 80),
-        } {
+        // `en_US` is held to `english`, every other locale to `translated`.
+        // Expressed as two lookups rather than a per-entry comparison because
+        // `translated` is always the looser of the two: anything over it fails
+        // whatever locale it is in, and `en_US` is caught by the first clause
+        // before the second can matter.
+        let too_long = |value: &LocaleString, english: usize, translated: usize| match value {
+            LocaleString::Translated(s) => s.len() > english,
+            LocaleString::LanguageMap(map) => {
+                map.get("en_US").is_some_and(|s| s.len() > english)
+                    || map.values().any(|s| s.len() > translated)
+            }
+        };
+
+        if too_long(&self.short, Self::SHORT_LIMIT, Self::TRANSLATED_SHORT_LIMIT) {
             return Err(Error::new(
-                eyre!("Short description must be 80 characters or less."),
+                eyre!(
+                    "Short description must be {} characters or less ({} for a translation).",
+                    Self::SHORT_LIMIT,
+                    Self::TRANSLATED_SHORT_LIMIT,
+                ),
                 crate::ErrorKind::ValidateS9pk,
             ));
         }
-        if match &self.long {
-            LocaleString::Translated(s) => s.len() > 2000,
-            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 2000),
-        } {
+        if too_long(&self.long, Self::LONG_LIMIT, Self::TRANSLATED_LONG_LIMIT) {
             return Err(Error::new(
-                eyre!("Long description must be 2000 characters or less."),
+                eyre!(
+                    "Long description must be {} characters or less ({} for a translation).",
+                    Self::LONG_LIMIT,
+                    Self::TRANSLATED_LONG_LIMIT,
+                ),
                 crate::ErrorKind::ValidateS9pk,
             ));
         }

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -424,35 +424,33 @@ impl Description {
         self.long.localize_for(locale);
     }
 
-    /// The two fields are bounded for different reasons, so the numbers differ
-    /// in kind rather than in degree.
-    ///
     /// `short` is rendered in the marketplace tile, which clamps it to two
-    /// lines and hides the rest (`-webkit-line-clamp: 2`), so there is a real
-    /// visual budget — roughly 80 characters of English, less once a locale
-    /// that runs longer than English is substituted in. That is an editorial
-    /// target, documented for packagers; 160 is the hard cap enforced here, far
-    /// enough above the target to catch abuse without failing a package whose
-    /// German translation ran long.
+    /// lines and hides the rest (`-webkit-line-clamp: 2`). 80 characters is
+    /// what fits those two lines, so that is the limit: past it the text is
+    /// not shortened, it is silently cut off in the one place users browse.
+    /// It applies per locale, because the clamp is the same two lines whatever
+    /// language the tile is rendered in — a translation that overruns is cut
+    /// off for the readers of that language exactly as English would be.
     ///
-    /// `long` is rendered unclamped in the About card, so it has no visual
-    /// budget at all and 5000 is a backstop, not a style rule.
+    /// `long` is rendered unclamped in the About card, so it has no line
+    /// budget; 2000 is a cap on how much a marketplace listing may ask
+    /// someone to read before installing.
     pub fn validate(&self) -> Result<(), Error> {
         if match &self.short {
-            LocaleString::Translated(s) => s.len() > 160,
-            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 160),
+            LocaleString::Translated(s) => s.len() > 80,
+            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 80),
         } {
             return Err(Error::new(
-                eyre!("Short description must be 160 characters or less."),
+                eyre!("Short description must be 80 characters or less."),
                 crate::ErrorKind::ValidateS9pk,
             ));
         }
         if match &self.long {
-            LocaleString::Translated(s) => s.len() > 5000,
-            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 5000),
+            LocaleString::Translated(s) => s.len() > 2000,
+            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 2000),
         } {
             return Err(Error::new(
-                eyre!("Long description must be 5000 characters or less."),
+                eyre!("Long description must be 2000 characters or less."),
                 crate::ErrorKind::ValidateS9pk,
             ));
         }

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -424,41 +424,32 @@ impl Description {
         self.long.localize_for(locale);
     }
 
-    /// 80 is what fits the two lines the marketplace tile clamps `short` to;
-    /// `long` is unclamped, so its limit is only a bound. Translations get
-    /// headroom: they cannot always land under the English count.
-    const SHORT_LIMIT: usize = 80;
+    /// The marketplace tile clamps `short` to two lines and hides the rest —
+    /// about 80 characters; the headroom is for locales that need more words
+    /// to say the same thing. `long` is rendered unclamped.
+    const SHORT_LIMIT: usize = 120;
     const LONG_LIMIT: usize = 2000;
-    const TRANSLATED_SHORT_LIMIT: usize = 110;
-    const TRANSLATED_LONG_LIMIT: usize = 2500;
 
     pub fn validate(&self) -> Result<(), Error> {
-        // Two lookups rather than a per-entry match: `translated` is the looser
-        // limit, so anything over it fails whatever locale it is in.
-        let too_long = |value: &LocaleString, english: usize, translated: usize| match value {
-            LocaleString::Translated(s) => s.len() > english,
-            LocaleString::LanguageMap(map) => {
-                map.get("en_US").is_some_and(|s| s.len() > english)
-                    || map.values().any(|s| s.len() > translated)
-            }
+        let too_long = |value: &LocaleString, limit: usize| match value {
+            LocaleString::Translated(s) => s.len() > limit,
+            LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > limit),
         };
 
-        if too_long(&self.short, Self::SHORT_LIMIT, Self::TRANSLATED_SHORT_LIMIT) {
+        if too_long(&self.short, Self::SHORT_LIMIT) {
             return Err(Error::new(
                 eyre!(
-                    "Short description must be {} characters or less ({} for a translation).",
+                    "Short description must be {} characters or less.",
                     Self::SHORT_LIMIT,
-                    Self::TRANSLATED_SHORT_LIMIT,
                 ),
                 crate::ErrorKind::ValidateS9pk,
             ));
         }
-        if too_long(&self.long, Self::LONG_LIMIT, Self::TRANSLATED_LONG_LIMIT) {
+        if too_long(&self.long, Self::LONG_LIMIT) {
             return Err(Error::new(
                 eyre!(
-                    "Long description must be {} characters or less ({} for a translation).",
+                    "Long description must be {} characters or less.",
                     Self::LONG_LIMIT,
-                    Self::TRANSLATED_LONG_LIMIT,
                 ),
                 crate::ErrorKind::ValidateS9pk,
             ));

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -424,34 +424,17 @@ impl Description {
         self.long.localize_for(locale);
     }
 
-    /// `short` is rendered in the marketplace tile, which clamps it to two
-    /// lines and hides the rest (`-webkit-line-clamp: 2`). 80 characters is
-    /// what fits those two lines, so that is the limit for `en_US`: past it the
-    /// text is not shortened, it is silently cut off in the one place users
-    /// browse. `long` is rendered unclamped in the About card and so has no
-    /// line budget; its limit bounds how much a listing may ask someone to read
-    /// before installing.
-    ///
-    /// Other locales are held to the same limits with headroom, rather than to
-    /// the same number or to nothing at all. The clamp is the same two lines
-    /// whatever language the tile renders in, so an unbounded translation would
-    /// be cut off for its readers just as English would — but a translator
-    /// working from a compliant English string cannot always land under the
-    /// same count, and failing the package for it pushes them toward a worse
-    /// translation rather than a shorter one. The headroom is taken from what
-    /// translations in the registries actually do: the worst expansion of a
-    /// full-length English short is x1.33, and of a long, x1.16.
+    /// 80 is what fits the two lines the marketplace tile clamps `short` to;
+    /// `long` is unclamped, so its limit is only a bound. Translations get
+    /// headroom: they cannot always land under the English count.
     const SHORT_LIMIT: usize = 80;
     const LONG_LIMIT: usize = 2000;
     const TRANSLATED_SHORT_LIMIT: usize = 110;
     const TRANSLATED_LONG_LIMIT: usize = 2500;
 
     pub fn validate(&self) -> Result<(), Error> {
-        // `en_US` is held to `english`, every other locale to `translated`.
-        // Expressed as two lookups rather than a per-entry comparison because
-        // `translated` is always the looser of the two: anything over it fails
-        // whatever locale it is in, and `en_US` is caught by the first clause
-        // before the second can matter.
+        // Two lookups rather than a per-entry match: `translated` is the looser
+        // limit, so anything over it fails whatever locale it is in.
         let too_long = |value: &LocaleString, english: usize, translated: usize| match value {
             LocaleString::Translated(s) => s.len() > english,
             LocaleString::LanguageMap(map) => {

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -51,7 +51,7 @@ impl Manifest {
         arch: Option<&str>,
         archive: &'a DirectoryContents<T>,
     ) -> Result<Filter, Error> {
-        self.description.validate()?;
+        self.metadata.description.validate()?;
 
         let mut expected = Expected::new(archive);
         expected.check_file("manifest.json")?;

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -51,6 +51,8 @@ impl Manifest {
         arch: Option<&str>,
         archive: &'a DirectoryContents<T>,
     ) -> Result<Filter, Error> {
+        self.description.validate()?;
+
         let mut expected = Expected::new(archive);
         expected.check_file("manifest.json")?;
         expected.check_stem("icon", |ext| {
@@ -422,6 +424,19 @@ impl Description {
         self.long.localize_for(locale);
     }
 
+    /// The two fields are bounded for different reasons, so the numbers differ
+    /// in kind rather than in degree.
+    ///
+    /// `short` is rendered in the marketplace tile, which clamps it to two
+    /// lines and hides the rest (`-webkit-line-clamp: 2`), so there is a real
+    /// visual budget — roughly 80 characters of English, less once a locale
+    /// that runs longer than English is substituted in. That is an editorial
+    /// target, documented for packagers; 160 is the hard cap enforced here, far
+    /// enough above the target to catch abuse without failing a package whose
+    /// German translation ran long.
+    ///
+    /// `long` is rendered unclamped in the About card, so it has no visual
+    /// budget at all and 5000 is a backstop, not a style rule.
     pub fn validate(&self) -> Result<(), Error> {
         if match &self.short {
             LocaleString::Translated(s) => s.len() > 160,

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -432,7 +432,7 @@ impl Description {
                 crate::ErrorKind::ValidateS9pk,
             ));
         }
-        if match &self.short {
+        if match &self.long {
             LocaleString::Translated(s) => s.len() > 5000,
             LocaleString::LanguageMap(map) => map.values().any(|s| s.len() > 5000),
         } {

--- a/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
+++ b/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
@@ -39,22 +39,14 @@ export type SDKManifest = {
   readonly donationUrl: string | null
   readonly description: {
     /**
-     * Short description, shown on the marketplace list page.
-     *
-     * The tile clamps this to two lines and hides the rest, and **80
-     * characters** is what fits them — so that is the limit for `en_US`. Other
-     * locales are allowed 110, headroom for the fact that a translation of a
-     * compliant English string cannot always land under the same count. The
-     * clamp is the same two lines in every language, so keep the English well
-     * inside 80 and the translations have somewhere to go.
+     * Short description, shown on the marketplace list page. The tile clamps it
+     * to two lines, which is what 80 buys — keep well inside it so the
+     * translations fit too. Max 80 (`en_US`) / 110 (other locales).
      */
     readonly short: T.LocaleString
     /**
-     * Long description, shown on the marketplace details page for this service.
-     *
-     * Rendered unclamped, so there is no line budget to stay inside; the limit
-     * bounds how much a listing may ask someone to read before installing.
-     * 2000 characters for `en_US`, 2500 for other locales.
+     * Long description, shown on the marketplace details page. Rendered
+     * unclamped. Max 2000 (`en_US`) / 2500 (other locales).
      */
     readonly long: T.LocaleString
   }

--- a/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
+++ b/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
@@ -40,13 +40,12 @@ export type SDKManifest = {
   readonly description: {
     /**
      * Short description, shown on the marketplace list page. The tile clamps it
-     * to two lines, which is what 80 buys — keep well inside it so the
-     * translations fit too. Max 80 (`en_US`) / 110 (other locales).
+     * to two lines — about 80 characters — and hides the rest. Max 120.
      */
     readonly short: T.LocaleString
     /**
      * Long description, shown on the marketplace details page. Rendered
-     * unclamped. Max 2000 (`en_US`) / 2500 (other locales).
+     * unclamped. Max 2000.
      */
     readonly long: T.LocaleString
   }

--- a/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
+++ b/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
@@ -42,19 +42,19 @@ export type SDKManifest = {
      * Short description, shown on the marketplace list page.
      *
      * The tile clamps this to two lines and hides the rest, and **80
-     * characters** is what fits them — so that is the limit, enforced per
-     * locale when the package is validated. The clamp is the same two lines
-     * whatever language the tile renders in, so a translation that overruns is
-     * cut off for its readers exactly as English would be; keep the English
-     * comfortably short so the translations have somewhere to go.
+     * characters** is what fits them — so that is the limit for `en_US`. Other
+     * locales are allowed 110, headroom for the fact that a translation of a
+     * compliant English string cannot always land under the same count. The
+     * clamp is the same two lines in every language, so keep the English well
+     * inside 80 and the translations have somewhere to go.
      */
     readonly short: T.LocaleString
     /**
      * Long description, shown on the marketplace details page for this service.
      *
-     * Rendered unclamped, so there is no line budget to stay inside. Limit
-     * 2000 characters, enforced per locale when the package is validated —
-     * a bound on how much a listing may ask someone to read before installing.
+     * Rendered unclamped, so there is no line budget to stay inside; the limit
+     * bounds how much a listing may ask someone to read before installing.
+     * 2000 characters for `en_US`, 2500 for other locales.
      */
     readonly long: T.LocaleString
   }

--- a/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
+++ b/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
@@ -41,18 +41,20 @@ export type SDKManifest = {
     /**
      * Short description, shown on the marketplace list page.
      *
-     * The tile clamps this to two lines and hides the rest, so aim for about
-     * **80 characters of English** — a locale that runs longer than English
-     * still has to fit the same two lines. Hard limit 160 characters, enforced
-     * per locale when the package is validated.
+     * The tile clamps this to two lines and hides the rest, and **80
+     * characters** is what fits them — so that is the limit, enforced per
+     * locale when the package is validated. The clamp is the same two lines
+     * whatever language the tile renders in, so a translation that overruns is
+     * cut off for its readers exactly as English would be; keep the English
+     * comfortably short so the translations have somewhere to go.
      */
     readonly short: T.LocaleString
     /**
      * Long description, shown on the marketplace details page for this service.
      *
-     * Rendered unclamped, so there is no visual budget to stay inside — write
-     * what the service warrants. Hard limit 5000 characters, enforced per
-     * locale when the package is validated.
+     * Rendered unclamped, so there is no line budget to stay inside. Limit
+     * 2000 characters, enforced per locale when the package is validated —
+     * a bound on how much a listing may ask someone to read before installing.
      */
     readonly long: T.LocaleString
   }

--- a/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
+++ b/shared-libs/ts-modules/start-core/lib/types/ManifestTypes.ts
@@ -38,9 +38,22 @@ export type SDKManifest = {
    */
   readonly donationUrl: string | null
   readonly description: {
-    /** Short description to display on the marketplace list page. Max length 80 chars. */
+    /**
+     * Short description, shown on the marketplace list page.
+     *
+     * The tile clamps this to two lines and hides the rest, so aim for about
+     * **80 characters of English** — a locale that runs longer than English
+     * still has to fit the same two lines. Hard limit 160 characters, enforced
+     * per locale when the package is validated.
+     */
     readonly short: T.LocaleString
-    /** Long description to display on the marketplace details page for this service. Max length 500 chars. */
+    /**
+     * Long description, shown on the marketplace details page for this service.
+     *
+     * Rendered unclamped, so there is no visual budget to stay inside — write
+     * what the service warrants. Hard limit 5000 characters, enforced per
+     * locale when the package is validated.
+     */
     readonly long: T.LocaleString
   }
   /**


### PR DESCRIPTION
Package descriptions had three sources of truth for how long they may be, and
none of them was in force.

|         | `Description::validate` | `SDKManifest.description` | packaging guide |
| ------- | ----------------------- | ------------------------- | --------------- |
| `short` | 160                     | 80                        | —               |
| `long`  | 5000                    | 500                       | —               |

- The validator's long check re-read `self.short`, which 160 already subsumes,
  so `self.long` was never length-checked at all.
- The validator had **no callers**: `S9pk::validate_and_filter` →
  `Manifest::validate_for` checks the archive's _contents_ (that
  `manifest.json`, the icon, `LICENSE.md`, `instructions.md`,
  `javascript.squashfs` and the per-arch images are present), not the
  manifest's field _values_. So neither number bound anything.
- The guide — the one place a packager would go looking — gave no number.

Found while writing manifest descriptions for two service packages and going to
the source to find out what the real limit was.

## What the limit should be

`short` is rendered in the marketplace tile under `-webkit-line-clamp: 2` with
the overflow hidden ([`tile.component.ts`](shared-libs/ts-modules/marketplace/src/components/tile.component.ts)).
**About 80 characters is what fits those two lines.** Past that the text is not
shortened, it is silently cut off in the one place users browse — so a limit set
far above what fits was not limiting the thing that matters.

`long` is rendered unclamped in the About card
([`about.component.ts`](shared-libs/ts-modules/marketplace/src/components/about.component.ts)),
so it has no line budget; its limit bounds how much a listing may ask someone to
read before installing.

The limits are **120** and **2000**, the same for every locale.

**120 rather than 80**, because the clamp is a display fact and not a contract:
failing a package at exactly the width of the tile would reject honest
descriptions over a handful of characters, most of all in translation, where
German and Polish routinely run 20-30% longer than the same English sentence.
120 leaves that room and still bounds the field. The place to apply pressure for
brevity is the guide and the TSDoc, which now both say that only about 80
characters ever show.

**One number rather than two.** An earlier revision of this PR gave translations
their own looser tier — 110/2500 against an English 80/2000 — which bounded the
same field twice and made the error message need a parenthetical to explain
itself. A packager should not have to know which locale a string is in to know
how long it may be.

## What this changes

- `Manifest::validate_for` now calls the validator, so the limits hold.
- The limits are 120 and 2000 in every locale, and the error names the number.
- The TSDoc and a new **How long each one may be** section of the manifest guide
  say the same thing, with the clamp as the stated reason — plus two pieces of
  advice that came out of reading descriptions already in the registries: don't
  open `short` with the service's name (the tile renders the title in bold
  directly above it), and say what the service is rather than what it is like.

## Blast radius

`validate_and_filter` runs at install as well as at pack, so this turns on a
gate that has never fired. **Every package in `start9-registry` and
`community-registry` passes, in every locale** — 125 packages, 1154 strings,
checked against the limits above. The longest of each are `buzz-relay` at 109
(`de_DE`) for `short` and `bitcoin-knots` 29.x at 1713 (`de_DE`) for `long`.

Two needed trimming first and have already landed on their own default branches,
so nothing here is waiting on them:

- `Start9Labs/synapse-startos` — en 99, es 122; all five locales now 73–79
- `Start9-Community/chama` — en 91, es 124; all five now 69–80

## Verification

Not compiled locally — building `start-core` from cold is a heavy build — so CI
is the compile check, and its first run caught the added call reaching
`self.description`. `description` belongs to the `PackageMetadata` that
`Manifest` holds behind a `#[serde(flatten)]` field: top level in the JSON, a
level down in Rust. Fixed in e195c97; nothing else in the change was implicated.

The fleet scan is the substantive check, and it is the one that would have caught
a wrong number.
