### PR TITLE
fix(core/net): close the client leg when the upstream leg closes

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -38,6 +38,17 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **Apps that hold a connection open — desktop sync clients, API pollers — stop
+  dropping in and out.** Nextcloud Desktop and clients like it showed a
+  recurring "Network error" that cleared itself a few seconds later. A service
+  routinely closes a connection once it has sat idle for a few seconds, and a
+  client is built to notice that and open a fresh one. StartOS's reverse proxy
+  kept the client's half of the pair open after the service had closed its own,
+  so the client went on holding a connection it had every reason to believe was
+  good, and the next request it sent over that connection was cut off with no
+  reply. The proxy now closes the client's half as soon as the service closes
+  its own, which is the signal the client is waiting for.
+
 - Trim whitespace on form inputs.
 
 - **Services that run their own containers or a VPN can reach the devices they

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -519,6 +519,50 @@ mod tests {
         assert_eq!(eof.unwrap(), 0);
     }
 
+    /// The proxy relays the backend's own 101 rather than answering the
+    /// upgrade itself, so the client hears nothing until the backend has
+    /// spoken.
+    #[tokio::test]
+    async fn upgrade_is_not_answered_before_the_backend_answers() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        tokio::spawn(run_http1_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        tokio::spawn(async move {
+            read_head(&mut backend).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            backend
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            std::future::pending::<()>().await;
+        });
+
+        client
+            .write_all(
+                b"GET /ws HTTP/1.1\r\nHost: x\r\n\
+                  Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), client.read(&mut [0u8; 1]))
+                .await
+                .is_err(),
+            "the client was answered before the backend had responded",
+        );
+        assert!(read_head(&mut client).await.starts_with("http/1.1 101"));
+    }
+
     /// Shutting the client leg down while a 101 is in flight makes hyper
     /// replace `Connection: Upgrade` with `Connection: close`, which
     /// conformant WebSocket clients reject (RFC 6455 §4.1). The tunnel still

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -6,6 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use bytes::Bytes;
+use futures::FutureExt;
 use http::{HeaderMap, HeaderValue};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
@@ -309,16 +310,12 @@ where
             }),
         );
     let mut from = Box::pin(from);
-    let mut to = Box::pin(to);
-    let mut upstream_done = false;
+    let mut to = Box::pin(to.fuse());
     loop {
         tokio::select! {
             res = from.as_mut() => return Ok(res?),
-            // Re-polling a hyper connection after it has resolved is a contract
-            // violation, so this arm has to disarm itself.
-            res = to.as_mut(), if !upstream_done => {
+            res = to.as_mut() => {
                 res?;
-                upstream_done = true;
                 // GOAWAY plus drain, so in-flight streams still finish.
                 from.as_mut().graceful_shutdown();
             }
@@ -439,17 +436,12 @@ where
             }),
         );
     let mut from = Box::pin(from.with_upgrades());
-    let mut to = Box::pin(to.with_upgrades());
-    let mut upstream_done = false;
+    let mut to = Box::pin(to.with_upgrades().fuse());
     loop {
         tokio::select! {
             res = from.as_mut() => return Ok(res?),
-            // Re-polling a hyper connection after it has resolved is a contract
-            // violation, and the client one panics outright, so this arm has to
-            // disarm itself.
-            res = to.as_mut(), if !upstream_done => {
+            res = to.as_mut() => {
                 res?;
-                upstream_done = true;
                 // The backend is gone. Hand the client the EOF now, the way the
                 // splice path does, instead of leaving it a connection that
                 // looks reusable and aborts the next request it carries.

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use bytes::Bytes;
-use futures::FutureExt;
 use http::{HeaderMap, HeaderValue};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
@@ -308,9 +308,22 @@ where
                 }
             }),
         );
