### PR TITLE
feat(s9pk): pack the package README

### DIFF
--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -11,6 +11,17 @@ or the CLI's externally observable behavior.
 
 ## [1.1.1]
 
+### Added
+
+- **`s9pk pack` packs the package's `README.md`.** It sits beside `instructions.md` in the
+  archive and is readable with `S9pk::readme()`. The point is what runs on the server: an AI
+  assistant administering a service can now read the package's technical reference from the
+  installed `.s9pk` — offline, and describing the version actually installed — instead of
+  fetching a repository's default branch, which has usually moved on. Unlike `instructions.md`
+  it is **optional**, so a package without one still builds; it is simply absent from the
+  archive and the accessor returns `None`. Nothing is packed for an s9pk built before this,
+  and v1 packages migrated forward carry no README either.
+
 ### Fixed
 
 - **`registry os asset remove` can be run.** Its `iso`/`img`/`squashfs` handlers were registered

--- a/projects/start-sdk/docs/package-template/AGENTS.md
+++ b/projects/start-sdk/docs/package-template/AGENTS.md
@@ -6,12 +6,6 @@ Develop it inside a StartOS packaging workspace created by `start-cli s9pk init-
 which provides the packaging guide and agent context one level up. If you're reading this in a
 bare clone with no workspace, the full guide is at <https://docs.start9.com/packaging>.
 
-**Start every task at the recipe index** — `../start-technologies/projects/start-sdk/docs/src/recipes.md`
-(or <https://docs.start9.com/packaging/recipes.html>). It maps an intent ("prompt the user to create
-admin credentials", "expose a web UI") to the constructs, the reference pages, and a named production
-package to copy. Find the recipe before you read this package's neighbours: a package you reach by
-grepping may be non-conformant, and the recipe outranks it.
-
 Work this package's `TODO.md` from top to bottom. Keep `README.md` (the package's technical reference — the only one an AI support or administering agent reads) and `instructions.md` (end-user docs) in sync with your changes.
 
 ## This repo

--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -207,6 +207,8 @@ If you are pulling a pre-built Docker image (no submodule), copy the license tex
 
 Service documentation following the structure described in [Writing READMEs](./writing-readmes.md). Every README should document how the StartOS package differs from the upstream service.
 
+It is **packed into the `.s9pk`** alongside `instructions.md`, so an AI assistant administering the server reads the README for the version actually installed, offline, rather than fetching whatever a repository's default branch has since moved to. Unlike `instructions.md` it is optional — a package without one still builds — but nothing on the server can fall back to a copy that isn't there, so ship one.
+
 ### TODO.md
 
 A running list of pending work on this package. Add items when you defer work; remove them when complete. An empty `TODO.md` (just the `# TODO` heading) is fine — keep the file present so contributors know where to record items.

--- a/projects/start-sdk/docs/src/writing-instructions.md
+++ b/projects/start-sdk/docs/src/writing-instructions.md
@@ -15,7 +15,7 @@ It is tempting to treat `instructions.md` as a copy of the README. Resist this. 
 | **Tone**                  | Technical, structured, scannable for parsing                                                     | Practical, instructional, written in second person              |
 | **Versions / image tags** | Avoided (manifest is source of truth)                                                            | Avoided for the same reason                                     |
 | **Upstream behavior**     | "Anything not listed here behaves as upstream documents"                                         | Linked from the Documentation section; never duplicated         |
-| **Surfaced where**        | The package repository on GitHub                                                                 | Inside the StartOS UI, post-install                             |
+| **Surfaced where**        | The package repository, and packed into the `.s9pk`                                              | Inside the StartOS UI, post-install                             |
 
 If your README is a reference manual, your instructions are a quick-start guide for a non-developer who just clicked Install.
 

--- a/projects/start-sdk/docs/src/writing-readmes.md
+++ b/projects/start-sdk/docs/src/writing-readmes.md
@@ -30,7 +30,9 @@ Two consequences:
 
 **Do not re-encode what StartOS can introspect.** An agent administering your service already has every action's id, name, description, warning, visibility, `allowedStatuses` and input schema from the OS, along with health-check ids and live status. Restating those here adds a second copy that goes stale and costs the agent context to read. Document instead what the ABI cannot express: **when** to run a thing, what it **costs**, whether it is **safe to repeat**, what **state** it changes, and which **symptom** it resolves.
 
