### PR TITLE
fix(start-os): warn on the DNS page when name resolution is broken

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -38,6 +38,16 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **The DNS page says so when your DNS servers cannot resolve anything.** A
+  server whose configured DNS never answers still routes traffic perfectly by
+  IP, so nothing looks wrong — but every service that reaches the internet by
+  name silently fails, and there was no indication anywhere in StartOS. This is
+  most likely on DHCP, where the servers come from a router that may filter DNS
+  or not serve it to every client. The page now resolves a name to check, and
+  warns when it cannot, pointing at the Static option. A warning about using a
+  gateway for private-domain resolution was also being computed and then thrown
+  away, so it never appeared at all; it does now.
+
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed
   at its LAN IP, or its `.local` name typed without the `.local` — was served

--- a/projects/start-os/docs/src/dns.md
+++ b/projects/start-os/docs/src/dns.md
@@ -17,6 +17,20 @@ To view or change the DNS servers StartOS uses, navigate to `System > DNS`. To o
 > [!NOTE]
 > If you want to use a specific DNS provider (such as Cloudflare or Quad9), it is generally better to configure it in your router so that all devices on your network benefit, not just your server.
 
+## When DNS is not working
+
+If your DNS servers do not answer, StartOS still reaches anything addressed by IP — so
+the server looks healthy — while every service that connects to the internet by name
+fails. Symptoms are unhelpfully varied: a service that cannot reach an update server, a
+Bitcoin node whose I2P router never finds peers, a download that never starts.
+
+The DNS page checks this for you and shows a warning when StartOS cannot resolve a name.
+
+This is most common on DHCP, where the servers come from your router. A router may filter
+DNS, hand out a server it does not actually run, or serve DNS only to certain clients. If
+you see the warning, select **Static** and enter a resolver you trust — your router's own
+IP if it does run one, or a public resolver such as `1.1.1.1` or `9.9.9.9`.
+
 ## Private Domains
 
 StartOS runs its own DNS server to resolve [private domains](private-domains.md) on your network. For setup details, see [DNS for Private Domains](private-domains.md#dns-for-private-domains).

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
@@ -4,10 +4,19 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms'
 import { RouterLink } from '@angular/router'
 import { DocsLinkDirective, i18nPipe, TaskService } from '@start9labs/shared'
 import { ISB } from '@start9labs/start-core'
-import { TuiButton, TuiTitle } from '@taiga-ui/core'
+import { TuiButton, TuiNotification, TuiTitle } from '@taiga-ui/core'
 import { TuiHeader } from '@taiga-ui/layout'
 import { PatchDB } from 'patch-db-client'
-import { combineLatest, first, switchMap } from 'rxjs'
+import {
+  catchError,
+  combineLatest,
+  defer,
+  first,
+  map,
+  of,
+  startWith,
+  switchMap,
+} from 'rxjs'
 import { FormGroupComponent } from 'src/app/routes/portal/components/form/containers/group.component'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
 import { FormService } from 'src/app/services/form.service'
@@ -63,6 +72,21 @@ const ipv6 =
 
         <form-group [spec]="d.spec" />
 
+        @if (resolves() === false) {
+          <p tuiNotification appearance="negative">
+            {{
+              'StartOS cannot resolve domain names with the current DNS servers. Services that reach the internet by name will fail.'
+                | i18n
+            }}
+            @if (d.dhcp) {
+              {{
+                'Your router is not providing a DNS server that answers. Select "Static" above and enter one.'
+                  | i18n
+              }}
+            }
+          </p>
+        }
+
         @for (warn of d.warn; track $index) {
           <p>{{ warn }}</p>
         }
@@ -106,6 +130,7 @@ const ipv6 =
     FormGroupComponent,
     TuiButton,
     TuiHeader,
+    TuiNotification,
     TuiTitle,
     RouterLink,
     TitleDirective,
@@ -159,6 +184,23 @@ export default class SystemDnsComponent {
     }),
   })
 
