### PR TITLE
fix(core): create granted device nodes with the host's permissions

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -40,6 +40,16 @@ file tracks notable changes since the move to the monorepo.
 
 - Trim whitespace on form inputs.
 
+- **Services that run their own containers or a VPN can reach the devices they
+  were granted.** A service opting into `userspaceFilesystems` or
+  `virtualNetworking` is handed `/dev/fuse` and `/dev/net/tun` inside its
+  container. Those nodes are now created with the same permissions the host
+  gives them, so a service running as a non-root user can open them. Previously
+  the permissions were left to whatever StartOS's own file-creation mask
+  produced, and only the container's boot-time device pass — which races with
+  the grant — widened them; on the losing side of that race a CI runner's jobs
+  failed to start with `Failed to open() /dev/net/tun: Permission denied`.
+
 - **Your server answers to its own addresses and no others.** A name that
   resolved to your server but was never configured on it — a domain you pointed
   at its LAN IP, or its `.local` name typed without the `.local` — was served

--- a/projects/start-sdk/docs/src/recipe-nested-oci-runtime.md
+++ b/projects/start-sdk/docs/src/recipe-nested-oci-runtime.md
@@ -47,7 +47,7 @@ With `userspaceFilesystems` and `virtualNetworking` set, the per-service LXC get
 
 `virtualNetworking` additionally grants `CAP_NET_ADMIN` (scoped to the container's user namespace). A rootless OCI engine using `slirp4netns`/`pasta` doesn't strictly need it, but the tun device and the capability are bundled under the one flag; the grant is namespaced and harmless here.
 
-Both devices are bind-mounted from the host (via the same machinery that handles `hardwareAcceleration` for GPU nodes). The host's `fuse` and `tun` kernel modules are auto-loaded at boot.
+Both devices are re-created inside the container with the host node's device numbers and permissions, then bind-mounted onto their usual `/dev` paths (via the same machinery that handles `hardwareAcceleration` for GPU nodes). The host's `fuse` and `tun` kernel modules are auto-loaded at boot.
 
 The host-level sysctls `kernel.unprivileged_userns_clone=1` and `user.max_user_namespaces=28633` are pinned at install time so unprivileged user-namespace creation is allowed and headroom for nested namespaces is reserved.
 

--- a/shared-libs/crates/start-core/src/lxc/mod.rs
+++ b/shared-libs/crates/start-core/src/lxc/mod.rs
@@ -389,7 +389,8 @@ impl LxcContainer {
                         let rdev = meta.st_rdev();
                         let major = ((rdev >> 8) & 0xfff) as u32;
                         let minor = ((rdev & 0xff) | ((rdev >> 12) & 0xfff00)) as u32;
-                        self.mknod(&path, ty, major, minor).await?;
+                        self.mknod(&path, ty, major, minor, meta.st_mode() & 0o7777)
+                            .await?;
                     }
                 }
             }
@@ -576,7 +577,16 @@ impl LxcContainer {
         Ok(UnixRpcClient::new(sock_path))
     }
 