-    futures::future::try_join(from.boxed(), to.boxed()).await?;
-
-    Ok(())
+    let mut from = Box::pin(from);
+    let mut to = Box::pin(to);
+    let mut upstream_done = false;
+    loop {
+        tokio::select! {
+            res = from.as_mut() => return Ok(res?),
+            // Re-polling a hyper connection after it has resolved is a contract
+            // violation, so this arm has to disarm itself.
+            res = to.as_mut(), if !upstream_done => {
+                res?;
+                upstream_done = true;
+                // GOAWAY plus drain, so in-flight streams still finish.
+                from.as_mut().graceful_shutdown();
+            }
+        }
+    }
 }
 
 pub async fn run_http1_proxy<F, T>(
@@ -330,6 +343,11 @@ where
         .handshake(TokioIo::new(to))
         .await?;
     let client = Arc::new(Mutex::new(client));
+    // Set while a 101 is being relayed. Shutting the client leg down in that
+    // window makes hyper replace the upstream's `Connection: Upgrade` with
+    // `Connection: close`, which conformant WebSocket clients reject.
+    let upgrading = Arc::new(AtomicBool::new(false));
+    let svc_upgrading = upgrading.clone();
     // hyper disarms `header_read_timeout` while a body or upgrade is in
     // flight, so this can't kill an active stream — only idle keep-alive.
     let from = hyper::server::conn::http1::Builder::new()
@@ -340,6 +358,7 @@ where
             service_fn(move |mut req| {
                 let client = client.clone();
                 let gate = gate.clone();
+                let upgrading = svc_upgrading.clone();
                 async move {
                     if let Err(resp) =
                         apply_request_policy(&mut req, src_ip, add_forwarded, gate.as_ref())
@@ -358,6 +377,10 @@ where
                                     .any(|s| s.trim().eq_ignore_ascii_case("upgrade"))
                             })
                         {
+                            // Must be set before `send_request`: the upstream
+                            // connection resolves in the same poll that delivers
+                            // the 101, before this future is resumed.
+                            upgrading.store(true, Ordering::Relaxed);
                             Some(hyper::upgrade::on(&mut req))
                         } else {
                             None
@@ -365,8 +388,14 @@ where
 
                     let mut res = match client.lock().await.send_request(req).await {
                         Ok(r) => r,
-                        Err(e) => return Err(e),
+                        Err(e) => {
+                            upgrading.store(false, Ordering::Relaxed);
+                            return Err(e);
+                        }
                     };
+                    if upgrade.is_some() && res.status() != http::StatusCode::SWITCHING_PROTOCOLS {
+                        upgrading.store(false, Ordering::Relaxed);
+                    }
 
                     if let Some(from) = upgrade {
                         let kind = res
@@ -409,9 +438,27 @@ where
                 }
             }),
         );
-    futures::future::try_join(from.with_upgrades().boxed(), to.with_upgrades().boxed()).await?;
-
-    Ok(())
+    let mut from = Box::pin(from.with_upgrades());
+    let mut to = Box::pin(to.with_upgrades());
+    let mut upstream_done = false;
+    loop {
+        tokio::select! {
+            res = from.as_mut() => return Ok(res?),
+            // Re-polling a hyper connection after it has resolved is a contract
+            // violation, and the client one panics outright, so this arm has to
+            // disarm itself.
+            res = to.as_mut(), if !upstream_done => {
+                res?;
+                upstream_done = true;
+                // The backend is gone. Hand the client the EOF now, the way the
+                // splice path does, instead of leaving it a connection that
+                // looks reusable and aborts the next request it carries.
+                if !upgrading.load(Ordering::Relaxed) {
+                    from.as_mut().graceful_shutdown();
+                }
+            }
+        }
+    }
 }
 
 // Silence unused-import lints that may show up depending on feature flags.
