### PR TITLE
fix(ci): carry the backport merge-commit fix onto live-docs

### DIFF
--- a/.github/workflows/docs-backport.yml
+++ b/.github/workflows/docs-backport.yml
@@ -105,7 +105,13 @@ jobs:
             # Cherry-picking commit-by-commit would abort on any patch that is
             # already in master (an "empty" pick), which is the common case when
             # a fix was written on live-docs and hand-copied to master first.
-            if ! git cherry-pick -x -n $(git rev-list --reverse "$RANGE"); then
+            #
+            # --first-parent with -m 1 takes a merged PR as a single patch: the
+            # merge's own net change against the previous live-docs tip. Without
+            # -m 1 cherry-pick refuses a merge outright, and replaying the
+            # branch's commits instead re-fights a conflict the merge already
+            # settled and drops a resolution recorded only in the merge.
+            if ! git cherry-pick -x -n -m 1 $(git rev-list --reverse --first-parent "$RANGE"); then
               git cherry-pick --abort || true
               echo "fallback=conflict" >> "$GITHUB_OUTPUT"
               echo "::warning::Backport conflicts with master — opening a PR instead."
@@ -224,10 +230,11 @@ jobs:
           # conflict, and a single --continue only advances past that one — the
           # tail would be dropped from a branch whose PR claims the whole range.
           # --allow-empty keeps a patch already present in master from aborting
-          # the sequence.
+          # the sequence. Same commit list as the bulk pick above, or the branch
+          # would carry something other than what was tried against master.
           DROPPED=""
-          for commit in $(git rev-list --reverse "${BEFORE}..${AFTER}"); do
-            if git cherry-pick -x --allow-empty --keep-redundant-commits "$commit"; then
+          for commit in $(git rev-list --reverse --first-parent "${BEFORE}..${AFTER}"); do
+            if git cherry-pick -x -m 1 --allow-empty --keep-redundant-commits "$commit"; then
               continue
             fi
             git add -A
@@ -239,6 +246,14 @@ jobs:
           done
 
           git push -f origin "$BRANCH"
+
+          # Keeping the markers leaves a branch GitHub still reports as
+          # mergeable, so the body has to say so out loud. --all-match is the
+          # per-file conjunction; -e A --and -e B would ask for both on one line.
+          MARKED=$(git grep -l --all-match -e '^<<<<<<< ' -e '^>>>>>>> ' HEAD -- . | sed 's|^HEAD:||' || true)
+          if [ -n "$MARKED" ]; then
+            echo "::warning::The backport branch carries unresolved conflict markers."
+          fi
 
           # The PR body must describe what the branch actually carries. A commit
           # that could not be applied at all is named here rather than left to be
@@ -253,12 +268,22 @@ jobs:
               contention)
                 echo "master moved under it three times running, so it comes as a branch instead. **Nothing is wrong with it** — review and merge normally."
                 ;;
-              *)
+              conflict)
                 echo "It could not be applied to master unattended — **resolve the conflicts before merging**."
+                ;;
+              *)
+                echo "It could not be applied to master unattended (\`$REASON\`) — check the run log before merging."
                 ;;
             esac
             echo
             echo "Until this lands, master's copy of the docs is out of step and the next tag will revert the published fix."
+            if [ -n "$MARKED" ]; then
+              echo
+              echo "> [!CAUTION]"
+              echo "> Conflicts were resolved by keeping the markers, so these files carry \`<<<<<<<\` / \`>>>>>>>\` and must be fixed before merging:"
+              echo ">"
+              printf '> - `%s`\n' $MARKED
+            fi
             if [ -n "$DROPPED" ]; then
               echo
               echo "> [!WARNING]"


### PR DESCRIPTION
#3696 fixed the wrong copy of the file. My mistake — this is the fix landing where it actually runs.

## Why #3696 had no effect

`docs-backport.yml` is triggered by `push` to `live-docs`, and **a push-triggered workflow runs the copy of the workflow file that lives on the pushed ref** — not the one on the default branch. So the run for #3709 executed `live-docs`'s copy, which is still the pre-#3696 code.

Not doctrine — the two runs say it directly:

| | |
|---|---|
| master got `-m 1 --first-parent` | `e1da45c84`, 2026-08-12T21:42:39Z |
| the 2026-08-14T19:38 run executed | `if ! git cherry-pick -x -n $(git rev-list --reverse "$RANGE")` |

That is the old line, two days after master stopped containing it. Same failure, same `error: commit c36b302c0… is a merge but no -m option was given`, same spurious "resolve the conflicts" body → #3710.

## Why the copies had drifted

`live-docs` branched at `7695ab1ff` (#3652, the commit that created it) and has taken nothing from master since — 30 commits of divergence. Its `.github/` is frozen at that point. Nothing syncs master → `live-docs`; the backport bot only goes the other way.

Current `.github/` drift is two files:

- `docs-backport.yml` — this PR
- `issue-triage.yml` — stale too, but it isn't triggered by a `live-docs` push, so it is inert here and I've left it alone

This makes `docs-backport.yml` byte-identical to `origin/master`'s copy (verified with `diff`, after lint-staged's prettier pass).

## What happens when this merges

The push runs the **new** file — the merge commit contains it — and the range's net change is this workflow file, which master already has. So `git diff --cached --quiet` is true and the run exits at *"live-docs commits are already in master — nothing to backport."* No commit to master, no PR. `docs-deploy` rebuilds the site from unchanged docs content.

#3710 still needs merging on its own; it is content-correct (no conflict markers, `git diff-tree --cc c36b302c0` shows no file rows, and the three `Auto-merging` files were master's own divergence resolving cleanly).

## The durable version, if you want it

This will recur for any change to either workflow a `live-docs` push triggers — `docs-backport.yml` and `docs-deploy.yml` — including the `curl -fsSL` fix I offered for the mdBook download.

The usual answer is to make `live-docs`'s copy a thin caller of a reusable workflow pinned to master:

```yaml
on:
  push:
    branches: ['live-docs']
jobs:
  backport:
    uses: Start9Labs/start-technologies/.github/workflows/docs-backport-impl.yml@master
```

after which logic changes only ever touch master. Two things I would want to verify before doing that rather than assert: that `github.ref` inside the called workflow is still `refs/heads/live-docs`, so the `docs-backport` environment's branch policy — the thing keeping this App token off every other ref — still gates it; and that the environment secrets resolve in the called job. Your call whether that is worth it or whether mirroring the file on the rare occasions it changes is simpler.
