### PR TITLE
ci: head the sync-next conflict PR with a scratch branch

### DIFF
--- a/.github/workflows/syncNext.yml
+++ b/.github/workflows/syncNext.yml
@@ -12,18 +12,20 @@ name: Sync next
 # `next`. A base with neither gets a branch created for it, which is how a
 # package that never had a `next` acquires one.
 #
-# Nothing here force-pushes and nothing rewrites history, so this cannot race a
-# Helix session working the same branch. The outcomes are: create, fast-forward
-# (the overwhelming majority), a merge commit when `next` carries unmerged work,
-# or — only when that merge conflicts — a pull request for a human.
+# Neither `next` nor the base is ever force-pushed or rewritten, so this cannot
+# race a Helix session working the same branch. The outcomes are: create,
+# fast-forward (the overwhelming majority), a merge commit when `next` carries
+# unmerged work, or — only when that merge conflicts — a pull request for a
+# human.
 #
-# That PR takes the base branch itself as its head, so it needs no scratch
-# branch, stays current as the base advances, and closes on its own once a later
-# run merges cleanly, because merging the base into `next` makes the PR's head
-# reachable from its own base.
+# That PR's head is a throwaway `sync-next/<base>` branch holding the base tip,
+# never the base itself: GitHub's web conflict editor commits to the head
+# branch, so a PR headed by the base would resolve straight onto the base. It
+# still closes on its own once a later run merges cleanly, because merging the
+# base into `next` makes the scratch tip reachable from the PR's own base.
 #
-# No loop is possible: this only ever writes to `next`/`next/*`, which is never
-# a trigger branch for this workflow.
+# No loop is possible: this only ever writes to `next`/`next/*` and
+# `sync-next/*`, none of which is a trigger branch for this workflow.
 
 on:
   workflow_call:
@@ -127,23 +129,31 @@ jobs:
           git merge --abort || true
 
           echo "::warning::Merging $BASE into $TARGET conflicts — opening a pull request."
-          OPEN=$(gh pr list --base "$TARGET" --head "$BASE" --state open --json number --jq 'length')
+          SCRATCH="sync-next/$BASE"
+          OPEN=$(gh pr list --base "$TARGET" --head "$SCRATCH" --state open --json number --jq 'length')
           if [ "$OPEN" != "0" ]; then
             echo "::notice::A sync pull request into $TARGET is already open."
             exit 0
           fi
+
+          # Only ever reached with no sync PR open, so this cannot discard
+          # conflict resolutions a human has already pushed onto the scratch
+          # branch.
+          git push --force origin "$BASE_SHA:refs/heads/$SCRATCH"
 
           {
             echo "\`$BASE\` has moved on and cannot be merged into \`$TARGET\` unattended — the merge conflicts."
             echo
             echo "Resolve the conflicts and merge this PR. Until it lands, \`$TARGET\` is missing what \`$BASE\` has gained, and work built on it will be based on a stale tree."
             echo
-            echo "Nothing was force-pushed and no history was rewritten; \`$TARGET\` is exactly as it was."
+            echo "**Merge it with a merge commit, not a squash.** \`$TARGET\` has to come out with \`$BASE\` as an ancestor; a squash gives it equivalent content under a fresh commit instead, and the next sync diverges again for the same reason this one did."
+            echo
+            echo "\`$TARGET\` and \`$BASE\` are both untouched — nothing was pushed to either and no history was rewritten. \`$SCRATCH\` is a throwaway branch holding the \`$BASE\` tip, and it is deleted when this merges."
           } > /tmp/sync-next-body.md
 
           gh pr create \
             --base "$TARGET" \
-            --head "$BASE" \
+            --head "$SCRATCH" \
             --title "chore: sync $BASE into $TARGET" \
             --body-file /tmp/sync-next-body.md \
             || echo "::warning::Could not open a sync pull request into $TARGET."

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -46,10 +46,14 @@
   and work resumed there starts from a stale tree. The paired
   branch is derived rather than configured (an explicit `next/<base>` where one
   exists, otherwise the default branch pairs with a plain `next`), and a repo
-  with no `next` gets one created at the base tip on the first run. Nothing is
-  force-pushed: `next` is fast-forwarded when merely behind, merged when it
-  carries unmerged work, and left alone with a PR opened for a human only when
-  that merge conflicts
+  with no `next` gets one created at the base tip on the first run. Neither
+  `next` nor the base is force-pushed: `next` is fast-forwarded when merely
+  behind, merged when it carries unmerged work, and left alone with a PR opened
+  for a human only when that merge conflicts. That PR is headed by a throwaway
+  `sync-next/<base>` branch rather than the base itself, because GitHub's web
+  conflict editor commits to the head branch — and it wants a merge commit, not
+  a squash, or `next` comes out without the base as an ancestor and the
+  following sync conflicts again
 
 - **`addDaemon()` / `addOneshot()` accept a `uses` value that
   `Daemons.dynamic` folds into the entry's `configHash`.** The reconciler's