@@ -423,8 +470,112 @@ fn _assert_body_bounds() {
 
 #[cfg(test)]
 mod tests {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, DuplexStream};
+
     use super::*;
     use crate::net::host::binding::BasicCredential;
+
+    async fn read_head(s: &mut DuplexStream) -> String {
+        let mut head = Vec::new();
+        let mut byte = [0u8; 1];
+        while !head.ends_with(b"\r\n\r\n") {
+            if s.read(&mut byte).await.unwrap() == 0 {
+                break;
+            }
+            head.push(byte[0]);
+        }
+        String::from_utf8_lossy(&head).to_lowercase()
+    }
+
+    /// A backend closing its idle keep-alive leg (Apache's `KeepAliveTimeout`
+    /// is 5s) must reach the client as an EOF, not as an abort on its next
+    /// request. See #3731.
+    #[tokio::test]
+    async fn upstream_close_is_relayed_to_the_client() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        tokio::spawn(run_http1_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        tokio::spawn(async move {
+            read_head(&mut backend).await;
+            backend
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+                .await
+                .unwrap();
+            drop(backend);
+        });
+
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        assert!(read_head(&mut client).await.starts_with("http/1.1 200 ok"));
+        client.read_exact(&mut [0u8; 2]).await.unwrap();
+
+        let eof = tokio::time::timeout(Duration::from_secs(5), client.read(&mut [0u8; 1]))
+            .await
+            .expect(
+                "client leg outlived the upstream: it is now a connection that looks reusable \
+                 and will abort the next request written to it",
+            );
+        assert_eq!(eof.unwrap(), 0);
+    }
+
+    /// Shutting the client leg down while a 101 is in flight makes hyper
+    /// replace `Connection: Upgrade` with `Connection: close`, which
+    /// conformant WebSocket clients reject (RFC 6455 §4.1). The tunnel still
+    /// carries bytes either way, so assert on the header too.
+    #[tokio::test]
+    async fn relayed_101_keeps_its_upgrade_header() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        tokio::spawn(run_http1_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        tokio::spawn(async move {
+            assert!(read_head(&mut backend).await.contains("upgrade: websocket"));
+            backend
+                .write_all(
+                    b"HTTP/1.1 101 Switching Protocols\r\n\
+                      Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            let mut framed = [0u8; 4];
+            backend.read_exact(&mut framed).await.unwrap();
+            backend.write_all(&framed).await.unwrap();
+        });
+
+        client
+            .write_all(
+                b"GET /ws HTTP/1.1\r\nHost: x\r\n\
+                  Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let head = read_head(&mut client).await;
+        assert!(head.contains("connection: upgrade"), "{head:?}");
+        assert!(!head.contains("connection: close"), "{head:?}");
+
+        client.write_all(b"ping").await.unwrap();
+        let mut echoed = [0u8; 4];
+        tokio::time::timeout(Duration::from_secs(5), client.read_exact(&mut echoed))
+            .await
+            .expect("tunnel stalled")
+            .unwrap();
+        assert_eq!(&echoed, b"ping");
+    }
 
     fn req_with_auth(auth: Option<&str>) -> Request<()> {
         let mut b = Request::builder().uri("/");

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -14,7 +14,7 @@ use hyper::body::{Body as HyperBody, Incoming};
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 use crate::net::host::binding::ProxyAuth;
 use crate::prelude::*;
@@ -33,6 +33,38 @@ fn box_incoming(b: Incoming) -> ProxyBody {
 
 fn box_full(bytes: Bytes) -> ProxyBody {
     Full::new(bytes).map_err(|e: Infallible| match e {}).boxed()
+}
+
+/// Marks a response as still on its way to the client. `disable_keep_alive`
+/// only closes the connection outright while it is idle; called mid-response
+/// it stamps `Connection: close` on the head instead. Held by the relayed
+/// body, so it drops once that head and body have been written.
+struct Relaying {
+    count: Arc<AtomicUsize>,
+    done: Arc<Notify>,
+}
+
+impl Relaying {
+    fn start(count: Arc<AtomicUsize>, done: Arc<Notify>) -> Self {
+        count.fetch_add(1, Ordering::Relaxed);
+        Self { count, done }
+    }
+
+    fn hold(self, body: ProxyBody) -> ProxyBody {
+        body.map_frame(move |frame| {
+            let _ = &self;
+            frame
+        })
+        .boxed()
+    }
+}
+
+impl Drop for Relaying {
+    fn drop(&mut self) {
+        if self.count.fetch_sub(1, Ordering::Relaxed) == 1 {
+            self.done.notify_one();
+        }
+    }
 }
 
 /// Pre-compiled view of a [`ProxyAuth`] used on the proxy hot-path.
@@ -340,11 +372,11 @@ where
         .handshake(TokioIo::new(to))
         .await?;
     let client = Arc::new(Mutex::new(client));
-    // Set while a 101 is being relayed. Shutting the client leg down in that
-    // window makes hyper replace the upstream's `Connection: Upgrade` with
-    // `Connection: close`, which conformant WebSocket clients reject.
-    let upgrading = Arc::new(AtomicBool::new(false));
-    let svc_upgrading = upgrading.clone();
+    // Non-zero while a relayed response is still being written to the client.
+    let relaying = Arc::new(AtomicUsize::new(0));
+    let relayed = Arc::new(Notify::new());
+    let svc_relaying = relaying.clone();
+    let svc_relayed = relayed.clone();
     // hyper disarms `header_read_timeout` while a body or upgrade is in
     // flight, so this can't kill an active stream — only idle keep-alive.
     let from = hyper::server::conn::http1::Builder::new()
@@ -355,7 +387,8 @@ where
             service_fn(move |mut req| {
                 let client = client.clone();
                 let gate = gate.clone();
-                let upgrading = svc_upgrading.clone();
+                let relaying = svc_relaying.clone();
+                let relayed = svc_relayed.clone();
                 async move {
                     if let Err(resp) =
                         apply_request_policy(&mut req, src_ip, add_forwarded, gate.as_ref())
@@ -374,25 +407,20 @@ where
                                     .any(|s| s.trim().eq_ignore_ascii_case("upgrade"))
                             })
                         {
-                            // Must be set before `send_request`: the upstream
-                            // connection resolves in the same poll that delivers
-                            // the 101, before this future is resumed.
-                            upgrading.store(true, Ordering::Relaxed);
                             Some(hyper::upgrade::on(&mut req))
                         } else {
                             None
                         };
 
+                    // Taken before `send_request`, because the upstream
+                    // connection can resolve in the same poll that delivers the
+                    // response — before this future is resumed.
+                    let relaying = Relaying::start(relaying, relayed);
+
                     let mut res = match client.lock().await.send_request(req).await {
                         Ok(r) => r,
-                        Err(e) => {
-                            upgrading.store(false, Ordering::Relaxed);
-                            return Err(e);
-                        }
+                        Err(e) => return Err(e),
                     };
-                    if upgrade.is_some() && res.status() != http::StatusCode::SWITCHING_PROTOCOLS {
-                        upgrading.store(false, Ordering::Relaxed);
-                    }
 
                     if let Some(from) = upgrade {
                         let kind = res
@@ -431,12 +459,13 @@ where
                         });
                     }
 
-                    Ok::<_, hyper::Error>(res.map(box_incoming))
+                    Ok::<_, hyper::Error>(res.map(|b| relaying.hold(box_incoming(b))))
                 }
             }),
         );
     let mut from = Box::pin(from.with_upgrades());
     let mut to = Box::pin(to.with_upgrades().fuse());
