### PR TITLE
fix(ci): retry the start-cli asset lookup when list-releases returns an empty 200

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -39,15 +39,31 @@ runs:
         ARCH=$(uname -m)
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ASSET_NAME="start-cli_${ARCH}-${OS}"
-        DOWNLOAD_URL=$(curl -fsS \
-          -H "Authorization: token ${{ github.token }}" \
-          https://api.github.com/repos/Start9Labs/start-technologies/releases \
-          | jq -r '[.[].assets[] | select(.name=="'"$ASSET_NAME"'")] | first | .browser_download_url')
-        if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
-          echo "Error: Could not find asset '$ASSET_NAME' in Start9Labs/start-technologies releases"
+        # A degraded list-releases endpoint answers 200 with an empty array, so
+        # curl sees success and --retry never fires. Retry on an empty list to
+        # keep that from reporting as a missing asset.
+        for attempt in 1 2 3 4 5; do
+          RELEASES=$(curl -fsS --retry 3 --retry-connrefused \
+            -H "Authorization: token ${{ github.token }}" \
+            'https://api.github.com/repos/Start9Labs/start-technologies/releases?per_page=100' || true)
+          COUNT=$(printf '%s' "$RELEASES" | jq 'length' 2>/dev/null || echo 0)
+          if [ "$COUNT" -gt 0 ]; then break; fi
+          if [ "$attempt" -lt 5 ]; then
+            echo "list-releases returned no releases (attempt ${attempt}/5); retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          fi
+        done
+        if [ "$COUNT" -eq 0 ]; then
+          echo "Error: Start9Labs/start-technologies list-releases returned no releases; the GitHub API is degraded"
           exit 1
         fi
-        curl -fsSL \
+        DOWNLOAD_URL=$(printf '%s' "$RELEASES" \
+          | jq -r --arg name "$ASSET_NAME" '[.[].assets[] | select(.name == $name)] | first | .browser_download_url')
+        if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+          echo "Error: no Start9Labs/start-technologies release of the $COUNT returned carries asset '$ASSET_NAME'"
+          exit 1
+        fi
+        curl -fsSL --retry 3 --retry-connrefused \
           -H "Authorization: token ${{ github.token }}" \
           -H "Accept: application/octet-stream" \
           "$DOWNLOAD_URL" -o /tmp/start-cli

--- a/.github/actions/setup-publish-env/action.yml
+++ b/.github/actions/setup-publish-env/action.yml
@@ -19,15 +19,31 @@ runs:
         ARCH=$(uname -m)
         OS=$(uname -s | tr '[:upper:]' '[:lower:]')
         ASSET_NAME="start-cli_${ARCH}-${OS}"
-        DOWNLOAD_URL=$(curl -fsS \
-          -H "Authorization: token ${{ github.token }}" \
-          https://api.github.com/repos/Start9Labs/start-technologies/releases \
-          | jq -r '[.[].assets[] | select(.name=="'"$ASSET_NAME"'")] | first | .browser_download_url')
-        if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
-          echo "Error: Could not find asset '$ASSET_NAME' in Start9Labs/start-technologies releases"
+        # A degraded list-releases endpoint answers 200 with an empty array, so
+        # curl sees success and --retry never fires. Retry on an empty list to
+        # keep that from reporting as a missing asset.
+        for attempt in 1 2 3 4 5; do
+          RELEASES=$(curl -fsS --retry 3 --retry-connrefused \
+            -H "Authorization: token ${{ github.token }}" \
+            'https://api.github.com/repos/Start9Labs/start-technologies/releases?per_page=100' || true)
+          COUNT=$(printf '%s' "$RELEASES" | jq 'length' 2>/dev/null || echo 0)
+          if [ "$COUNT" -gt 0 ]; then break; fi
+          if [ "$attempt" -lt 5 ]; then
+            echo "list-releases returned no releases (attempt ${attempt}/5); retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          fi
+        done
+        if [ "$COUNT" -eq 0 ]; then
+          echo "Error: Start9Labs/start-technologies list-releases returned no releases; the GitHub API is degraded"
           exit 1
         fi
-        curl -fsSL \
+        DOWNLOAD_URL=$(printf '%s' "$RELEASES" \
+          | jq -r --arg name "$ASSET_NAME" '[.[].assets[] | select(.name == $name)] | first | .browser_download_url')
+        if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+          echo "Error: no Start9Labs/start-technologies release of the $COUNT returned carries asset '$ASSET_NAME'"
+          exit 1
+        fi
+        curl -fsSL --retry 3 --retry-connrefused \
           -H "Authorization: token ${{ github.token }}" \
           -H "Accept: application/octet-stream" \
           "$DOWNLOAD_URL" -o /tmp/start-cli

