### PR TITLE
docs(start-sdk): scaffold new packages against the README contract

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -38,6 +38,41 @@
   into a position whose type it does not match. Passing either positionally is
   now a compile error, so anything that needs updating says so at build time
 
+- **Service READMEs now have a fixed section contract, and the scaffolded
+  template matches it.** A package README is the only technical file an AI
+  support agent is given, and the file an assistant administering a server
+  reads to operate a service — so its headings are an addressing scheme that
+  lets an agent fetch one section instead of a whole file, not a style choice.
+  A renamed section does not fail loudly; it silently degrades retrieval to
+  loading everything. The set is now fixed and ordered in four groups, gaining
+  `File Models` (replacing `Configuration Management`, which named an
+  abstraction rather than the config files it covers), `Tasks`, and
+  `Troubleshooting`, and losing `Contributing` and `What Is Unchanged from
+Upstream` — the first is boilerplate identical in every package and already
+  in `AGENTS.md`, the second an unbounded list that inverts the scoping note
+  at the top of the file, which already says everything unmentioned behaves as
+  upstream. Sections must not restate `instructions.md` (upstream
+  documentation links belong only in its `## Documentation` section, which is
+  parsed) or re-encode what StartOS already exposes — action ids,
+  descriptions, warnings, `allowedStatuses`, input schemas, health-check ids.
+  Document instead what the ABI cannot carry: when to run a thing, what it
+  costs, whether it is safe to repeat, what it changes, and which symptom it
+  resolves. See
+  [Writing Service READMEs](https://docs.start9.com/packaging/writing-readmes.html)
+
+- **A package's `AGENTS.md` is now scoped to what only a contributor needs.** It
+  had drifted into a third description of the package, restating whole README
+  sections nearly verbatim — and it is the one documentation file no support or
+  administering agent ever reads, so anything support-relevant that landed there
+  was invisible exactly where it was needed. It now carries only what the other
+  two files cannot: repo mechanics, prohibitions worth stating as imperatives,
+  extension points, naming traps, and build invocations specific to the package.
+  Most packages want one to four bullets; a simple one wants none. The scaffolded
+  template accordingly no longer ships an "Inspecting a running install" section
+  — `start-cli package attach`'s `-n`-takes-a-name versus `-s`-takes-a-Guid trap
+  is guide material rather than per-package boilerplate, and now lives in
+  [Development Workflow](https://docs.start9.com/packaging/workflow.html)
+
 ### Added
 
 - **`addDaemon()` / `addOneshot()` accept a `uses` value that

--- a/projects/start-sdk/docs/package-template/AGENTS.md
+++ b/projects/start-sdk/docs/package-template/AGENTS.md
@@ -12,8 +12,23 @@ admin credentials", "expose a web UI") to the constructs, the reference pages, a
 package to copy. Find the recipe before you read this package's neighbours: a package you reach by
 grepping may be non-conformant, and the recipe outranks it.
 
-Work this package's `TODO.md` from top to bottom. Keep `README.md` (architecture, for developers and LLMs) and `instructions.md` (end-user docs) in sync with your changes.
+Work this package's `TODO.md` from top to bottom. Keep `README.md` (the package's technical reference — the only one an AI support or administering agent reads) and `instructions.md` (end-user docs) in sync with your changes.
 
-## Inspecting a running install
+## This repo
 
-To run a command inside a service's container (read its generated config, grep app logs), use `start-cli package attach <id> -n <subcontainer-name> -- <cmd>`. Select the subcontainer by **name** with `-n` (the name passed to `SubContainer.of` in `main.ts`, e.g. `-n web`) or by image with `-i`. Note: `-s/--subcontainer` matches the internal **Guid**, not the name, so passing a name to `-s` fails with "no matching subcontainers". A service with more than one subcontainer requires a selector; with none given, `attach` falls back to an interactive picker that panics in a non-TTY shell — that's the missing selector, not a TTY requirement.
+<!--
+TODO: only what someone *changing* this package needs and cannot get from
+README.md or instructions.md. Those two are the richer sources on how the package
+works and who it serves — restating them here creates a third copy that drifts.
+
+What has no home in them, and belongs here:
+
+  - repo mechanics — parallel version branches, a worktree layout, a vendored tree
+  - prohibitions — a change that looks right and is not, plus the one clause saying why
+  - extension points — where the next backend, interface, or migration gets added
+  - naming traps — e.g. a package id that differs from the repo directory name
+  - build or test invocations specific to this package
+
+Most packages need one to four bullets. A simple one needs none — delete the
+section rather than padding it. Remove this comment when you write yours.
+-->

--- a/projects/start-sdk/docs/package-template/README.md
+++ b/projects/start-sdk/docs/package-template/README.md
@@ -5,49 +5,100 @@
 # {{name}} on StartOS
 
 > Everything not listed in this document should behave the same as upstream {{name}}.
+> If a feature, setting, or behavior is not mentioned here, the upstream
+> documentation is accurate and fully applicable — see the Documentation section of
+> `instructions.md` for links.
 
 <!--
 TODO: Write this README per the packaging guide:
   ../src/writing-readmes.md
 
-It documents how the StartOS package differs from upstream — for developers and AI
-assistants, not end users (those get instructions.md). Fill in the sections below,
-delete the ones that don't apply, and remove these comments. No version numbers or
-image tags anywhere — the manifest is the source of truth.
+It documents how the StartOS package differs from upstream. Its readers are an AI
+support agent, an AI assistant administering the server, and developers — end users
+get instructions.md instead, and everyone who reads this file has that one too, so
+never restate it.
+
+The headings below are a fixed set, in this order: they are how an agent fetches part
+of this file without loading all of it. Don't rename or reorder them. They run in four
+groups — what the package is made of, how it behaves, what to expect when it doesn't,
+then meta. Delete a section only where the guide says you may (Tasks and
+Troubleshooting, if the package has neither). Open every section with a sentence or two
+of prose before any table — that text becomes the section's summary in the generated
+index.
+
+Don't restate what StartOS already exposes (action ids, descriptions, allowed
+statuses, input schemas): document when to run a thing, what it costs, whether it is
+safe to repeat, and what it changes. No version numbers or image tags anywhere — the
+manifest is the source of truth. Remove these comments when you're done.
 -->
