### PR TITLE
docs(sdk): drop the fleet-provenance clause from the description advice

### DIFF
--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -46,8 +46,7 @@ routinely run 20-30% longer than the same English sentence — not as permission
 to run long. Write the English well inside 80 and every locale still fits the
 tile.
 
-Two more characters' worth of advice, both from descriptions already in the
-registries:
+Two more characters' worth of advice:
 
 - **Don't open with the service's name.** The tile renders the title in bold on
   the line directly above, so "Foo is a self-hosted bar" spends its first words


### PR DESCRIPTION
One deletion from the packaging-guide cruft audit, split out because it can only be made here.

> Two more characters' worth of advice, ~~both from descriptions already in the registries~~:

The provenance clause is a claim about what the fleet's short descriptions look like right now, with no mechanism keeping it true. It is already only partly accurate: parsing the `en_US` short out of all 107 fleet `startos/manifest/i18n.ts` files and matching each against its package `title`, 4 open with the service name — the exact pattern the first bullet tells you to avoid.

The two bullets it introduces both have live producers and stay exactly as written.

**Why this one is on `master`:** the rest of the audit — 19 deletions across 18 pages — corrects text that is wrong on docs.start9.com today, so it lands on `live-docs` in #3725 and reaches master through the backport. This paragraph exists **only** on master (the published guide does not carry it), so it cannot be fixed there. Splitting it keeps the same fix from being written in both places.