+    let mut deferred = false;
     loop {
         tokio::select! {
             res = from.as_mut() => return Ok(res?),
@@ -444,10 +473,20 @@ where
                 res?;
                 // The backend is gone. Hand the client the EOF now, the way the
                 // splice path does, instead of leaving it a connection that
-                // looks reusable and aborts the next request it carries.
-                if !upgrading.load(Ordering::Relaxed) {
+                // looks reusable and aborts the next request it carries. But
+                // `disable_keep_alive` only closes outright when the connection
+                // is idle — mid-response it stamps `Connection: close` on the
+                // head instead, which is a header the backend never sent, and
+                // on a 101 it lands on top of `Connection: Upgrade`.
+                if relaying.load(Ordering::Relaxed) == 0 {
                     from.as_mut().graceful_shutdown();
+                } else {
+                    deferred = true;
                 }
+            }
+            _ = relayed.notified(), if deferred => {
+                deferred = false;
+                from.as_mut().graceful_shutdown();
             }
         }
     }
@@ -516,6 +555,44 @@ mod tests {
                 "client leg outlived the upstream: it is now a connection that looks reusable \
                  and will abort the next request written to it",
             );
+        assert_eq!(eof.unwrap(), 0);
+    }
+
+    /// A backend that answers and closes in the same breath still gets its
+    /// response relayed verbatim: `Connection: close` is a header it never
+    /// sent, and the close is carried by closing, not by editing the reply.
+    #[tokio::test]
+    async fn a_relayed_response_is_not_rewritten_when_the_backend_closes() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        tokio::spawn(run_http1_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        tokio::spawn(async move {
+            read_head(&mut backend).await;
+            backend
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nhi")
+                .await
+                .unwrap();
+            drop(backend);
+        });
+
+        client
+            .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+            .await
+            .unwrap();
+        let head = read_head(&mut client).await;
+        assert!(!head.contains("connection: close"), "{head:?}");
+        client.read_exact(&mut [0u8; 2]).await.unwrap();
+
+        let eof = tokio::time::timeout(Duration::from_secs(5), client.read(&mut [0u8; 1]))
+            .await
+            .expect("client leg outlived the upstream");
         assert_eq!(eof.unwrap(), 0);
     }
 


### PR DESCRIPTION
Fixes #3731.

## The bug

The HTTP-aware vhost proxy pins one client connection to one upstream connection. `run_http1_proxy` ended in `futures::future::try_join(from, to)`, which short-circuits only on `Err`. A backend closing its idle keep-alive leg is a clean FIN, which hyper reports as **`Ok(())`** — so `try_join` parked the upstream side and went on driving the client side for up to `header_read_timeout` (60s).