--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -177,7 +177,7 @@ jobs:
 
 The paired branch is derived rather than configured: an explicit `next/<base>` is used where one exists — that is how the multi-branch packages keep one iteration branch per major line or flavor — and otherwise the repo's default branch pairs with a plain `next`. **A repo with no `next` gets one created at the base tip on the first run**, so a package never has to be seeded by hand.
 
-Nothing is force-pushed and no history is rewritten. `next` is fast-forwarded when it is merely behind, given a merge commit when it carries unmerged work, and left untouched with a pull request opened for a human only when that merge conflicts. `workflow_dispatch` is there so a package can be brought into line without waiting for its next merge.
+Neither `next` nor the base branch is force-pushed or rewritten. `next` is fast-forwarded when it is merely behind, given a merge commit when it carries unmerged work, and left untouched with a pull request opened for a human only when that merge conflicts. That pull request is headed by a throwaway `sync-next/<base>` branch rather than the base itself, so resolving its conflicts in GitHub's web editor — which commits to the head branch — cannot land on the base. **Merge it with a merge commit rather than a squash**, so `next` comes out with the base as an ancestor; a squash leaves equivalent content under a fresh commit and the following sync conflicts all over again. `workflow_dispatch` is there so a package can be brought into line without waiting for its next merge.
 
 List every base branch the package maintains under `branches:`, and note this is one of the two workflows whose branch list must match the branch the repo actually uses — a package on `main` that still says `master` here silently never syncs.
 


### PR DESCRIPTION
`syncNext` opens a pull request when it cannot merge the base into `next`
unattended. That PR was headed by the base branch itself, which #3722 justified
as needing no scratch branch and staying current as the base advances. The first
real conflict — [hello-world-startos#54](https://github.com/Start9Labs/hello-world-startos/pull/54)
— showed what that costs.

## What it looked like

`master` had six commits `next` lacked, so the PR rendered as **+1477/−296
across 15 files**: it reads like a large feature PR rather than a branch-hygiene
sync, and the actual conflict was five files.

Two sharper problems sit behind the presentation:

- **GitHub's web conflict editor commits to the head branch.** With the base as
  head, the obvious way to resolve the PR writes straight onto `master`.
- **Squash-merging it re-creates the divergence.** `next` would get master's six
  commits collapsed into one new commit with no ancestry link, so the following
  sync diverges again — the same failure, one round later.

## Why the conflict happens at all

It is not a hello-world quirk. `next` had been squash-merged into `master`
(`chore: migrate to start-sdk 2.0 (#53)`), so `master` carried one squashed
commit while `next` kept the four originals — identical content, unrelated
history. `master` then moved to start-sdk 2.0.9 while `next` sat at 2.0.6, and
both sides had touched `package.json`, `package-lock.json`,
`startos/versions/current.ts`, `AGENTS.md` and `build.yml`.

Squash is how PRs land across the fleet and `next` is never deleted, so every
package whose `next` has been merged back and whose base has since moved is in
this state. Across the 133 package checkouts: 86 have a `next` that is simply
behind (clean fast-forward), 14 already contain the base, 11 have none — and
**21 are diverged** and can land here.

## The change

The conflict PR is now headed by a throwaway `sync-next/<base>` branch holding
the base tip:

- Resolving conflicts in the web editor commits to the scratch branch, never to
  the base.
- The PR still closes on its own once a later run merges cleanly, because
  merging the base into `next` makes the scratch tip reachable from the PR's own
  base — the property that made the old design attractive is kept.
- `delete-branch-on-merge` cleans the scratch branch up.

The scratch branch is force-updated only on the path where no sync PR is open,
so it cannot discard resolutions someone has already pushed onto it. The
trade-off against the old design is that while a PR *is* open the scratch tip no
longer tracks the base; the merge is still retried on every push, so the moment
it succeeds the normal path takes over.

The PR body now also asks for a merge commit rather than a squash, and says why.

`project-structure.md` and the start-sdk changelog both asserted "nothing is
force-pushed"; both are corrected to say neither `next` nor the base is, and
both now describe the scratch branch and the merge-not-squash requirement. The
changelog entry is the one #3722 added under the unreleased 2.0.10, amended in
place rather than appended to, since the behaviour it describes has not shipped.