--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -253,11 +253,31 @@ jobs:
           ARCH=$(uname -m)
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ASSET_NAME="start-cli_${ARCH}-${OS}"
-          DOWNLOAD_URL=$(curl -fsS \
-            -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/repos/Start9Labs/start-technologies/releases \
-            | jq -r '[.[].assets[] | select(.name=="'"$ASSET_NAME"'")] | first | .browser_download_url')
-          curl -fsSL \
+          # A degraded list-releases endpoint answers 200 with an empty array, so
+          # curl sees success and --retry never fires. Retry on an empty list to
+          # keep that from reporting as a missing asset.
+          for attempt in 1 2 3 4 5; do
+            RELEASES=$(curl -fsS --retry 3 --retry-connrefused \
+              -H "Authorization: token ${{ github.token }}" \
+              'https://api.github.com/repos/Start9Labs/start-technologies/releases?per_page=100' || true)
+            COUNT=$(printf '%s' "$RELEASES" | jq 'length' 2>/dev/null || echo 0)
+            if [ "$COUNT" -gt 0 ]; then break; fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "list-releases returned no releases (attempt ${attempt}/5); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Error: Start9Labs/start-technologies list-releases returned no releases; the GitHub API is degraded"
+            exit 1
+          fi
+          DOWNLOAD_URL=$(printf '%s' "$RELEASES" \
+            | jq -r --arg name "$ASSET_NAME" '[.[].assets[] | select(.name == $name)] | first | .browser_download_url')
+          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+            echo "Error: no Start9Labs/start-technologies release of the $COUNT returned carries asset '$ASSET_NAME'"
+            exit 1
+          fi
+          curl -fsSL --retry 3 --retry-connrefused \
             -H "Authorization: token ${{ github.token }}" \
             -H "Accept: application/octet-stream" \
             "$DOWNLOAD_URL" -o /tmp/start-cli

--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -568,11 +568,31 @@ jobs:
           ARCH=$(uname -m)
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ASSET_NAME="start-cli_${ARCH}-${OS}"
-          DOWNLOAD_URL=$(curl -fsS \
-            -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/repos/Start9Labs/start-technologies/releases \
-            | jq -r '[.[].assets[] | select(.name=="'"$ASSET_NAME"'")] | first | .browser_download_url')
-          curl -fsSL \
+          # A degraded list-releases endpoint answers 200 with an empty array, so
+          # curl sees success and --retry never fires. Retry on an empty list to
+          # keep that from reporting as a missing asset.
+          for attempt in 1 2 3 4 5; do
+            RELEASES=$(curl -fsS --retry 3 --retry-connrefused \
+              -H "Authorization: token ${{ github.token }}" \
+              'https://api.github.com/repos/Start9Labs/start-technologies/releases?per_page=100' || true)
+            COUNT=$(printf '%s' "$RELEASES" | jq 'length' 2>/dev/null || echo 0)
+            if [ "$COUNT" -gt 0 ]; then break; fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "list-releases returned no releases (attempt ${attempt}/5); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Error: Start9Labs/start-technologies list-releases returned no releases; the GitHub API is degraded"
+            exit 1
+          fi
+          DOWNLOAD_URL=$(printf '%s' "$RELEASES" \
+            | jq -r --arg name "$ASSET_NAME" '[.[].assets[] | select(.name == $name)] | first | .browser_download_url')
+          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+            echo "Error: no Start9Labs/start-technologies release of the $COUNT returned carries asset '$ASSET_NAME'"
+            exit 1
+          fi
+          curl -fsSL --retry 3 --retry-connrefused \
             -H "Authorization: token ${{ github.token }}" \
             -H "Accept: application/octet-stream" \
             "$DOWNLOAD_URL" -o /tmp/start-cli

--- a/.github/workflows/tagAndRelease.yml
+++ b/.github/workflows/tagAndRelease.yml
@@ -45,15 +45,31 @@ jobs:
           ARCH=$(uname -m)
           OS=$(uname -s | tr '[:upper:]' '[:lower:]')
           ASSET_NAME="start-cli_${ARCH}-${OS}"
-          DOWNLOAD_URL=$(curl -fsS \
-            -H "Authorization: token ${{ github.token }}" \
-            https://api.github.com/repos/Start9Labs/start-technologies/releases \
-            | jq -r '[.[].assets[] | select(.name=="'"$ASSET_NAME"'")] | first | .browser_download_url')
-          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
-            echo "Error: Could not find asset '$ASSET_NAME' in Start9Labs/start-technologies releases"
+          # A degraded list-releases endpoint answers 200 with an empty array, so
+          # curl sees success and --retry never fires. Retry on an empty list to
+          # keep that from reporting as a missing asset.
+          for attempt in 1 2 3 4 5; do
+            RELEASES=$(curl -fsS --retry 3 --retry-connrefused \
+              -H "Authorization: token ${{ github.token }}" \
+              'https://api.github.com/repos/Start9Labs/start-technologies/releases?per_page=100' || true)
+            COUNT=$(printf '%s' "$RELEASES" | jq 'length' 2>/dev/null || echo 0)
+            if [ "$COUNT" -gt 0 ]; then break; fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "list-releases returned no releases (attempt ${attempt}/5); retrying in $((attempt * 10))s"
+              sleep $((attempt * 10))
+            fi
+          done
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Error: Start9Labs/start-technologies list-releases returned no releases; the GitHub API is degraded"
             exit 1
           fi