-**The heading set is fixed, not suggested.** Section headings are how an agent retrieves part of a README without loading all of it, so they are an addressing scheme. A package that renames `## Actions` to `## Available Actions` does not fail loudly — it silently degrades retrieval to "load the whole file". Use the headings below verbatim, in this order, and omit a section only where the guidance below says you may.
+**The heading set is fixed, not suggested.** Section headings are how an agent retrieves part of a README without loading all of it, so they are an addressing scheme. A package that renames `## Actions` to `## Available Actions` does not fail loudly — it silently degrades retrieval to "load the whole file". Use the headings below verbatim, in this order.
+
+**A section with nothing to say still says "None."** Only **Tasks** and **Troubleshooting** may be left out, and only when the package genuinely has neither. Everywhere else an empty section is a fact worth stating: "no config file on disk", "no dependencies", "no actions" each answer a question outright, where a missing heading is ambiguous — the reader cannot tell an absent section from an unwritten one, and an agent addressing that heading gets nothing back either way.
 
 The order runs in four groups: **what the package is made of** (runtime, volumes, file models, dependencies, interfaces), **how it behaves** (install, actions, tasks, health, backups), **what to expect when it doesn't** (limitations, troubleshooting), then the machine-readable summary. Keep a new section inside the group it belongs to.
 
@@ -164,6 +166,8 @@ Note `store.json` if the package keeps one — it holds StartOS-side state rathe
 
 Where a setting is delivered by environment variable instead of a file, say so and say why: a variable the application re-reads on every launch behaves nothing like one it consumes only on the launch that finds its value unset, and treating the second kind as authoritative is a common packaging bug. A configuration file the package writes without a model belongs in this section too.
 
+If the package writes no configuration at all, state "None" and say so plainly — that there is nothing on disk to inspect or correct is an answer, and a useful one.
+
 ### Dependencies
 
 What this service needs from other services.
@@ -195,7 +199,7 @@ The OS supplies each action's id, name, description, warning, visibility, `allow
 - **What happens next** — restarts, where to watch progress.
 - **Outputs** — credentials or values the caller receives.
 
-Flag actions with `visibility: 'hidden'` as not user-facing, so a support agent never tells a user to run one. Where an action exists to satisfy a task, leave the trigger and clearing rules to [Tasks](#tasks) rather than describing them twice.
+Flag actions with `visibility: 'hidden'` as not user-facing, so a support agent never tells a user to run one. Where an action exists to satisfy a task, leave the trigger and clearing rules to [Tasks](#tasks) rather than describing them twice. If the package declares no actions, state "None".
 
 ### Tasks
 

--- a/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/manifest.rs
@@ -66,6 +66,12 @@ impl Manifest {
             tracing::warn!("{e}");
             tracing::debug!("{e:?}");
         }
+        // README.md is optional, but it has to be checked to be kept: this filter drops
+        // every entry no check claims, so an unchecked README would be packed and then
+        // immediately stripped.
+        if let Err(e) = expected.check_file("README.md") {
+            tracing::debug!("{e:?}");
+        }
         expected.check_file("javascript.squashfs")?;
         for (dependency, _) in &self.dependencies.0 {
             let dep_path = Path::new("dependencies").join(dependency);

--- a/shared-libs/crates/start-core/src/s9pk/v2/mod.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/mod.rs
@@ -36,6 +36,7 @@ pub mod recipe;
     ├── icon.<ext>
     ├── LICENSE.md
     ├── instructions.md
+    ├── README.md (optional)
     ├── dependencies
     │   └── <id>
     │       ├── metadata.json
@@ -59,10 +60,11 @@ fn priority(s: &str) -> Option<usize> {
         a if Path::new(a).file_stem() == Some(OsStr::new("icon")) => Some(1),
         "LICENSE.md" => Some(2),
         "instructions.md" => Some(3),
-        "dependencies" => Some(4),
-        "javascript.squashfs" => Some(5),
-        "assets.squashfs" => Some(6),
-        "images" => Some(7),
+        "README.md" => Some(4),
+        "dependencies" => Some(5),
+        "javascript.squashfs" => Some(6),
+        "assets.squashfs" => Some(7),
+        "images" => Some(8),
         _ => None,
     }
 }
@@ -205,6 +207,17 @@ impl<S: FileSource + Clone> S9pk<S> {
 
     pub async fn instructions(&self) -> Result<Option<String>, Error> {
         let Some(entry) = self.archive.contents().get_path("instructions.md") else {
+            return Ok(None);
+        };
+        let bytes = entry.expect_file()?.to_vec(entry.hash()).await?;
+        Ok(Some(String::from_utf8(bytes)?))
+    }
+
+    /// The package's technical reference, as packed at build time. `None` for a package
+    /// built before READMEs were packed, or one whose repository has no README — callers
+    /// must handle its absence rather than assume it.
+    pub async fn readme(&self) -> Result<Option<String>, Error> {
+        let Some(entry) = self.archive.contents().get_path("README.md") else {
             return Ok(None);
         };
         let bytes = entry.expect_file()?.to_vec(entry.hash()).await?;

--- a/shared-libs/crates/start-core/src/s9pk/v2/pack.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/pack.rs
@@ -279,6 +279,17 @@ impl PackParams {
             }
         }
     }
+    /// Unlike `instructions`, a README is optional: it is a repository document, and an
+    /// existing package that lacks one must keep building. When present it is packed so an
+    /// agent administering the service can read it from the installed s9pk — version-matched,
+    /// and without reaching the network.
+    async fn readme(&self) -> Result<Option<PathBuf>, Error> {
+        let candidate = self.path().join("README.md");
+        Ok(tokio::fs::metadata(&candidate)
+            .await
+            .is_ok()
+            .then_some(candidate))
+    }
     fn assets(&self) -> PathBuf {
         self.assets
             .as_ref()
@@ -698,6 +709,12 @@ pub async fn pack(ctx: CliContext, params: PackParams) -> Result<(), Error> {
             PackSource::File(params.instructions().await?),
         )),
     );
+    if let Some(readme) = params.readme().await? {
+        files.insert(
+            "README.md".into(),
+            Entry::file(TmpSource::new(tmp_dir.clone(), PackSource::File(readme))),
+        );
+    }
     files.insert(
         "javascript.squashfs".into(),
         Entry::file(TmpSource::new(
@@ -909,7 +926,10 @@ pub async fn list_ingredients(_: CliContext, params: PackParams) -> Result<Vec<P
                 params.icon().await?,
                 params.license().await?,
                 params.instructions().await?,
-            ]);
+            ]
+            .into_iter()
+            .chain(params.readme().await?)
+            .collect());
         }
     };
     let mut ingredients = vec![
@@ -918,6 +938,7 @@ pub async fn list_ingredients(_: CliContext, params: PackParams) -> Result<Vec<P
         params.license().await?,
         params.instructions().await?,
     ];