+
+## Table of Contents
+
+<!-- TODO: link every section present below -->
 
 ## Image and Container Runtime
 
-<!-- TODO -->
+<!-- TODO: image source, architectures, entrypoint, and the subcontainers this package runs -->
 
 ## Volume and Data Layout
 
 <!-- TODO -->
 
-## Network Access and Interfaces
+## File Models
 
-<!-- TODO -->
-
-## Actions (StartOS UI)
-
-<!-- TODO: list each action, or "None." -->
-
-## Backups and Restore
-
-<!-- TODO -->
-
-## Health Checks
-
-<!-- TODO -->
+<!-- TODO: each config file the package owns — format, how it's seeded, what rewrites it, and whether a hand edit survives -->
 
 ## Dependencies
 
 <!-- TODO: list each dependency, or "None." -->
 
+## Network Access and Interfaces
+
+<!-- TODO -->
+
+## Installation and First-Run Flow
+
+<!-- TODO: what setup differs from upstream, and any ordering the user must respect -->
+
+## Actions
+
+<!-- TODO: each user-facing action — when to run it, what it changes, cost, repeat safety. Or "None." -->
+
+## Tasks
+
+<!-- TODO: each task — what raises it, severity, what clears it. Delete the section if the package raises none. -->
+
+## Health Checks
+
+<!-- TODO: what each check probes, and what a failure means -->
+
+## Backups and Restore
+
+<!-- TODO -->
+
 ## Limitations and Differences
 
 <!-- TODO -->
 
-## What Is Unchanged from Upstream
+## Troubleshooting
 
-<!-- TODO -->
+<!-- TODO: symptom → check → action, for this package's real failure modes. Delete if there are none beyond upstream's. -->
+
+---
+
+## Quick Reference for AI Consumers
+
+```yaml
+package_id: '{{id}}'
+image:
+architectures: []
+subcontainers: []
+volumes: {}
+file_models: []
+startos_managed_env_vars: []
+dependencies: []
+interfaces: {}
+actions: []
+tasks: []
+health_checks: []
+```


### PR DESCRIPTION
Updates the package template so newly scaffolded packages match the README section contract. **The guide pages defining that contract are in #3709**, which targets `live-docs` because they correct instructions the site is serving right now and depend on nothing unreleased.

This PR was originally the whole change; the book pages were moved to #3709 so `docs-backport.yml` can carry them to master without colliding with this branch. The two are disjoint.

## Why the template has to change with the doctrine

`docs/package-template/` is live code — `s9pk init-package` copies it verbatim out of the checkout (`TEMPLATE_SUBPATH` joined onto the workspace's `start-technologies/`). If it keeps scaffolding `## What Is Unchanged from Upstream` and `## Actions (StartOS UI)`, every new package starts non-conformant and the sweep never converges.

## What changes

**`package-template/README.md`** takes the fixed heading set in section order, adding `File Models`, `Tasks` and `Troubleshooting` and dropping `Contributing` and `What Is Unchanged from Upstream`. Its TODO comments now teach the rules that are easy to get wrong — don't restate `instructions.md`, don't re-encode what StartOS already exposes, open each section with prose for the generated index.

The quick reference mirrors the sections and gains `image`, `subcontainers`, `file_models`, `tasks` and `health_checks`. `package_id` is quoted (`'{{id}}'`) because Prettier rewrites a bare `{{id}}` inside a YAML fence into `{ { id } }`, which would not interpolate — worth knowing before editing that block.

**`package-template/AGENTS.md`** stops shipping an "Inspecting a running install" section. It was inherited by all 57 start9-registry packages and is package-independent apart from the subcontainer names, which now belong in the README's operable surface; the `attach` `-n`-vs-`-s` trap moves into `workflow.md` in #3709. Its `## This repo` section becomes a prompt for what only a contributor needs — repo mechanics, prohibitions, extension points, naming traps — which is where the duplication kept regrowing.

**`CHANGELOG.md`** records both halves under the accumulating `2.0.10` heading. That heading is the prospective next version, not a dependency claim — see #3709 for the verification that nothing here needs 2.0.10 or StartOS 0.4.0.2.

## Follow-on

Existing packages don't conform yet. A per-package sweep follows and has to be source-verified rather than mechanical: File Models, Tasks, subcontainers and the quick reference all have to be read out of `startos/`. The first package through the shape turned up a quick reference listing environment variables that no longer exist, omitting an action entirely, and giving a health check's display string where its id was needed.