-          curl -fsSL \
+          DOWNLOAD_URL=$(printf '%s' "$RELEASES" \
+            | jq -r --arg name "$ASSET_NAME" '[.[].assets[] | select(.name == $name)] | first | .browser_download_url')
+          if [ -z "$DOWNLOAD_URL" ] || [ "$DOWNLOAD_URL" = "null" ]; then
+            echo "Error: no Start9Labs/start-technologies release of the $COUNT returned carries asset '$ASSET_NAME'"
+            exit 1
+          fi
+          curl -fsSL --retry 3 --retry-connrefused \
             -H "Authorization: token ${{ github.token }}" \
             -H "Accept: application/octet-stream" \
             "$DOWNLOAD_URL" -o /tmp/start-cli


### PR DESCRIPTION
Every package repo's CI is failing right now at **Setup build environment**, before a single package is built:

```
Error: Could not find asset 'start-cli_x86_64-linux' in Start9Labs/start-technologies releases
```

The message is wrong about the cause. The asset exists — it's on `start-cli/v1.1.0`, currently the 10th newest release. What's broken is the endpoint the lookup reads.

### What's actually happening

`GET /repos/Start9Labs/start-technologies/releases` is answering **200 OK with an empty array**, on every page, while its own `Link` header advertises 28 pages of releases:

```
HTTP/2.0 200 OK
Content-Length: 2
Link: <...releases?per_page=3&page=2>; rel="next", <...&page=28>; rel="last"
```

The single-release endpoint (`/releases/tags/…`), `/tags`, and GraphQL are all healthy and return real data — it's the REST list-releases endpoint specifically.

That makes it a **silent** failure. `curl -fsS` sees a 200 and reports success, so `--retry` would never have fired even if it had been there; `jq` faithfully returns `null` from an empty array; and the step reports a missing asset, pointing whoever debugs it at the releases page rather than at the API.

### The change

Applied identically to all five copies of the "Install start-cli" step — `setup-build-env`, `setup-publish-env`, `tagAndRelease.yml`, `startos-iso.yaml`, `start-wrt.yaml`:

- **Retry on an empty list** (5 attempts, 10/20/30/40s backoff), since an empty 200 is not something curl can be asked to detect.
- **Separate the two failure reports.** "The API returned no releases at all, it's degraded" and "the releases are there but none carries this asset" are now distinct messages. Previously both surfaced as the latter.
- **`per_page=100`.** The lookup only ever scanned the first 30 releases. `start-cli/v1.1.0` is 10th today, so this wasn't the trigger — but with `start-sdk`, `start-tunnel` and `start-os` releasing far more often than `start-cli`, that bound was one quiet quarter away from breaking on its own.
- **`--retry 3 --retry-connrefused`** on both curls, for the ordinary 5xx case (which is also happening today — unrelated endpoints have been 503ing intermittently).

`startos-iso.yaml` and `start-wrt.yaml` additionally had **no guard at all** — an empty `DOWNLOAD_URL` went straight into the download curl, so the failure surfaced later and less legibly. They now match the other three.

### What this does and doesn't fix

It does **not** make CI pass during a sustained outage — today's has persisted for hours and no retry budget covers that. What it does is make the failure say what it is, and survive the transient case, which is the more common one.

### Verification

The block was extracted from each of the five files and run under CI's exact shell flags (`bash --noprofile --norc -e -o pipefail`) with `curl` stubbed, against three response shapes:

| Response | Expected | All 5 files |
| --- | --- | --- |
| Healthy list containing the asset | resolves the URL, exit 0 | ok |
| `200 []` (today's degradation) | retries, then "the GitHub API is degraded", exit 1 | ok |
| Healthy list without the asset | "no release … carries asset", exit 1 | ok |

The `jq` selector was also checked against the real `start-cli/v1.1.0` payload from the single-release endpoint — resolves `start-cli_{x86_64,aarch64}-linux` and `start-cli_x86_64-macos` correctly, `null` for a bogus arch. `prettier --check` passes on all five files.

Not verified: an actual CI run, for the reason this PR exists.

### Note on scope

Five near-identical copies of this step is the underlying problem, and a shared `install-start-cli` composite action is the obvious follow-up. I left it out deliberately: the reusable workflows reference actions as `Start9Labs/start-technologies/.github/actions/…@master` precisely because `./` resolves against the *caller's* checkout, and nesting a local action inside a remote composite action has enough resolution subtlety that I wouldn't want to land it while CI can't run to prove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