+    ingredients.extend(params.readme().await?);
 
     for (_, dependency) in manifest.dependencies.0 {
         match dependency.metadata {


### PR DESCRIPTION
An AI assistant administering a service on the server should not reach the internet for something the s9pk could carry. This packs `README.md` alongside `instructions.md`, and closes two gaps the fleet sweep hit on its second package.

## Packing the README

`README.md` was never packed — only ever present in the package repository. So anything on the server wanting the package's technical reference had to fetch it over the network, from a default branch that has usually moved past the version actually installed. Packing it fixes both: offline, and version-matched.

- Packed beside `instructions.md`, sorted with the other documents, read with `S9pk::readme()`.
- **Optional**, unlike `instructions.md`. A README is a repository document and an existing package that lacks one has to keep building, so a missing README packs nothing and the accessor returns `None`. Every package in both registries has one today, so tightening this to required later is possible — flagging it as a deliberate choice rather than an oversight.
- Added to `list_ingredients`, so editing a README repacks.

### The one non-obvious line

The `check_file("README.md")` in `Manifest::validate_for` is **load-bearing, not validation**. `Expected` doubles as a filter — `into_filter()` → `keep_checked()` drops every archive entry no check claims, and `pack` runs `validate_and_filter` before writing. An unchecked README would be packed and then silently stripped. Its error is discarded because absence is allowed.

### Compatibility

- **Old server, new s9pk:** the README is filtered out, not rejected. That path already drops the architectures a server doesn't need before the commitment is computed, and `Expected` only errors on *missing* expected files, never on extra ones.
- **New server, old s9pk:** no README in the archive, accessor returns `None`.
- **v1 packages migrated forward:** no README either — `compat.rs` stubs `instructions.md` because it is required, and nothing equivalent is needed for an optional file.

## Guide follow-ups

**A section with nothing to say still says "None."** Only `Tasks` and `Troubleshooting` may be omitted. Everywhere else an empty section is a fact worth stating: "no config file on disk" answers a question outright, where a missing heading is ambiguous — a reader cannot tell an absent section from an unwritten one, and an agent addressing that heading gets nothing back either way. `File Models` and `Actions` now say so at the section level, where `Dependencies` already did. This came up on `hello-world`, which has neither.

**The template's recipe-index paragraph is dropped.** Every claim in it — find the recipe first, a neighbouring package is not the authority — is already in `agent-context.md`, which is always-on in every workspace. It was generic guide content restated per package, which the same guidance forbids. It also meant a freshly scaffolded package and a swept one would differ.

## Note for review

**The Rust is uncompiled.** Building `start-core` locally is heavy enough to be discouraged in this workspace, so I've left it to CI rather than running it here. The change is small and mirrors the existing `instructions.md` path at every touchpoint, but it has not been type-checked on my machine — worth a CI green before merge rather than a read-through alone.

Formatting: markdown is prettier-clean. `rustfmt` on stable reports only pre-existing import-ordering diffs it can't reproduce without the repo's pinned nightly options (it flags `compat.rs`, untouched here); none land in the added code.