-    pub async fn mknod(&self, path: &Path, ty: char, major: u32, minor: u32) -> Result<(), Error> {
+    pub async fn mknod(
+        &self,
+        path: &Path,
+        ty: char,
+        major: u32,
+        minor: u32,
+        mode: u32,
+    ) -> Result<(), Error> {
+        // -m so the node carries the host's mode instead of `0666 & ~umask(startd)`.
+        let mode = format!("{mode:04o}");
         if let Ok(dev_rel) = path.strip_prefix("/dev") {
             let parent = dev_rel.parent();
             let media_dev = self.rootfs_dir().join("media/startos/dev");
@@ -598,6 +608,8 @@ impl LxcContainer {
                 }
             }
             Command::new("mknod")
+                .arg("-m")
+                .arg(&mode)
                 .arg(&target_path)
                 .arg(&*InternedString::from_display(&ty))
                 .arg(&*InternedString::from_display(&major))
@@ -643,6 +655,8 @@ impl LxcContainer {
                 return Ok(());
             }
             Command::new("mknod")
+                .arg("-m")
+                .arg(&mode)
                 .arg(&target_path)
                 .arg(&*InternedString::from_display(&ty))
                 .arg(&*InternedString::from_display(&major))


### PR DESCRIPTION
Fixes the OS-side cause of [Start9Labs/gitea-runner-startos#13](https://github.com/Start9Labs/gitea-runner-startos/issues/13) — every CI job failing before its first step with:

```
pasta failed with exit code 1:
Failed to open() /dev/net/tun: Permission denied
Failed to set up tap device in namespace
```

## The bug

`LxcContainer::mknod` (`shared-libs/crates/start-core/src/lxc/mod.rs:600`) shells out to coreutils `mknod` with no `-m`, so the node is created at `0666 & ~umask(startd)`. `startd.service` sets no `UMask=`, so systemd's default 0022 applies and the node lands **0644**, owned by uid 0 of the container's userns. A service running as a non-root user is neither owner nor group, so `other` applies — `r--` — and `open(O_RDWR)` returns EACCES. `CAP_DAC_OVERRIDE` can't rescue it either: in the nested userns a rootless engine creates, the owning uid is unmapped.

`handle_devices` already stats the host node for `st_rdev` and throws its mode away, so the host's 0666 never reaches the container.

## Why it's intermittent, and why nobody noticed

The guest repairs it by accident. The container-runtime rootfs is Debian, whose systemd ships `/usr/lib/tmpfiles.d/static-nodes-permissions.conf`:

```
z /dev/net/tun      0666 - -     -
z /dev/fuse         0666 - -     -
```

`systemd-tmpfiles-setup-dev.service` chmods the bind-mounted inode back to 0666, and that propagates to the host-side node and into every subcontainer's `mount --rbind /dev`.

But `handle_devices` runs *after* `lxc-start -d` returns, concurrently with the guest's boot, and tmpfiles `z` only adjusts paths that **already exist** — it never creates. So the two race. Win it and the node is 0666; lose it and the node keeps 0644 for the entire life of that container, and every restart re-rolls (a fresh LXC, a fresh node).

Measured on a 0.4.0 VM, instrumenting `mknod`:

```
AT-CREATION mode=644 path=.../media/startos/dev/net/tun
systemd-tmpfiles-setup-dev.service: Finished    (~30 ms later)
mode NOW: 666
```

Forcing the losing side — `chmod 0644` on that node, then restarting the service — reproduces the report verbatim, and `slirp4netns` fails identically (`open("/dev/net/tun"): Permission denied`), since both backends open the same node. `--network=host` and `--network=none` keep working. `chmod 0666` restores it.

## The fix

Pass the host node's mode through to `mknod -m`, which sets the mode explicitly instead of through the umask.

- `/dev/fuse` and `/dev/net/tun` → 0666, matching the host and matching what `recipe-nested-oci-runtime.md` already promises.
- `/dev/dri/*` and `/dev/kfd` → the host's 0660, rather than being widened to 0666. Owner is still container-root, so nothing changes for the four GPU packages, which all run as root — and that is exactly why a defect present since the `hardwareAcceleration` grant landed stayed invisible. The two CI-runner packages are the only ones in either org that combine a device grant with a non-root consumer.

Also corrects the recipe's claim that the devices are "bind-mounted from the host" — they are re-created inside the container and bind-mounted internally, which is the whole reason the mode has to be set.

## Verification

- `cargo check -p start-core` clean; `cargo fmt --check` clean.
- Root cause and reproduction measured end-to-end on a StartOS 0.4.0 VM (`git-info 514af0c`) with a package carrying both flags and a uid-1000 consumer: 0644 → both rootless network backends fail with the reported error; 0666 → `podman run` succeeds under pasta, slirp4netns, none and host.
- `mknod -m` bypassing the umask verified on the same box: `umask 0022; mknod -m 0666` → 666, `-m 0660` → 660.

The two runner packages ship a `chmod` workaround so users on released 0.4.0/0.4.0.1 aren't blocked; it becomes redundant once this lands.