+  // Configured servers can be present and simply not answer — indistinguishable
+  // from a working setup until something asks — so this resolves a name rather
+  // than inspecting the list. Re-runs when the servers change, so saving a fix
+  // clears the warning. `null` while in flight: absence of an answer yet is not
+  // a failure.
+  protected readonly resolves = toSignal(
+    this.patch.watch$('serverInfo', 'network', 'dns').pipe(
+      switchMap(() =>
+        defer(() => this.api.queryDns({ fqdn: 'registry.start9.com' })).pipe(
+          map(res => !!res.ipv4 || !!res.ipv6),
+          catchError(() => of(false)),
+          startWith(null),
+        ),
+      ),
+    ),
+  )
+
   readonly data = toSignal(
     combineLatest([
       this.patch.watch$('packageData').pipe(first()),
@@ -185,31 +227,28 @@ export default class SystemDnsComponent {
 
         const form = this.formService.createForm(spec, { strategy: current })
 
-        let warn: string[] = []
-
-        if (
-          Object.values(pkgs).some(p =>
-            Object.values(p.hosts).some(
-              h => Object.keys(h?.privateDomains || {}).length,
-            ),
-          )
-        ) {
-          Object.values(gateways)
-            .filter(g =>
-              (dns.staticServers || dns.dhcpServers).some(d =>
-                g.ipInfo?.lanIp.includes(d),
-              ),
-            )
-            .map(
-              g =>
-                `${this.i18n.transform('Warning. StartOS is currently using the following gateway for DNS')}: ${g.ipInfo!.name}. ${this.i18n.transform('If you intend to use this gateway for private domain resolution, set alternative static DNS servers using the form above.')}`,
-            )
-        }
+        const warn = Object.values(pkgs).some(p =>
+          Object.values(p.hosts).some(
+            h => Object.keys(h?.privateDomains || {}).length,
+          ),
+        )
+          ? Object.values(gateways)
+              .filter(g =>
+                (dns.staticServers || dns.dhcpServers).some(d =>
+                  g.ipInfo?.lanIp.includes(d),
+                ),
+              )
+              .map(
+                g =>
+                  `${this.i18n.transform('Warning. StartOS is currently using the following gateway for DNS')}: ${g.ipInfo!.name}. ${this.i18n.transform('If you intend to use this gateway for private domain resolution, set alternative static DNS servers using the form above.')}`,
+              )
+          : []
 
         return {
           spec,
           form,
           warn,
+          dhcp: !dns.staticServers,
         }
       }),
     ),

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
@@ -11,6 +11,7 @@ import {
   catchError,
   combineLatest,
   defer,
+  distinctUntilChanged,
   first,
   map,
   of,
@@ -189,8 +190,14 @@ export default class SystemDnsComponent {
   // than inspecting the list. Re-runs when the servers change, so saving a fix
   // clears the warning. `null` while in flight: absence of an answer yet is not
   // a failure.
+  //
+  // Deduped because watch$ emits for a patch on the watched path OR any
+  // ancestor of it, and never compares values — so anything touching the busy
+  // /serverInfo/network subtree would otherwise re-probe and, via startWith,
+  // blink the warning off and back while DNS settings had not changed.
   protected readonly resolves = toSignal(
     this.patch.watch$('serverInfo', 'network', 'dns').pipe(
+      distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b)),
       switchMap(() =>
         defer(() => this.api.queryDns({ fqdn: 'registry.start9.com' })).pipe(
           map(res => !!res.ipv4 || !!res.ipv6),

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
@@ -805,4 +805,6 @@ export default {
   912: 'Die StartOS-Daten auf dem ausgewählten Datenlaufwerk befinden sich auf einer Partition neben einer älteren OS-Installation und können auf diesem Gerät nicht beibehalten werden. Um das Laufwerk zu löschen und neu zu beginnen, wählen Sie "Überschreiben".',
   913: 'Die StartOS-Daten auf dem ausgewählten Datenlaufwerk erstrecken sich über das gesamte Laufwerk, sodass das OS nicht auf demselben Laufwerk installiert werden kann, ohne sie zu löschen. Um Ihre Daten zu behalten, wählen Sie ein anderes OS-Laufwerk. Um sie zu löschen, wählen Sie "Überschreiben".',
   914: 'Anmeldung erfolgreich, aber der Server hat den neuen Geräteschlüssel abgelehnt. Versuchen Sie es erneut.',
+  915: 'StartOS kann mit den aktuellen DNS-Servern keine Domainnamen auflösen. Dienste, die das Internet über Namen erreichen, werden fehlschlagen.',
+  916: 'Ihr Router stellt keinen antwortenden DNS-Server bereit. Wählen Sie oben "Statisch" und geben Sie einen an.',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
@@ -806,4 +806,6 @@ export const ENGLISH: Record<string, number> = {
   'The StartOS data on the selected data drive is stored on a partition alongside an older OS installation, and cannot be preserved on this device. To erase the drive and start fresh, choose "Overwrite".': 912,
   'The StartOS data on the selected data drive spans the entire drive, so the OS cannot be installed to the same drive without erasing it. To preserve your data, select a different OS drive. To erase it, choose "Overwrite".': 913,
   'Login succeeded, but the server rejected the new device key. Try again.': 914,
+  'StartOS cannot resolve domain names with the current DNS servers. Services that reach the internet by name will fail.': 915,
+  'Your router is not providing a DNS server that answers. Select "Static" above and enter one.': 916,
 }

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
@@ -805,4 +805,6 @@ export default {
   912: 'Los datos de StartOS en la unidad de datos seleccionada están en una partición junto a una instalación de SO anterior, y no pueden conservarse en este dispositivo. Para borrar la unidad y empezar de nuevo, elija "Sobrescribir".',
   913: 'Los datos de StartOS en la unidad de datos seleccionada ocupan toda la unidad, por lo que el SO no puede instalarse en la misma unidad sin borrarlos. Para conservar sus datos, seleccione otra unidad para el SO. Para borrarlos, elija "Sobrescribir".',
   914: 'Inicio de sesión correcto, pero el servidor rechazó la nueva clave del dispositivo. Inténtelo de nuevo.',
+  915: 'StartOS no puede resolver nombres de dominio con los servidores DNS actuales. Los servicios que acceden a internet por nombre fallarán.',
+  916: 'Su router no está proporcionando un servidor DNS que responda. Seleccione "Estático" arriba e introduzca uno.',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
@@ -805,4 +805,6 @@ export default {
   912: 'Les données StartOS du disque de données sélectionné se trouvent sur une partition aux côtés d’une ancienne installation de l’OS et ne peuvent pas être conservées sur cet appareil. Pour effacer le disque et repartir à zéro, choisissez « Écraser ».',
   913: 'Les données StartOS du disque de données sélectionné occupent l’intégralité du disque : l’OS ne peut donc pas être installé sur le même disque sans les effacer. Pour conserver vos données, sélectionnez un autre disque pour l’OS. Pour les effacer, choisissez « Écraser ».',
   914: 'Connexion réussie, mais le serveur a rejeté la nouvelle clé de l’appareil. Réessayez.',
+  915: 'StartOS ne peut pas résoudre les noms de domaine avec les serveurs DNS actuels. Les services qui accèdent à internet par nom échoueront.',
+  916: 'Votre routeur ne fournit pas de serveur DNS qui répond. Sélectionnez « Statique » ci-dessus et indiquez-en un.',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
@@ -805,4 +805,6 @@ export default {
   912: 'Dane StartOS na wybranym dysku danych znajdują się na partycji obok starszej instalacji systemu i nie można ich zachować na tym urządzeniu. Aby wymazać dysk i zacząć od nowa, wybierz „Nadpisz”.',
   913: 'Dane StartOS na wybranym dysku danych zajmują cały dysk, więc systemu nie można zainstalować na tym samym dysku bez ich wymazania. Aby zachować dane, wybierz inny dysk systemowy. Aby je wymazać, wybierz „Nadpisz”.',
   914: 'Logowanie powiodło się, ale serwer odrzucił nowy klucz urządzenia. Spróbuj ponownie.',
+  915: 'StartOS nie może rozwiązywać nazw domen przy obecnych serwerach DNS. Usługi łączące się z internetem po nazwie będą zawodzić.',
+  916: 'Twój router nie udostępnia działającego serwera DNS. Wybierz powyżej „Statyczny” i podaj własny.',
 } satisfies i18n


### PR DESCRIPTION
## What happens today

A server whose configured DNS servers don't answer still routes everything addressed by IP, so it looks healthy from every angle a user can see — while every service that reaches the internet **by name** fails. Nothing in StartOS says so.

This came out of [bitcoin-core-startos#261](https://github.com/Start9Labs/bitcoin-core-startos/issues/261), which took days to pin down. The reporter's box: a raw-IP HTTPS request connected in 10 ms, and every name failed instantly. The visible symptom was a Bitcoin node whose embedded i2pd never joined the I2P network — because reseed servers are addressed by hostname, and nothing else on the box happened to need DNS. `bitcoind` itself was unaffected, since it resolves through Tor's SOCKS proxy and never asks the local resolver.

Containers point at `10.0.3.1`, which is StartOS, which forwards to upstreams learned from `/run/systemd/resolve/resolv.conf` plus any static servers. With no usable upstream those queries fail immediately. That is invisible until something needs a name.

## The change

**Resolve a name to check, rather than inspecting the configured list.** Those are different questions: servers can be present, well-formed, and simply not reply — precisely the DHCP case, where the list comes from a router that may filter DNS, hand out a resolver it doesn't run, or serve DNS only to certain clients. A config check would have called the reporter's box fine.

It reuses the existing `net.dns.query` RPC (already on `ApiService`, already used by domain validation), keyed off the DNS settings so it re-runs when they change — saving a fix clears the warning with no extra machinery. It reports nothing while in flight, since "no answer yet" isn't a failure. The extra line pointing at **Static** shows only on DHCP, where that's the actionable advice.

**On how often it probes** — only while the page is open, and only when the settings actually change. That second part needs `distinctUntilChanged`, because `watch$` is looser than it looks:

```ts
// patch-db.ts, handleRevision
const match = patchArrs.find(
  ({ arr }) => startsWith(pathArr, arr) || startsWith(arr, pathArr),
)
```

`startsWith(pathArr, arr)` is the **ancestor** case, so a patch to `/serverInfo/network` — gateways, IP info, interfaces, all busy — fires a watch on `/serverInfo/network/dns`. A full dump re-emits every watched node unconditionally, and `updateWatchedNode` calls `subject.next` without comparing. Undeduped, the probe re-ran on unrelated churn and `startWith(null)` blinked the warning off and back each time — worst on precisely the boxes it exists for, where each probe blocks on a resolver that never answers.

## Drive-by: a warning that could never appear

```ts
let warn: string[] = []
if (…) {
  Object.values(gateways).filter(…).map(g => `…`)   // result discarded
}
```

The private-domain gateway warning was computed and thrown away — `warn` was always `[]`, so that message has never rendered for anyone. Now assigned.

## Verification

- `npm run check:ui` — clean
- `npm run check:i18n` — clean (805 keys)
- `npx prettier --check` — clean
- `TuiNotification` and the `tuiNotification appearance="…"` form verified against existing fleet usage rather than assumed — my first attempt used `tuiNotification="negative"`, which isn't the API.

Not manually exercised against a running server, so the probe path is unverified end to end — worth a look on a box where DNS is deliberately broken.

Docs (`docs/src/dns.md`) and `CHANGELOG.md` updated in the same change; `0.4.0.2` has no origin tag, so the entry goes under the existing heading.