The client was then holding a connection it had every reason to believe was healthy. The next request on it reached `send_request` against a dead connection, the error came back out of the `service_fn`, and hyper tore the connection down **without writing a response** (`Server::on_error` declines anything that isn't a parse error). The client sees a bare remote close.

Apache's default `KeepAliveTimeout` is 5s and Nextcloud Desktop polls `status.php` every 30s, so this landed on essentially every idle cycle — Connected → "Network error" → recover, with nothing in the service to explain it.

The raw-splice path has never had this: `copy_bidirectional` propagates the FIN, and client connection pools recover from an EOF invisibly. This makes the HTTP-aware path behave the same way, which is the point — the proxy should be indistinguishable from the backend apart from the headers it deliberately mutates.

## The fix

Replace the bare `try_join` with a select loop that calls `graceful_shutdown()` on the client connection once the upstream one resolves. Same change on the h2 path, which has the identical shape at `http.rs:311` and is in fact worse: its client leg has no `header_read_timeout`, so the orphan was permanent rather than 60s.

One rule carries this, and it took two rounds of review to find it: **never disable keep-alive while a response is still on its way out.** `disable_keep_alive` (`proto/h1/conn.rs`) closes the connection outright *only* when it is idle; mid-response it sets `KA::Disabled` instead, and `enforce_version` then `insert`s `Connection: close` into the head as it is written. That is a header the backend never sent, and on a 101 it lands on top of `Connection: Upgrade`, which conformant WebSocket clients reject (RFC 6455 §4.1) even though the tunnel still carries bytes.

So the shutdown is deferred until the relayed response has actually been written, tracked by a guard that the response body holds — it drops once hyper is done with that head and body, at which point the connection is idle and `disable_keep_alive` takes its clean-close branch. Measured, both failure modes are real: making the shutdown unconditional produces

```
http/1.1 200 ok / content-length: 2 / connection: close / date: ...
http/1.1 101 switching protocols / connection: close / upgrade: websocket / ...
```

The second thing worth knowing: **re-polling a resolved hyper connection is a contract violation, and the client one panics outright** — `UpgradeableConnection::poll` does `self.inner.as_mut().unwrap()` on an `Option` its upgrade path `take`s, unlike the server's, which returns `Ok(())` on `None`. `.fuse()` on the upstream leg handles that.

## Tests

Two duplex-driven tests in `net::http::tests`, both verified to fail without the change:

| Test | Reverted to | Result |
| --- | --- | --- |
| `upstream_close_is_relayed_to_the_client` | the original `try_join` | fails — 5.00s timeout waiting for an EOF that never comes |
| `relayed_101_keeps_its_upgrade_header` | latch removed (unconditional shutdown) | fails — `connection: close` in the relayed 101 |

`cargo test -p start-core --lib` is green (598 passed).

## What this does not change

- **The eager dial stays.** A client that opens a socket and sends nothing still opens a backend connection at ClientHello, so the paired `408`s in #3731 remain. That is the transparent behaviour — a client connecting directly would produce the same entry — and removing it would mean the proxy inventing a connection lifecycle the backend would not otherwise see.
- **The in-flight race remains**, and should: a request already on the wire when the FIN lands still fails, exactly as it would against the backend directly. The exposure window goes from up to 60s to the time it takes to relay a close.
- Idle client connections now live as long as the backend's keep-alive rather than up to 60s. That is the same coupling the splice path already has. Worth noting separately that the vhost builds a fresh rustls `ServerConfig` per ClientHello, whose session cache and ticketer are per-connection, so none of those reconnects can resume — caching the per-SNI config is a real follow-up, but it is not a regression introduced here.

## Noted while in here, not fixed

The ALPN reflection at `vhost.rs:1153-1155` is a no-op and always has been. `tokio-rustls`'s `connect_with` closure runs *before* the handshake, so `conn.alpn_protocol()` is unconditionally `None` there and the `extend` appends nothing. Verified against the pinned `tokio-rustls` 0.26.4 / `rustls` 0.23: with the upstream negotiating `h2`, the client-facing config still ends up with an empty ALPN list. Introduced in #3037, untouched since. Consequence worth a separate look: on the `connect_ssl: Ok` branch (the `https`/`wss` presets) we advertise no ALPN to the client while forwarding the client's whole offer upstream.

