### PR TITLE
fix(web): trim surrounding whitespace from text inputs

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -38,6 +38,8 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- Trim whitespace on form inputs.
+
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed
   at its LAN IP, or its `.local` name typed without the `.local` — was served

--- a/projects/start-os/web/ui/src/app/routes/portal/components/form.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/form.component.ts
@@ -12,7 +12,7 @@ import { injectContext } from '@taiga-ui/polymorpheus'
 import { Operation } from 'fast-json-patch'
 import { FormGroupComponent } from 'src/app/routes/portal/components/form/containers/group.component'
 import { InvalidService } from 'src/app/routes/portal/components/form/containers/control.directive'
-import { FormService } from 'src/app/services/form.service'
+import { FormService, trim } from 'src/app/services/form.service'
 
 export interface ActionButton<T> {
   text: string
@@ -144,6 +144,7 @@ export class FormComponent<T extends Record<string, any>> implements OnInit {
   }
 
   async onClick(handler: Required<ActionButton<T>>['handler']) {
+    trim(this.form)
     tuiMarkControlAsTouchedAndValidate(this.form)
     this.invalidService.scrollIntoView()
 

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/dns/dns.component.ts
@@ -1,16 +1,21 @@
 import { Component, inject } from '@angular/core'
 import { toSignal } from '@angular/core/rxjs-interop'
-import { FormsModule, ReactiveFormsModule } from '@angular/forms'
+import {
+  FormsModule,
+  ReactiveFormsModule,
+  UntypedFormGroup,
+} from '@angular/forms'
 import { RouterLink } from '@angular/router'
 import { DocsLinkDirective, i18nPipe, TaskService } from '@start9labs/shared'
 import { ISB } from '@start9labs/start-core'
+import { tuiMarkControlAsTouchedAndValidate } from '@taiga-ui/cdk'
 import { TuiButton, TuiTitle } from '@taiga-ui/core'
 import { TuiHeader } from '@taiga-ui/layout'
 import { PatchDB } from 'patch-db-client'
 import { combineLatest, first, switchMap } from 'rxjs'
 import { FormGroupComponent } from 'src/app/routes/portal/components/form/containers/group.component'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
-import { FormService } from 'src/app/services/form.service'
+import { FormService, trim } from 'src/app/services/form.service'
 import { DataModel } from 'src/app/services/patch-db/data-model'
 import { TitleDirective } from 'src/app/services/title.service'
 import { configBuilderToSpec } from 'src/app/utils/configBuilderToSpec'
@@ -71,8 +76,8 @@ const ipv6 =
           <button
             tuiButton
             size="l"
-            [disabled]="d.form.invalid || d.form.pristine"
-            (click)="save(d.form.value)"
+            [disabled]="d.form.pristine"
+            (click)="save(d.form)"
           >
             {{ 'Save' | i18n }}
           </button>
@@ -215,7 +220,14 @@ export default class SystemDnsComponent {
     ),
   )
 
-  async save({ strategy }: typeof this.dnsSpec._TYPE): Promise<void> {
+  async save(form: UntypedFormGroup): Promise<void> {
+    trim(form)
+    tuiMarkControlAsTouchedAndValidate(form)
+
+    if (form.invalid) return
+
+    const { strategy } = form.value as typeof this.dnsSpec._TYPE
+
     this.tasks.run(
       async () =>
         await this.api.setDns({

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/smtp/smtp.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/system/routes/smtp/smtp.component.ts
@@ -1,6 +1,10 @@
 import { CommonModule } from '@angular/common'
 import { Component, inject } from '@angular/core'
-import { FormControl, ReactiveFormsModule } from '@angular/forms'
+import {
+  FormControl,
+  ReactiveFormsModule,
+  UntypedFormGroup,
+} from '@angular/forms'
 import { RouterLink } from '@angular/router'
 import {
   DialogService,
@@ -10,13 +14,14 @@ import {
   TaskService,
 } from '@start9labs/shared'
 import { inputSpec, ISB, utils } from '@start9labs/start-core'
+import { tuiMarkControlAsTouchedAndValidate } from '@taiga-ui/cdk'
 import { TuiButton, TuiError, TuiInput, TuiTitle } from '@taiga-ui/core'
 import { TuiHeader } from '@taiga-ui/layout'
 import { PatchDB } from 'patch-db-client'
 import { switchMap } from 'rxjs'
 import { FormGroupComponent } from 'src/app/routes/portal/components/form/containers/group.component'
 import { ApiService } from 'src/app/services/api/embassy-api.service'
-import { FormService } from 'src/app/services/form.service'
+import { FormService, trim } from 'src/app/services/form.service'
 import { DataModel } from 'src/app/services/patch-db/data-model'
 import { TitleDirective } from 'src/app/services/title.service'
 import { configBuilderToSpec } from 'src/app/utils/configBuilderToSpec'
@@ -88,8 +93,8 @@ function detectProviderKey(host: string | undefined): string {
           <button
             tuiButton
             size="l"
-            [disabled]="data.form.invalid || data.form.pristine"
-            (click)="save(data.form.value)"
+            [disabled]="data.form.pristine"
+            (click)="save(data.form)"
           >
             {{ 'Save' | i18n }}
           </button>
@@ -122,9 +127,7 @@ function detectProviderKey(host: string | undefined): string {
               tuiButton
               type="button"
               size="l"
-              [disabled]="
-                !testEmailControl.value || isEmailInvalid || data.form.invalid
-              "
+              [disabled]="!testEmail || isEmailInvalid || data.form.invalid"
               (click)="sendTestEmail(data.form.value)"
             >
               {{ 'Send' | i18n }}
@@ -180,9 +183,12 @@ export default class SystemEmailComponent {
   private readonly emailRegex = new RegExp(utils.Patterns.email.regex)
   readonly testEmailControl = new FormControl('')
 
+  get testEmail(): string {
+    return this.testEmailControl.value?.trim() || ''
+  }
+
   get isEmailInvalid(): boolean {
-    const value = this.testEmailControl.value
-    return !!value && !this.emailRegex.test(value)
+    return !!this.testEmail && !this.emailRegex.test(this.testEmail)
   }
 
   private readonly smtpSpec = ISB.InputSpec.of({
@@ -243,7 +249,14 @@ export default class SystemEmailComponent {
     }
   }
 
-  async save(formValue: Record<string, any>): Promise<void> {
+  async save(form: UntypedFormGroup): Promise<void> {
+    trim(form)
+    tuiMarkControlAsTouchedAndValidate(form)
+
+    if (form.invalid) return
+
+    const formValue = form.value as Record<string, any>
+
     this.tasks.run(async () => {
       if (formValue['smtp'].selection === 'disabled') {
         await this.api.clearSmtp({})
@@ -262,7 +275,7 @@ export default class SystemEmailComponent {
 
   async sendTestEmail(formValue: Record<string, any>) {
     const smtpValue = this.getSmtpValue(formValue)
-    const address = this.testEmailControl.value!
+    const address = this.testEmail
     const success =
       `${this.i18n.transform('A test email has been sent to')} ${address}. <i>${this.i18n.transform('Check your spam folder and mark as not spam.')}</i>` as i18nKey
 

--- a/projects/start-os/web/ui/src/app/services/form.service.ts
+++ b/projects/start-os/web/ui/src/app/services/form.service.ts
@@ -1,5 +1,8 @@
 import { inject, Injectable } from '@angular/core'
 import {
+  AbstractControl,
+  FormArray,
+  FormGroup,
   UntypedFormArray,
   UntypedFormBuilder,
   UntypedFormControl,
@@ -516,45 +519,10 @@ function isListObject(
   return 'uniqueBy' in spec
 }
 
-export function convertValuesRecursive(
-  configSpec: IST.InputSpec,
-  group: UntypedFormGroup,
-) {
-  Object.entries(configSpec).forEach(([key, valueSpec]) => {
-    const control = group.get(key)
-
-    if (!control) return
-
-    if (valueSpec.type === 'number') {
-      control.setValue(
-        control.value || control.value === 0 ? Number(control.value) : null,
-      )
-    } else if (valueSpec.type === 'text' || valueSpec.type === 'textarea') {
-      if (!control.value) control.setValue(null)
-    } else if (valueSpec.type === 'object') {
-      convertValuesRecursive(valueSpec.spec, group.get(key) as UntypedFormGroup)
-    } else if (valueSpec.type === 'union') {
-      const formGr = group.get(key) as UntypedFormGroup
-      const value = formGr.controls['selection']?.value
-      const spec = !!value && valueSpec.variants[value]?.spec
-
-      if (spec) {
-        convertValuesRecursive(spec, formGr)
-      }
-    } else if (valueSpec.type === 'list') {
-      const formArr = group.get(key) as UntypedFormArray
-      const { controls } = formArr
-
-      if (valueSpec.spec.type === 'text') {
-        controls.forEach(control => {
-          if (!control.value) control.setValue(null)
-        })
-      } else if (valueSpec.spec.type === 'object') {
-        controls.forEach(formGroup => {
-          const objectSpec = valueSpec.spec as IST.ListValueSpecObject
-          convertValuesRecursive(objectSpec.spec, formGroup as UntypedFormGroup)
-        })
-      }
-    }
-  })
+export function trim(control: AbstractControl) {
+  if (control instanceof FormGroup || control instanceof FormArray) {
+    Object.values(control.controls).forEach(trim)
+  } else if (typeof control.value === 'string') {
+    control.setValue(control.value.trim() || null)
+  }
 }

--- a/shared-libs/ts-modules/marketplace/src/pipes/filter-packages.pipe.ts
+++ b/shared-libs/ts-modules/marketplace/src/pipes/filter-packages.pipe.ts
@@ -15,6 +15,8 @@ export function filterPackages(
   category: string | null = '',
   sort: string | null = '',
 ): MarketplacePkg[] {
+  query = query?.trim() || ''
+
   // query
   if (query) {
     let options: Fuse.IFuseOptions<MarketplacePkg> = {


### PR DESCRIPTION
Closes the Add Public Domain report. **+56/−58.**

## Why the trim couldn't just go in the handler

`FormComponent.onClick` gates the handler on validity:

```ts
if (this.form.valid && (await handler(this.form.value as T))) {
```

The domain field's pattern is anchored, so ` domain.com ` is invalid and the handler is never reached. Measured before any change: type a padded domain, click Save, dialog stays open, nothing saved. So the trim goes in `onClick`, before `tuiMarkControlAsTouchedAndValidate`.

(Related: `configBuilderToSpec` is `builder.build({}).then(a => a.spec)` — it keeps the spec and discards the validator. `Value.map()` writes its transform to the validator, so the `.map(f => f.toLowerCase())` on that field has never run in the UI. `.map(f => f.trim())` compiles and does nothing.)

## The change

**Trim on submit, always.** A generic 7-line walk of the `FormGroup`/`FormArray` tree in `form.service.ts`, called from `FormComponent.onClick`. No spec, no exclusions — masked and textarea fields are trimmed too.

**DNS and SMTP now allow clicking Save while invalid.** They bound `[disabled]="form.invalid || form.pristine"`, which would have put the trim out of reach: a padded value disabled the very button whose handler trims it. Both now match `FormComponent` and the documented house pattern — Save stays enabled, and clicking it trims, marks every control touched, and surfaces the errors, instead of leaving a dead button and no explanation.

**Two inputs outside the form stack.** Marketplace search: queries ≥4 chars go through fuse.js extended search as `` `'${query}` ``, so a *leading* space makes ` bitcoin` an exact-include of `" bitcoin"` and returns nothing (verified against the repo's fuse.js 6.6.2 — `lnd` finds LND, ` lnd` returns `[]`; a trailing space is harmless). And the SMTP test-email field, validated against the same anchored email pattern.

**Deletes `convertValuesRecursive`** — no callers, and its union branch walked the wrapper group instead of its `value` child.

## Verification

Headless Chromium against the mock backend:

```
PASS  Add Public Domain saves padded value via click
PASS  Add Public Domain saves padded value via enter
PASS  DNS Save is clickable while padded value is invalid
PASS  DNS padded value is trimmed on save  [8.8.8.8]
PASS  DNS shows no error after saving a good value
PASS  DNS Save is clickable with a genuinely invalid value
PASS  DNS shows no error before clicking Save
PASS  DNS surfaces the validation error after clicking Save
```

Before the change, the same flow left the dialog open with "Must be a valid Fully Qualified Domain Name" against a value that looked correct.

`npm run check` (all 5 apps + i18n), `prettier --check`, and a production `ng build` of `ui` pass.

## One thing that needs a decision

Trimming masked fields means the **master password change form** now trims, while `login.page.ts` submits the typed password **raw**. So someone who pastes a padded password sets `hunter2` and is then rejected when they paste the same padded string at login.

Trimming at login too (one line) makes it consistent — and matches `PromptModal`, which already trims — but locks out anyone who *already* has boundary whitespace in their password, since the stored hash is of the untrimmed string. Happy to do either; flagging rather than choosing.

Same class, lower stakes: WPA passphrases and CIFS/SMB backup passwords are credentials for external systems where a trailing space is legal and we don't control the stored value.
