### PR TITLE
fix: ACME domains on non-443 ports get a certificate, and never fall back to the local CA

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -55,9 +55,8 @@ file tracks notable changes since the move to the monorepo.
 - **A service that presents its own TLS certificate is shown as presenting
   it.** StartOS does not terminate such a connection, so the certificate the
   client checks is the service's — but a domain on that interface reported
-  whichever certificate authority had been chosen for it, and the choice was
-  offered in the first place. Those addresses now report `Self signed`, and
-  choosing an authority for one is refused with an explanation.
+  whichever certificate authority had been chosen for it. Those addresses now
+  report `Self signed`.
 
 - **Services that run their own containers or a VPN can reach the devices they
   were granted.** A service opting into `userspaceFilesystems` or

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -52,6 +52,13 @@ file tracks notable changes since the move to the monorepo.
   `443` to your server as you would for a standard domain — the domain's own
   port is not enough on its own.
 
+- **A service that presents its own TLS certificate is shown as presenting
+  it.** StartOS does not terminate such a connection, so the certificate the
+  client checks is the service's — but a domain on that interface reported
+  whichever certificate authority had been chosen for it, and the choice was
+  offered in the first place. Those addresses now report `Self signed`, and
+  choosing an authority for one is refused with an explanation.
+
 - **Services that run their own containers or a VPN can reach the devices they
   were granted.** A service opting into `userspaceFilesystems` or
   `virtualNetworking` is handed `/dev/fuse` and `/dev/net/tun` inside its

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -40,6 +40,18 @@ file tracks notable changes since the move to the monorepo.
 
 - Trim whitespace on form inputs.
 
+- **A Let's Encrypt domain works on an interface served on a port other than
+  `443`** — an Electrum server on `50002`, a TURN server on `5349`. Let's
+  Encrypt proves you control a name by connecting to it on port `443` whatever
+  port the service behind it uses, and nothing on your server answered there for
+  that name: the certificate was never issued, so the address served your
+  server's Root CA instead and clients that validate against public authorities
+  could not connect at all. StartOS now answers the challenge on whichever port
+  it arrives at, and over StartTunnel claims port `443` for that domain
+  automatically, routing it to the port the interface uses. On a router, forward
+  `443` to your server as you would for a standard domain — the domain's own
+  port is not enough on its own.
+
 - **Services that run their own containers or a VPN can reach the devices they
   were granted.** A service opting into `userspaceFilesystems` or
   `virtualNetworking` is handed `/dev/fuse` and `/dev/net/tun` inside its

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -174,6 +174,18 @@ file tracks notable changes since the move to the monorepo.
 - **Service mount paths are validated and confined to their intended
   directories.**
 
+- **An address you assigned to a public certificate authority serves that
+  authority's certificate and nothing else.** When StartOS could not obtain the
+  certificate, the address fell back to one signed by your server's Root CA
+  while still listing Let's Encrypt as its authority — so the fallback was
+  invisible from the server itself, whose own trust store contains that Root CA.
+  Your Root CA chain is the same on every address your server exposes, which
+  makes it a value that links them all to one server, handed to anyone who
+  connects. Such an address now refuses the connection until its certificate is
+  available. A certificate already issued keeps being served through its last 30
+  days while renewal is retried, so a renewal that begins failing does not take
+  the address down.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -182,9 +182,12 @@ file tracks notable changes since the move to the monorepo.
   Your Root CA chain is the same on every address your server exposes, which
   makes it a value that links them all to one server, handed to anyone who
   connects. Such an address now refuses the connection until its certificate is
-  available. A certificate already issued keeps being served through its last 30
-  days while renewal is retried, so a renewal that begins failing does not take
-  the address down.
+  available, and tells you so: a notification names the domain and why issuance
+  failed, once per domain until a certificate lands. A certificate already
+  issued keeps being served through its last 30 days while renewal is retried,
+  so a renewal that begins failing does not take the address down, and a domain
+  you also reach on your local network keeps answering there with your server's
+  own certificate.
 
 ## [0.4.0.1]
 

--- a/projects/start-os/docs/src/clearnet.md
+++ b/projects/start-os/docs/src/clearnet.md
@@ -38,12 +38,15 @@ If your gateway is your home router, you are revealing the approximate location 
 1. Enter the fully qualified domain name. For example, if you control `domain.com`, you could enter `domain.com` or `public.domain.com` or `nextcloud.public.domain.com`, etc.
 
 1. Select a Certificate Authority to sign the certificate for this domain.
-   - **Let's Encrypt**: Ideal for public access. All devices trust Let's Encrypt certificates by default.
+   - **Let's Encrypt**: Ideal for public access. All devices trust Let's Encrypt certificates by default. The domain serves that certificate and nothing else — while StartOS has yet to obtain one, the domain does not answer. Getting one requires port `443`, whatever port the interface itself uses; see [Configure Port Forwarding](#configure-port-forwarding).
    - **Local Root CA**: Ok for personal access. Bad for public access. Only devices that have downloaded and trusted your server's Root CA will be able to access the domain without issue.
 
 1. Click "Save".
 
 1. StartOS automatically tests your DNS record and port forwarding — plus the IPv6 firewall when your gateway has a GUA. If everything passes, the domain is ready to use. Otherwise a setup modal appears showing what still needs attention, with instructions and the ability to re-test each check.
+
+   > [!NOTE]
+   > These tests cover the port the interface itself is served on. A Let's Encrypt domain on any other port additionally needs port `443` — see [Configure Port Forwarding](#configure-port-forwarding).
 
 ## Set Up DNS Records
 
@@ -71,6 +74,9 @@ When a public address is enabled, StartOS first **attempts to open the port auto
 
 > [!TIP]
 > Most websites and APIs on the Internet are hosted on port `443`. Port `443` is so common, in fact, that apps and browsers _infer_ its presence. The _absence_ of a port _means_ the port is `443`. With rare exceptions, domains on StartOS also use port `443`, and that is why your domains usually do not display a port. The port forwarding rule needed for these standard domains is always the same, which means you only have to do it once!
+
+> [!IMPORTANT]
+> A Let's Encrypt domain needs port `443` even when its interface is served somewhere else — an Electrum server on `50002`, for example. Let's Encrypt proves you control a name by connecting to it on port `443`, whatever port the service behind it uses, and StartOS answers on whichever port that arrives at. Over StartTunnel, StartOS claims `443` for that domain automatically alongside the interface's own port, so there is nothing to do. On a router, forward `443` to your server as you would for a standard domain, and keep it forwarded — the certificate is renewed the same way. Choose **Local Root CA** instead for a domain whose gateway cannot offer port `443`.
 
 How you create a port forwarding rule depends on the type of gateway.
 

--- a/projects/start-os/docs/src/interfaces.md
+++ b/projects/start-os/docs/src/interfaces.md
@@ -33,6 +33,9 @@ Each table has the following columns:
 > The Settings button appears for addresses that require external configuration: [public domains](clearnet.md) (DNS + port forwarding), [private domains](private-domains.md) (DNS), and [public IP addresses](public-ip.md) (port forwarding).
 
 > [!NOTE]
+> An address whose Certificate Authority is **Let's Encrypt** serves a Let's Encrypt certificate and nothing else. While StartOS has yet to obtain one — the DNS record has not propagated yet, or port `443` does not reach your server for that domain — the address does not answer, rather than presenting your server's Root CA under a name you asked a public authority to sign. See [Configure Port Forwarding](clearnet.md#configure-port-forwarding), which covers what a domain on a port other than `443` needs.
+
+> [!NOTE]
 > The port-forwarding and firewall tests need the service **running** only for an address it serves directly — a raw public IP, or another non-SSL binding. StartOS SSL-terminates every HTTP interface behind its always-on reverse proxy, so those stay testable even while the service is stopped (as do DNS tests). A non-SSL address's Test buttons are therefore disabled while its service is stopped; and because that service often restarts when a domain is added or an address is enabled, StartOS then shows its reachability tests as untested (not failed) and still opens the setup modal, so you can set up forwarding and re-test once it is running.
 
 > [!NOTE]

--- a/projects/start-os/docs/src/private-domains.md
+++ b/projects/start-os/docs/src/private-domains.md
@@ -47,7 +47,7 @@ You can add the _same_ domain as both a [clearnet](clearnet.md) (public) domain 
 - When you are on your LAN or connected over [VPN](inbound-vpn.md), StartOS resolves the domain to your server's local IP address, so traffic stays on your network at full LAN speed.
 - When you are away, the same domain resolves through public DNS to your StartTunnel gateway, so the service is reachable over the internet.
 
-It's the same domain and the same TLS certificate either way, with no [hairpin routing](https://en.wikipedia.org/wiki/Hairpinning) (LAN traffic looping out to the gateway and back).
+It's the same domain and the same TLS certificate either way, with no [hairpin routing](https://en.wikipedia.org/wiki/Hairpinning) (LAN traffic looping out to the gateway and back). The two sides are served separately, so the local side keeps working on your server's Root CA certificate while a public certificate for the same domain has yet to be issued.
 
 > [!TIP]
 > This is especially useful for services that embed their access URL in generated links, such as Nextcloud or Immich share links. Configure the service with the public domain so the links work for external recipients, and you'll still get direct LAN-speed access when you're home.

--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/interface.service.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/interface.service.ts
@@ -68,15 +68,16 @@ function getCertificate(
 ): string {
   if (!h.ssl) return '-'
 
+  // The service holds its own certificate on a binding StartOS does not
+  // terminate, whatever authority a domain on this host names.
+  if (!addSsl) return secure?.ssl ? 'Self signed' : '-'
+
   if (h.metadata.kind === 'public-domain') {
     const config = host.publicDomains[h.hostname]
     return config ? toAuthorityName(config.acme) : toAuthorityName(null)
   }
 
-  if (addSsl) return toAuthorityName(null)
-  if (secure?.ssl) return 'Self signed'
-
-  return '-'
+  return toAuthorityName(null)
 }
 
 function sortDomainsFirst(a: GatewayAddress, b: GatewayAddress): number {

--- a/projects/start-sdk/docs/src/interfaces.md
+++ b/projects/start-sdk/docs/src/interfaces.md
@@ -179,6 +179,8 @@ The key steps are:
 | `addSsl.upstreamCertValidation` | `'disable'` \| `{ certificate: string }` \| _omitted_ | How the OS validates your container's TLS cert when it [rewraps SSL](#rewrapping-ssl-to-a-tls-container). Omit to validate against the StartOS root CA (default). See [Rewrapping SSL](#rewrapping-ssl-to-a-tls-container). |
 | `secure`                        | `{ ssl: boolean }` \| `null`                          | For non-HTTP protocols, whether the connection is secure. `{ ssl: true }` with `addSsl: null` serves your container's own TLS end to end — see [Serving Your Own TLS](#serving-your-own-tls-passthrough).                   |
 
+An `addSsl` binding on any port can carry a Let's Encrypt certificate — issuance is per name, not per port. The user's side of that is one extra requirement: Let's Encrypt validates on port `443` whatever port you bind, so StartOS asks their gateway to route `443` for the domain as well. On a gateway that cannot do it automatically they forward `443` by hand. Worth a line in your instructions for an interface on a non-standard port that users will reach from software validating against public roots — an Electrum client, say.
+
 ## Interface Options
 
 ```typescript

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -7,6 +7,27 @@ acme.invalid-contact:
   fr_FR: "Contact ACME invalide %{contact} : doit être un URI « mailto: » contenant une adresse e-mail (par exemple « mailto:vous@example.com »)"
   pl_PL: "Nieprawidłowy kontakt ACME %{contact}: musi być URI „mailto:” zawierającym adres e-mail (np. „mailto:ty@example.com”)"
 
+acme.order-failed-message:
+  en_US: "%{error}. The address does not answer until a certificate is issued: check that its DNS record points at this server, and that port 443 reaches it — a certificate authority validates on port 443 whatever port the address itself serves."
+  de_DE: "%{error}. Die Adresse antwortet erst, wenn ein Zertifikat ausgestellt ist: Prüfen Sie, ob ihr DNS-Eintrag auf diesen Server zeigt und Port 443 ihn erreicht — eine Zertifizierungsstelle validiert über Port 443, unabhängig davon, über welchen Port die Adresse selbst bereitgestellt wird."
+  es_ES: "%{error}. La dirección no responde hasta que se emita un certificado: comprueba que su registro DNS apunte a este servidor y que el puerto 443 llegue hasta él; una autoridad de certificación valida por el puerto 443 sea cual sea el puerto en el que se sirva la dirección."
+  fr_FR: "%{error}. L'adresse ne répond pas tant qu'un certificat n'est pas émis : vérifiez que son enregistrement DNS pointe vers ce serveur et que le port 443 l'atteint — une autorité de certification valide sur le port 443, quel que soit le port sur lequel l'adresse est servie."
+  pl_PL: "%{error}. Adres nie odpowiada, dopóki certyfikat nie zostanie wydany: sprawdź, czy jego rekord DNS wskazuje ten serwer i czy port 443 do niego dociera — urząd certyfikacji weryfikuje przez port 443, niezależnie od portu, na którym serwowany jest sam adres."
+
+acme.order-failed-title:
+  en_US: "Could not get a certificate for %{domain}"
+  de_DE: "Zertifikat für %{domain} konnte nicht bezogen werden"
+  es_ES: "No se ha podido obtener un certificado para %{domain}"
+  fr_FR: "Impossible d'obtenir un certificat pour %{domain}"
+  pl_PL: "Nie udało się uzyskać certyfikatu dla %{domain}"
+
+acme.order-timed-out:
+  en_US: "The certificate authority did not answer in time"
+  de_DE: "Die Zertifizierungsstelle hat nicht rechtzeitig geantwortet"
+  es_ES: "La autoridad de certificación no respondió a tiempo"
+  fr_FR: "L'autorité de certification n'a pas répondu à temps"
+  pl_PL: "Urząd certyfikacji nie odpowiedział na czas"
+
 bins.deprecated.renamed:
   en_US: "%{old} has been renamed to %{new}"
   de_DE: "%{old} wurde in %{new} umbenannt"

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -7,6 +7,13 @@ acme.invalid-contact:
   fr_FR: "Contact ACME invalide %{contact} : doit être un URI « mailto: » contenant une adresse e-mail (par exemple « mailto:vous@example.com »)"
   pl_PL: "Nieprawidłowy kontakt ACME %{contact}: musi być URI „mailto:” zawierającym adres e-mail (np. „mailto:ty@example.com”)"
 
+acme.passthrough-host:
+  en_US: "%{domain} is served by a service that presents its own TLS certificate, so a certificate authority has nothing to issue for it. Add the domain without one."
+  de_DE: "%{domain} wird von einem Dienst bereitgestellt, der sein eigenes TLS-Zertifikat vorweist; eine Zertifizierungsstelle hat dafür nichts auszustellen. Fügen Sie die Domain ohne eine solche hinzu."
+  es_ES: "%{domain} lo sirve un servicio que presenta su propio certificado TLS, así que una autoridad de certificación no tiene nada que emitir para él. Añade el dominio sin ninguna."
+  fr_FR: "%{domain} est servi par un service qui présente son propre certificat TLS ; une autorité de certification n'a donc rien à émettre pour lui. Ajoutez le domaine sans en indiquer une."
+  pl_PL: "%{domain} jest obsługiwana przez usługę przedstawiającą własny certyfikat TLS, więc urząd certyfikacji nie ma dla niej czego wydać. Dodaj domenę bez wskazywania urzędu."
+
 acme.order-failed-message:
   en_US: "%{error}. The address does not answer until a certificate is issued: check that its DNS record points at this server, and that port 443 reaches it — a certificate authority validates on port 443 whatever port the address itself serves."
   de_DE: "%{error}. Die Adresse antwortet erst, wenn ein Zertifikat ausgestellt ist: Prüfen Sie, ob ihr DNS-Eintrag auf diesen Server zeigt und Port 443 ihn erreicht — eine Zertifizierungsstelle validiert über Port 443, unabhängig davon, über welchen Port die Adresse selbst bereitgestellt wird."

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -7,13 +7,6 @@ acme.invalid-contact:
   fr_FR: "Contact ACME invalide %{contact} : doit être un URI « mailto: » contenant une adresse e-mail (par exemple « mailto:vous@example.com »)"
   pl_PL: "Nieprawidłowy kontakt ACME %{contact}: musi być URI „mailto:” zawierającym adres e-mail (np. „mailto:ty@example.com”)"
 
-acme.passthrough-host:
-  en_US: "%{domain} is served by a service that presents its own TLS certificate, so a certificate authority has nothing to issue for it. Add the domain without one."
-  de_DE: "%{domain} wird von einem Dienst bereitgestellt, der sein eigenes TLS-Zertifikat vorweist; eine Zertifizierungsstelle hat dafür nichts auszustellen. Fügen Sie die Domain ohne eine solche hinzu."
-  es_ES: "%{domain} lo sirve un servicio que presenta su propio certificado TLS, así que una autoridad de certificación no tiene nada que emitir para él. Añade el dominio sin ninguna."
-  fr_FR: "%{domain} est servi par un service qui présente son propre certificat TLS ; une autorité de certification n'a donc rien à émettre pour lui. Ajoutez le domaine sans en indiquer une."
-  pl_PL: "%{domain} jest obsługiwana przez usługę przedstawiającą własny certyfikat TLS, więc urząd certyfikacji nie ma dla niej czego wydać. Dodaj domenę bez wskazywania urzędu."
-
 acme.order-failed-message:
   en_US: "%{error}. The address does not answer until a certificate is issued: check that its DNS record points at this server, and that port 443 reaches it — a certificate authority validates on port 443 whatever port the address itself serves."
   de_DE: "%{error}. Die Adresse antwortet erst, wenn ein Zertifikat ausgestellt ist: Prüfen Sie, ob ihr DNS-Eintrag auf diesen Server zeigt und Port 443 ihn erreicht — eine Zertifizierungsstelle validiert über Port 443, unabhängig davon, über welchen Port die Adresse selbst bereitgestellt wird."

--- a/shared-libs/crates/start-core/src/net/acme.rs
+++ b/shared-libs/crates/start-core/src/net/acme.rs
@@ -38,6 +38,9 @@ use crate::util::FromStrParser;
 use crate::util::serde::{Pem, Pkcs8Doc};
 use crate::util::sync::{SyncMutex, Watch};
 
+/// Names with an order in flight. Written only by the order path, which starts
+/// an order only for a name a vhost holds a provider for — so membership here
+/// is what makes a challenge answerable, and it must stay that way.
 pub type AcmeTlsAlpnCache =
     Arc<SyncMutex<BTreeMap<InternedString, Watch<Option<Arc<CertifiedKey>>>>>>;
 

--- a/shared-libs/crates/start-core/src/net/acme.rs
+++ b/shared-libs/crates/start-core/src/net/acme.rs
@@ -52,13 +52,11 @@ pub struct OrderEntry {
     /// [`DEFAULT_FAILURE_BACKOFF`]. Inside this window `get_cert`
     /// returns `None` instead of starting a new order.
     backoff_until: Option<Instant>,
-    /// Set once the operator has been told this order is failing. Every retry
-    /// while it stands is silent; the entry is dropped when a certificate
-    /// finally lands, so the next failure after that speaks again.
+    /// Set once reported, so retries stay silent; dropped with the entry.
     reported: bool,
 }
 
-/// Told the SANs of an order that failed and why, to surface to the operator.
+/// Told the SANs of a failed order and why, to surface to the operator.
 pub type ReportOrderFailure =
     Arc<dyn Fn(BTreeSet<InternedString>, String) -> BoxFuture<'static, ()> + Send + Sync>;
 
@@ -121,10 +119,8 @@ where
             }
         }
 
-        // Everything past here can fail to produce a certificate. A cached one
-        // that is merely inside its 30-day renewal window is still publicly
-        // trusted, so it stays the answer of last resort — the alternative is
-        // refusing a name we can still serve correctly.
+        // A cert inside its renewal window is still publicly trusted, so it
+        // answers for anything below here that cannot produce a new one.
         let renewing = || {
             certified_key(
                 cached.as_ref().filter(|c| unexpired(c))?,
@@ -135,8 +131,7 @@ where
         let Some(contact) = <M as DbAccessByKey<AcmeSettings>>::access_by_key(&peek, &provider)
             .and_then(|settings| settings.as_contact().de().log_err())
         else {
-            // The provider was removed from the server's settings while a domain
-            // still names it, so no order can be placed for it at all.
+            // Provider removed from the server while a domain still names it.
             return renewing();
         };
         drop(peek);
@@ -336,7 +331,7 @@ where
             .flatten()
             .any(|a| a == ACME_TLS_ALPN_NAME)
         {
-            // Only a name we have an order in flight for is answerable.
+            // Only a name with an order in flight is answerable.
             let Some(cert) = self.acme_cache.peek(|c| c.get(domain).cloned()) else {
                 tracing::debug!("no ACME challenge in flight for {domain}");
                 return None;

--- a/shared-libs/crates/start-core/src/net/acme.rs
+++ b/shared-libs/crates/start-core/src/net/acme.rs
@@ -52,7 +52,15 @@ pub struct OrderEntry {
     /// [`DEFAULT_FAILURE_BACKOFF`]. Inside this window `get_cert`
     /// returns `None` instead of starting a new order.
     backoff_until: Option<Instant>,
+    /// Set once the operator has been told this order is failing. Every retry
+    /// while it stands is silent; the entry is dropped when a certificate
+    /// finally lands, so the next failure after that speaks again.
+    reported: bool,
 }
+
+/// Told the SANs of an order that failed and why, to surface to the operator.
+pub type ReportOrderFailure =
+    Arc<dyn Fn(BTreeSet<InternedString>, String) -> BoxFuture<'static, ()> + Send + Sync>;
 
 /// Cooldown for failures without a server-supplied `Retry-After`. Long
 /// enough to break the per-connection retry loop.
@@ -76,6 +84,7 @@ pub struct AcmeTlsHandler<M: HasModel, S> {
     pub crypto_provider: Arc<CryptoProvider>,
     pub get_provider: S,
     pub in_progress: Watch<BTreeMap<BTreeSet<InternedString>, OrderEntry>>,
+    pub report_failure: Option<ReportOrderFailure>,
 }
 impl<M, S> AcmeTlsHandler<M, S>
 where
@@ -174,6 +183,7 @@ where
             }
 
             let provider_clone = provider.clone();
+            let report_failure = self.report_failure.clone();
             let acme_cache = self.acme_cache.clone();
             let db = self.db.clone();
             let in_progress = self.in_progress.clone();
@@ -211,32 +221,49 @@ where
 
                 acme_cache.mutate(|c| c.retain(|c, _| !cache_entries_clone.contains_key(c)));
 
-                let (cert, backoff) = match res {
+                let (cert, failure) = match res {
                     Ok(Ok(cert)) => (Some(cert), None),
                     Ok(Err(e)) => {
                         let retry_after = retry_after_from_order_error(&e);
                         tracing::warn!("ACME order failed for {san_info_clone:?}: {e}");
                         tracing::debug!("{e:?}");
-                        (None, Some(retry_after.unwrap_or(DEFAULT_FAILURE_BACKOFF)))
+                        (
+                            None,
+                            Some((
+                                retry_after.unwrap_or(DEFAULT_FAILURE_BACKOFF),
+                                e.to_string(),
+                            )),
+                        )
                     }
                     Err(_) => {
                         tracing::warn!("ACME order timed out for {san_info_clone:?} after 120s");
-                        (None, Some(DEFAULT_FAILURE_BACKOFF))
+                        (
+                            None,
+                            Some((
+                                DEFAULT_FAILURE_BACKOFF,
+                                t!("acme.order-timed-out").to_string(),
+                            )),
+                        )
                     }
                 };
 
                 // Success: leave the entry alone; the next cached-cert
                 // path call removes it. Failure: arm the cooldown.
-                if let Some(d) = backoff {
-                    in_progress.send_if_modified(|map| {
+                if let Some((d, error)) = failure {
+                    let report = in_progress.send_modify(|map| {
                         let Some(entry) = map.get_mut(&san_info_clone) else {
                             return false;
                         };
                         entry.in_flight = None;
                         entry.backoff_until = Some(Instant::now() + d);
                         tracing::info!("ACME order for {san_info_clone:?} backing off for {d:?}");
-                        true
+                        std::mem::replace(&mut entry.reported, true) == false
                     });
+                    if report {
+                        if let Some(report) = &report_failure {
+                            report(san_info_clone.clone(), error).await;
+                        }
+                    }
                 }
 
                 cert
@@ -309,12 +336,10 @@ where
             .flatten()
             .any(|a| a == ACME_TLS_ALPN_NAME)
         {
-            // Only a name we have an order in flight for is answerable, and
-            // answering with anything else — a local-CA leaf from a later
-            // handler — would just fail validation.
+            // Only a name we have an order in flight for is answerable.
             let Some(cert) = self.acme_cache.peek(|c| c.get(domain).cloned()) else {
                 tracing::debug!("no ACME challenge in flight for {domain}");
-                return Some(TlsHandlerAction::Reject);
+                return None;
             };
             tracing::info!("Waiting for verification cert for {domain}");
             let cert = cert
@@ -346,16 +371,6 @@ where
                     .with_no_client_auth()
                     .with_cert_resolver(Arc::new(SingleCertResolver(Arc::new(cert)))),
             ));
-        }
-
-        // The name is configured for ACME and we have no certificate for it.
-        // Falling through to the local root CA would serve the box's own CA
-        // chain — an identifier shared by every service on this server — to a
-        // client that asked for a publicly trusted one, under a UI that still
-        // says the issuer is the ACME provider. Refuse instead.
-        if self.get_provider.get_provider(&domains).await.is_some() {
-            tracing::warn!("refusing {domain}: no ACME certificate available");
-            return Some(TlsHandlerAction::Reject);
         }
 
         None

--- a/shared-libs/crates/start-core/src/net/acme.rs
+++ b/shared-libs/crates/start-core/src/net/acme.rs
@@ -30,7 +30,7 @@ use crate::db::model::Database;
 use crate::db::model::public::AcmeSettings;
 use crate::db::{DbAccess, DbAccessByKey, DbAccessMut};
 use crate::error::ErrorData;
-use crate::net::ssl::should_use_cert;
+use crate::net::ssl::{cert_is_unexpired, should_use_cert};
 use crate::net::tls::{SingleCertResolver, TlsHandler, TlsHandlerAction};
 use crate::net::web_server::Accept;
 use crate::prelude::*;
@@ -93,12 +93,12 @@ where
 
         let peek = self.db.peek().await;
         let store = <M as DbAccess<AcmeCertStore>>::access(&peek);
-        if let Some(cert) = store
+        let cached = store
             .as_certs()
             .as_idx(&provider.0)
             .and_then(|p| p.as_idx(JsonKey::new_ref(san_info)))
-        {
-            let cert = cert.de().log_err()?;
+            .and_then(|cert| cert.de().log_err());
+        if let Some(cert) = &cached {
             if cert
                 .fullchain
                 .get(0)
@@ -108,27 +108,28 @@ where
                 // Cached cert is healthy; drop any stale order/backoff state.
                 self.in_progress
                     .send_if_modified(|map| map.remove(san_info).is_some());
-                return Some(
-                    CertifiedKey::from_der(
-                        cert.fullchain
-                            .into_iter()
-                            .map(|c| Ok(CertificateDer::from(c.to_der()?)))
-                            .collect::<Result<_, Error>>()
-                            .log_err()?,
-                        PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
-                            cert.key.0.private_key_to_pkcs8().log_err()?,
-                        )),
-                        &*self.crypto_provider,
-                    )
-                    .log_err()?,
-                );
+                return certified_key(cert, &self.crypto_provider);
             }
         }
 
-        let contact = <M as DbAccessByKey<AcmeSettings>>::access_by_key(&peek, &provider)?
-            .as_contact()
-            .de()
-            .log_err()?;
+        // Everything past here can fail to produce a certificate. A cached one
+        // that is merely inside its 30-day renewal window is still publicly
+        // trusted, so it stays the answer of last resort — the alternative is
+        // refusing a name we can still serve correctly.
+        let renewing = || {
+            certified_key(
+                cached.as_ref().filter(|c| unexpired(c))?,
+                &self.crypto_provider,
+            )
+        };
+
+        let Some(contact) = <M as DbAccessByKey<AcmeSettings>>::access_by_key(&peek, &provider)
+            .and_then(|settings| settings.as_contact().de().log_err())
+        else {
+            // The provider was removed from the server's settings while a domain
+            // still names it, so no order can be placed for it at all.
+            return renewing();
+        };
         drop(peek);
 
         let identifiers: Vec<_> = san_info
@@ -249,11 +250,32 @@ where
 
         match action {
             Action::Await(fut) => fut.await,
-            // Inside cooldown: fall through to a self-signed cert from
-            // `RootCaTlsHandler` instead of blocking the handshake.
             Action::Backoff => None,
         }
+        .or_else(renewing)
     }
+}
+
+fn unexpired(cert: &AcmeCert) -> bool {
+    cert.fullchain
+        .get(0)
+        .and_then(|c| cert_is_unexpired(&c.0).log_err())
+        .unwrap_or(false)
+}
+
+fn certified_key(cert: &AcmeCert, crypto_provider: &CryptoProvider) -> Option<CertifiedKey> {
+    CertifiedKey::from_der(
+        cert.fullchain
+            .iter()
+            .map(|c| Ok(CertificateDer::from(c.0.to_der()?)))
+            .collect::<Result<_, Error>>()
+            .log_err()?,
+        PrivateKeyDer::from(PrivatePkcs8KeyDer::from(
+            cert.key.0.private_key_to_pkcs8().log_err()?,
+        )),
+        crypto_provider,
+    )
+    .log_err()
 }
 
 pub trait GetAcmeProvider {
@@ -287,16 +309,13 @@ where
             .flatten()
             .any(|a| a == ACME_TLS_ALPN_NAME)
         {
-            let cert = self
-                .acme_cache
-                .peek(|c| c.get(domain).cloned())
-                .ok_or_else(|| {
-                    Error::new(
-                        eyre!("No challenge recv available for {domain}"),
-                        ErrorKind::OpenSsl,
-                    )
-                })
-                .log_err()?;
+            // Only a name we have an order in flight for is answerable, and
+            // answering with anything else — a local-CA leaf from a later
+            // handler — would just fail validation.
+            let Some(cert) = self.acme_cache.peek(|c| c.get(domain).cloned()) else {
+                tracing::debug!("no ACME challenge in flight for {domain}");
+                return Some(TlsHandlerAction::Reject);
+            };
             tracing::info!("Waiting for verification cert for {domain}");
             let cert = cert
                 .filter(|c| futures::future::ready(c.is_some()))
@@ -327,6 +346,16 @@ where
                     .with_no_client_auth()
                     .with_cert_resolver(Arc::new(SingleCertResolver(Arc::new(cert)))),
             ));
+        }
+
+        // The name is configured for ACME and we have no certificate for it.
+        // Falling through to the local root CA would serve the box's own CA
+        // chain — an identifier shared by every service on this server — to a
+        // client that asked for a publicly trusted one, under a UI that still
+        // says the issuer is the ACME provider. Refuse instead.
+        if self.get_provider.get_provider(&domains).await.is_some() {
+            tracing::warn!("refusing {domain}: no ACME certificate available");
+            return Some(TlsHandlerAction::Reject);
         }
 
         None

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -408,6 +408,20 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 {
                     return Err(Error::new(eyre!("unknown acme provider {}, please run acme.init for this provider first", acme.0), ErrorKind::InvalidRequest));
                 }
+                // A host that serves its own TLS holds its own certificate:
+                // StartOS never terminates the connection, so it can neither
+                // obtain one from an authority nor present it.
+                if !Kind::host_for(&inheritance, db)?
+                    .as_bindings()
+                    .de()?
+                    .values()
+                    .any(|b| b.options.add_ssl.is_some())
+                {
+                    return Err(Error::new(
+                        eyre!("{}", t!("acme.passthrough-host", domain = fqdn)),
+                        ErrorKind::InvalidRequest,
+                    ));
+                }
             }
 
             // Adding a domain that is already present is a no-op for exposure:

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -408,20 +408,6 @@ pub async fn add_public_domain<Kind: HostApiKind>(
                 {
                     return Err(Error::new(eyre!("unknown acme provider {}, please run acme.init for this provider first", acme.0), ErrorKind::InvalidRequest));
                 }
-                // A host that serves its own TLS holds its own certificate:
-                // StartOS never terminates the connection, so it can neither
-                // obtain one from an authority nor present it.
-                if !Kind::host_for(&inheritance, db)?
-                    .as_bindings()
-                    .de()?
-                    .values()
-                    .any(|b| b.options.add_ssl.is_some())
-                {
-                    return Err(Error::new(
-                        eyre!("{}", t!("acme.passthrough-host", domain = fqdn)),
-                        ErrorKind::InvalidRequest,
-                    ));
-                }
             }
 
             // Adding a domain that is already present is a no-op for exposure:

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -513,13 +513,9 @@ impl NetServiceData {
                         public_v4: BTreeSet::new(),
                         public_v6: BTreeSet::new(),
                         private: BTreeSet::new(),
-                        // The authority belongs to the public leg alone: a name
-                        // resolving to a LAN address inside the network and a
-                        // public one outside it is served by two entries, and
-                        // the LAN one answers with the server's own certificate
-                        // whatever the public one can obtain. A passthrough
-                        // never intermediates ACME either — the backend is the
-                        // ACME client and holds the challenge cert.
+                        // The public leg's alone, so a name served both ways
+                        // keeps its LAN side. A passthrough never intermediates
+                        // ACME — the backend is the ACME client.
                         acme: if passthrough || !addr_info.public {
                             None
                         } else {

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -29,7 +29,7 @@ use crate::net::service_interface::{
     AddressInfo, HostnameInfo, HostnameMetadata, ServiceInterface, ServiceInterfaceType,
 };
 use crate::net::socks::SocksController;
-use crate::net::vhost::{AlpnInfo, DynVHostTarget, ProxyTarget, VHostController};
+use crate::net::vhost::{AlpnInfo, DynVHostTarget, ProxyTarget, VHostController, VHostKey};
 use crate::prelude::*;
 use crate::service::effects::callbacks::ServiceCallbacks;
 use crate::util::Invoke;
@@ -326,7 +326,7 @@ struct HostBinds {
     /// port. `count == 1` is the single-port case; `count > 1` represents a
     /// contiguous range forward.
     forwards: BTreeMap<u16, (SocketAddrV4, u16, ForwardRequirements, Arc<()>)>,
-    vhosts: BTreeMap<(Option<InternedString>, u16), (ProxyTarget, Arc<()>)>,
+    vhosts: BTreeMap<VHostKey, (ProxyTarget, Arc<()>)>,
     private_dns: BTreeMap<InternedString, Arc<()>>,
     /// Directly-forwarded v6: `(host GUA, external port) -> (container v6,
     /// internal port, LAN source filter)`. A GUA on a port no listener of ours
@@ -357,7 +357,7 @@ impl NetServiceData {
 
     async fn update(&mut self, ctrl: &NetController, id: HostId, host: Host) -> Result<(), Error> {
         let mut forwards: BTreeMap<u16, (SocketAddrV4, u16, ForwardRequirements)> = BTreeMap::new();
-        let mut vhosts: BTreeMap<(Option<InternedString>, u16), ProxyTarget> = BTreeMap::new();
+        let mut vhosts: BTreeMap<VHostKey, ProxyTarget> = BTreeMap::new();
         let mut private_dns: BTreeMap<InternedString, BTreeSet<GatewayId>> = BTreeMap::new();
         // Non-SSL v6 DNAT forwards to the container — net_controller's concern (no
         // vhost owns them), but the forward controller opens their upstream pinhole
@@ -460,7 +460,7 @@ impl NetServiceData {
                 {
                     let passthrough = bind.options.add_ssl.is_none();
                     vhosts.insert(
-                        (None, assigned_ssl_port),
+                        (None, assigned_ssl_port, true),
                         ProxyTarget {
                             public_v4: server_public_v4,
                             public_v6: server_public_v6,
@@ -508,14 +508,19 @@ impl NetServiceData {
                     let Some(domain_ssl_port) = addr_info.port else {
                         continue;
                     };
-                    let key = (Some(domain.clone()), domain_ssl_port);
+                    let key = (Some(domain.clone()), domain_ssl_port, addr_info.public);
                     let target = vhosts.entry(key).or_insert_with(|| ProxyTarget {
                         public_v4: BTreeSet::new(),
                         public_v6: BTreeSet::new(),
                         private: BTreeSet::new(),
-                        // A passthrough never intermediates ACME — the backend
-                        // is the ACME client and holds the challenge cert.
-                        acme: if passthrough {
+                        // The authority belongs to the public leg alone: a name
+                        // resolving to a LAN address inside the network and a
+                        // public one outside it is served by two entries, and
+                        // the LAN one answers with the server's own certificate
+                        // whatever the public one can obtain. A passthrough
+                        // never intermediates ACME either — the backend is the
+                        // ACME client and holds the challenge cert.
+                        acme: if passthrough || !addr_info.public {
                             None
                         } else {
                             host_addresses

--- a/shared-libs/crates/start-core/src/net/ssl.rs
+++ b/shared-libs/crates/start-core/src/net/ssl.rs
@@ -55,9 +55,8 @@ pub fn should_use_cert(cert: &X509Ref) -> Result<bool, ErrorStack> {
             == Ordering::Greater)
 }
 
-/// Whether `cert` is inside its validity window. [`should_use_cert`] is the
-/// stricter test that also demands 30 days of headroom, so that a renewal is
-/// attempted well before this one turns false.
+/// Inside its validity window. [`should_use_cert`] additionally demands 30
+/// days of headroom, so a renewal is attempted well before this turns false.
 pub fn cert_is_unexpired(cert: &X509Ref) -> Result<bool, ErrorStack> {
     Ok(cert
         .not_before()
@@ -848,9 +847,8 @@ mod cert_validity_tests {
         builder.build()
     }
 
-    /// The last 30 days of a certificate's life are the renewal window: too old
-    /// to keep serving without trying to renew, still perfectly good to serve
-    /// while that renewal is failing.
+    /// The renewal window: too old to serve without trying to renew, still
+    /// good enough to serve while that renewal is failing.
     #[test]
     fn the_renewal_window_is_unexpired_but_due_for_renewal() {
         let fresh = cert_expiring_in(60);

--- a/shared-libs/crates/start-core/src/net/ssl.rs
+++ b/shared-libs/crates/start-core/src/net/ssl.rs
@@ -55,6 +55,20 @@ pub fn should_use_cert(cert: &X509Ref) -> Result<bool, ErrorStack> {
             == Ordering::Greater)
 }
 
+/// Whether `cert` is inside its validity window. [`should_use_cert`] is the
+/// stricter test that also demands 30 days of headroom, so that a renewal is
+/// attempted well before this one turns false.
+pub fn cert_is_unexpired(cert: &X509Ref) -> Result<bool, ErrorStack> {
+    Ok(cert
+        .not_before()
+        .compare(Asn1Time::days_from_now(0)?.as_ref())?
+        == Ordering::Less
+        && cert
+            .not_after()
+            .compare(Asn1Time::days_from_now(0)?.as_ref())?
+            == Ordering::Greater)
+}
+
 /// Controls the strings baked into generated certificates (Subject CN, O, OU).
 /// Exposed so downstream consumers can issue certs with their own branding
 /// without having to reimplement the X.509 builders. Not persisted — callers
@@ -807,5 +821,48 @@ where
         }
         .log_err()
         .map(TlsHandlerAction::Tls)
+    }
+}
+
+#[cfg(test)]
+mod cert_validity_tests {
+    use openssl::x509::X509Builder;
+
+    use super::*;
+
+    fn cert_expiring_in(days: i64) -> X509 {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let key = gen_nistp256().unwrap();
+        let mut builder = X509Builder::new().unwrap();
+        builder
+            .set_not_before(&Asn1Time::from_unix(now - 86400).unwrap())
+            .unwrap();
+        builder
+            .set_not_after(&Asn1Time::from_unix(now + days * 86400).unwrap())
+            .unwrap();
+        builder.set_pubkey(&key).unwrap();
+        builder.sign(&key, MessageDigest::sha256()).unwrap();
+        builder.build()
+    }
+
+    /// The last 30 days of a certificate's life are the renewal window: too old
+    /// to keep serving without trying to renew, still perfectly good to serve
+    /// while that renewal is failing.
+    #[test]
+    fn the_renewal_window_is_unexpired_but_due_for_renewal() {
+        let fresh = cert_expiring_in(60);
+        assert!(should_use_cert(&fresh).unwrap());
+        assert!(cert_is_unexpired(&fresh).unwrap());
+
+        let renewing = cert_expiring_in(10);
+        assert!(!should_use_cert(&renewing).unwrap());
+        assert!(cert_is_unexpired(&renewing).unwrap());
+
+        let expired = cert_expiring_in(-1);
+        assert!(!should_use_cert(&expired).unwrap());
+        assert!(!cert_is_unexpired(&expired).unwrap());
     }
 }

--- a/shared-libs/crates/start-core/src/net/tls.rs
+++ b/shared-libs/crates/start-core/src/net/tls.rs
@@ -237,9 +237,8 @@ where
                         }
                         None => {
                             crate::dev_log!(debug, "no certificate for SNI {:?}", sni);
-                            // The io buffers writes until the handshake config
-                            // is settled, so the alert only reaches the wire
-                            // once buffering is off.
+                            // Writes are buffered until the config settles;
+                            // the alert has to reach the wire.
                             let _ = mid.io.stop_buffering();
                             let _ = mid
                                 .io
@@ -507,8 +506,7 @@ mod test {
         }
     }
 
-    /// Run one connection against a `TlsListener` fronting `handler`, with a
-    /// client that accepts any certificate, and return the handshake result.
+    /// One connection through `handler`, from a client that accepts any cert.
     async fn handshake_through<H>(handler: H) -> Result<(), std::io::Error>
     where
         for<'a> H: TlsHandler<'a, tokio::net::TcpListener> + Clone + Send + 'static,
@@ -532,8 +530,8 @@ mod test {
         res
     }
 
-    /// A refused connection says so: the client is told the name was not
-    /// recognized instead of watching the socket close mid-handshake.
+    /// The client is told the name was not recognized, rather than watching
+    /// the socket close mid-handshake.
     #[tokio::test]
     async fn a_refused_connection_gets_a_tls_alert() {
         let err = handshake_through(Declines)

--- a/shared-libs/crates/start-core/src/net/tls.rs
+++ b/shared-libs/crates/start-core/src/net/tls.rs
@@ -29,9 +29,6 @@ pub enum TlsHandlerAction {
     Tls(ServerConfig),
     /// Don't complete TLS — rewind the BackTrackingIO and return the raw stream.
     Passthrough,
-    /// Refuse the connection. Unlike returning `None`, this stops the chain: a
-    /// later handler must not answer for a name this one owns.
-    Reject,
 }
 
 use crate::net::http::handle_http_on_https;
@@ -69,27 +66,6 @@ pub trait TlsHandler<'a, A: Accept> {
         hello: &'a ClientHello<'a>,
         metadata: &'a A::Metadata,
     ) -> impl Future<Output = Option<TlsHandlerAction>> + Send + 'a;
-}
-
-#[derive(Clone)]
-pub struct ChainedHandler<H0, H1>(pub H0, pub H1);
-impl<'a, A, H0, H1> TlsHandler<'a, A> for ChainedHandler<H0, H1>
-where
-    A: Accept + 'a,
-    <A as Accept>::Metadata: Send + Sync,
-    H0: TlsHandler<'a, A> + Send,
-    H1: TlsHandler<'a, A> + Send,
-{
-    async fn get_config(
-        &'a mut self,
-        hello: &'a ClientHello<'a>,
-        metadata: &'a <A as Accept>::Metadata,
-    ) -> Option<TlsHandlerAction> {
-        if let Some(config) = self.0.get_config(hello, metadata).await {
-            return Some(config);
-        }
-        self.1.get_config(hello, metadata).await
-    }
 }
 
 #[derive(Debug)]
@@ -259,7 +235,7 @@ where
                                 Box::pin(bt) as AcceptStream,
                             )));
                         }
-                        Some(TlsHandlerAction::Reject) | None => {
+                        None => {
                             crate::dev_log!(debug, "no certificate for SNI {:?}", sni);
                             // The io buffers writes until the handshake config
                             // is settled, so the alert only reaches the wire
@@ -502,21 +478,6 @@ mod test {
     }
 
     #[derive(Clone)]
-    struct Rejects;
-    impl<'a, A: Accept + 'a> TlsHandler<'a, A> for Rejects
-    where
-        A::Metadata: Sync,
-    {
-        async fn get_config(
-            &'a mut self,
-            _: &'a ClientHello<'a>,
-            _: &'a A::Metadata,
-        ) -> Option<TlsHandlerAction> {
-            Some(TlsHandlerAction::Reject)
-        }
-    }
-
-    #[derive(Clone)]
     struct Declines;
     impl<'a, A: Accept + 'a> TlsHandler<'a, A> for Declines
     where
@@ -571,15 +532,13 @@ mod test {
         res
     }
 
-    /// A handler that owns a name refuses for it: the next handler in the chain
-    /// must not answer with a certificate of its own.
+    /// A refused connection says so: the client is told the name was not
+    /// recognized instead of watching the socket close mid-handshake.
     #[tokio::test]
-    async fn a_rejecting_handler_stops_the_chain() {
-        let cert = Arc::new(self_signed_for_loopback());
-
-        let err = handshake_through(ChainedHandler(Rejects, Serves(cert.clone())))
+    async fn a_refused_connection_gets_a_tls_alert() {
+        let err = handshake_through(Declines)
             .await
-            .expect_err("a rejected connection must not complete a handshake");
+            .expect_err("a handler that serves nothing must not complete a handshake");
         assert!(
             matches!(
                 err.into_inner()
@@ -589,13 +548,12 @@ mod test {
                     tokio_rustls::rustls::AlertDescription::UnrecognisedName
                 ))
             ),
-            "the rejection must reach the client as a TLS alert, not a bare close",
+            "the refusal must reach the client as a TLS alert, not a bare close",
         );
 
-        // Declining still falls through — that is what makes the two distinct.
-        handshake_through(ChainedHandler(Declines, Serves(cert)))
+        handshake_through(Serves(Arc::new(self_signed_for_loopback())))
             .await
-            .expect("a handler that declines lets the next one answer");
+            .expect("a handler that serves a certificate completes the handshake");
     }
 
     #[tokio::test]

--- a/shared-libs/crates/start-core/src/net/tls.rs
+++ b/shared-libs/crates/start-core/src/net/tls.rs
@@ -29,6 +29,9 @@ pub enum TlsHandlerAction {
     Tls(ServerConfig),
     /// Don't complete TLS — rewind the BackTrackingIO and return the raw stream.
     Passthrough,
+    /// Refuse the connection. Unlike returning `None`, this stops the chain: a
+    /// later handler must not answer for a name this one owns.
+    Reject,
 }
 
 use crate::net::http::handle_http_on_https;
@@ -256,8 +259,12 @@ where
                                 Box::pin(bt) as AcceptStream,
                             )));
                         }
-                        None => {
+                        Some(TlsHandlerAction::Reject) | None => {
                             crate::dev_log!(debug, "no certificate for SNI {:?}", sni);
+                            // The io buffers writes until the handshake config
+                            // is settled, so the alert only reaches the wire
+                            // once buffering is off.
+                            let _ = mid.io.stop_buffering();
                             let _ = mid
                                 .io
                                 .write_all(&[
@@ -492,6 +499,103 @@ mod test {
         // sanity: the other cert is itself valid against its own pin
         let other_match = client_config_with_cert(provider(), &other_pem).unwrap();
         assert!(handshake_succeeds(&other_key, &other_cert, other_match).await);
+    }
+
+    #[derive(Clone)]
+    struct Rejects;
+    impl<'a, A: Accept + 'a> TlsHandler<'a, A> for Rejects
+    where
+        A::Metadata: Sync,
+    {
+        async fn get_config(
+            &'a mut self,
+            _: &'a ClientHello<'a>,
+            _: &'a A::Metadata,
+        ) -> Option<TlsHandlerAction> {
+            Some(TlsHandlerAction::Reject)
+        }
+    }
+
+    #[derive(Clone)]
+    struct Declines;
+    impl<'a, A: Accept + 'a> TlsHandler<'a, A> for Declines
+    where
+        A::Metadata: Sync,
+    {
+        async fn get_config(
+            &'a mut self,
+            _: &'a ClientHello<'a>,
+            _: &'a A::Metadata,
+        ) -> Option<TlsHandlerAction> {
+            None
+        }
+    }
+
+    #[derive(Clone)]
+    struct Serves(Arc<(PKey<Private>, X509)>);
+    impl<'a, A: Accept + 'a> TlsHandler<'a, A> for Serves
+    where
+        A::Metadata: Sync,
+    {
+        async fn get_config(
+            &'a mut self,
+            _: &'a ClientHello<'a>,
+            _: &'a A::Metadata,
+        ) -> Option<TlsHandlerAction> {
+            Some(TlsHandlerAction::Tls(server_config(&self.0.0, &self.0.1)))
+        }
+    }
+
+    /// Run one connection against a `TlsListener` fronting `handler`, with a
+    /// client that accepts any certificate, and return the handshake result.
+    async fn handshake_through<H>(handler: H) -> Result<(), std::io::Error>
+    where
+        for<'a> H: TlsHandler<'a, tokio::net::TcpListener> + Clone + Send + 'static,
+    {
+        let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut tls = TlsListener::new(listener, handler);
+        let server = tokio::spawn(async move {
+            let _ = futures::future::poll_fn(|cx| tls.poll_accept(cx)).await;
+        });
+
+        let connector = TlsConnector::from(Arc::new(client_config_no_verify(provider()).unwrap()));
+        let tcp = TcpStream::connect(addr).await.unwrap();
+        let res = connector
+            .connect(ServerName::try_from("example.com").unwrap(), tcp)
+            .await
+            .map(|_| ());
+        server.abort();
+        res
+    }
+
+    /// A handler that owns a name refuses for it: the next handler in the chain
+    /// must not answer with a certificate of its own.
+    #[tokio::test]
+    async fn a_rejecting_handler_stops_the_chain() {
+        let cert = Arc::new(self_signed_for_loopback());
+
+        let err = handshake_through(ChainedHandler(Rejects, Serves(cert.clone())))
+            .await
+            .expect_err("a rejected connection must not complete a handshake");
+        assert!(
+            matches!(
+                err.into_inner()
+                    .and_then(|e| e.downcast::<tokio_rustls::rustls::Error>().ok())
+                    .as_deref(),
+                Some(tokio_rustls::rustls::Error::AlertReceived(
+                    tokio_rustls::rustls::AlertDescription::UnrecognisedName
+                ))
+            ),
+            "the rejection must reach the client as a TLS alert, not a bare close",
+        );
+
+        // Declining still falls through — that is what makes the two distinct.
+        handshake_through(ChainedHandler(Declines, Serves(cert)))
+            .await
+            .expect("a handler that declines lets the next one answer");
     }
 
     #[tokio::test]

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -37,6 +37,7 @@ use crate::db::model::public::{AcmeSettings, NetworkInterfaceInfo};
 use crate::db::{DbAccessByKey, DbAccessMut};
 use crate::net::acme::{
     AcmeCertStore, AcmeProvider, AcmeTlsAlpnCache, AcmeTlsHandler, GetAcmeProvider,
+    ReportOrderFailure,
 };
 use crate::net::forward::START9_BRIDGE_V6_SUBNET;
 use crate::net::gateway::{
@@ -44,9 +45,10 @@ use crate::net::gateway::{
 };
 use crate::net::port_map::{PortMapController, candidate_gateways};
 use crate::net::ssl::{CertBranding, CertStore, RootCaTlsHandler};
-use crate::net::tls::{ChainedHandler, TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata};
+use crate::net::tls::{TlsHandler, TlsHandlerAction, TlsListener, TlsMetadata};
 use crate::net::utils::{bind_mio_listener, ipv6_is_link_local, is_private_ip};
 use crate::net::web_server::{Accept, AcceptStream, ExtractVisitor, TcpMetadata, extract};
+use crate::notifications::NotificationLevel;
 use crate::prelude::*;
 use crate::util::collections::EqSet;
 use crate::util::future::NonDetachingJoinHandle;
@@ -324,6 +326,33 @@ impl VHostController {
         })
     }
 
+    /// Notifies the operator, once per name until a certificate lands, that
+    /// ACME issuance is failing. The address refuses connections while that is
+    /// true, so nothing else would say why.
+    fn report_acme_failure(&self) -> ReportOrderFailure {
+        let db = self.db.clone();
+        Arc::new(move |sans, error| {
+            let db = db.clone();
+            async move {
+                let domain = sans.iter().map(|s| &**s).collect::<Vec<_>>().join(", ");
+                db.mutate(|db| {
+                    crate::notifications::notify(
+                        db,
+                        None,
+                        NotificationLevel::Warning,
+                        t!("acme.order-failed-title", domain = domain).to_string(),
+                        t!("acme.order-failed-message", domain = domain, error = error).to_string(),
+                        (),
+                    )
+                })
+                .await
+                .result
+                .log_err();
+            }
+            .boxed()
+        })
+    }
+
     fn create_server(&self, port: u16) -> VHostServer<VHostBindListener> {
         let bind_reqs = Watch::new(VHostBindRequirements::default());
         let listener = VHostBindListener {
@@ -340,6 +369,7 @@ impl VHostController {
             self.crypto_provider.clone(),
             self.branding.clone(),
             self.acme_cache.clone(),
+            self.report_acme_failure(),
         )
     }
 
@@ -453,7 +483,7 @@ impl VHostController {
     pub fn reconcile_port_maps(
         &self,
         owner: HostMapOwner,
-        targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
+        targets: &BTreeMap<VHostKey, ProxyTarget>,
     ) {
         let ip_info = self.interfaces.watcher.ip_info();
         self.sync_port_maps(owner, desired_port_maps(targets, &ip_info));
@@ -501,6 +531,11 @@ impl VHostController {
     }
 }
 
+/// A vhost entry's identity: `(hostname, external port, serves the public
+/// exposure)`. A name reachable both from the LAN and from the internet has one
+/// entry per side, so that only the public one carries a certificate authority.
+pub type VHostKey = (Option<InternedString>, u16, bool);
+
 /// The port ACME's TLS-ALPN-01 challenge is dialed at. Fixed by the protocol —
 /// the validator ignores whatever port the name is actually served on.
 const ACME_CHALLENGE_PORT: u16 = 443;
@@ -527,11 +562,11 @@ type DesiredPortMaps = BTreeMap<
 /// IPv4s gets a mapping keyed by the vhost's hostname. IPv6 GUAs carry no NAT,
 /// so they get a firewall pinhole at the same port instead.
 fn desired_port_maps(
-    targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
+    targets: &BTreeMap<VHostKey, ProxyTarget>,
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
 ) -> DesiredPortMaps {
     let mut desired = DesiredPortMaps::new();
-    for ((maybe_host, external), target) in targets {
+    for ((maybe_host, external, _), target) in targets {
         // IPv4: forward the port to the box's LAN IPv4 — a PCP HOSTNAME mapping
         // (SNI demux) for a domain, a plain pinhole for a bare `*` vhost.
         for gw_id in &target.public_v4 {
@@ -794,6 +829,16 @@ pub trait VHostTarget<A: Accept>: std::fmt::Debug + Eq {
     fn filter(&self, metadata: &<A as Accept>::Metadata) -> bool {
         true
     }
+    /// Whether this target answers `metadata` as one of the box's own private
+    /// addresses, which takes precedence over answering it as a public one. A
+    /// name can be served both ways at once — the same domain resolving to a
+    /// LAN address inside the network and a public one outside it — and on
+    /// IPv4 both arrive on the same gateway, so a target that claims the
+    /// connection here is the one that owns it.
+    #[allow(unused_variables)]
+    fn filter_private(&self, metadata: &<A as Accept>::Metadata) -> bool {
+        false
+    }
     fn acme(&self) -> Option<&AcmeProvider> {
         None
     }
@@ -821,6 +866,7 @@ pub trait VHostTarget<A: Accept>: std::fmt::Debug + Eq {
 
 pub trait DynVHostTargetT<A: Accept>: std::fmt::Debug + Any {
     fn filter(&self, metadata: &<A as Accept>::Metadata) -> bool;
+    fn filter_private(&self, metadata: &<A as Accept>::Metadata) -> bool;
     fn acme(&self) -> Option<&AcmeProvider>;
     fn bind_requirements(&self) -> (BTreeSet<GatewayId>, BTreeSet<IpAddr>);
     fn is_passthrough(&self) -> bool;
@@ -844,6 +890,9 @@ pub trait DynVHostTargetT<A: Accept>: std::fmt::Debug + Any {
 impl<A: Accept, T: VHostTarget<A> + 'static> DynVHostTargetT<A> for T {
     fn filter(&self, metadata: &<A as Accept>::Metadata) -> bool {
         VHostTarget::filter(self, metadata)
+    }
+    fn filter_private(&self, metadata: &<A as Accept>::Metadata) -> bool {
+        VHostTarget::filter_private(self, metadata)
     }
     fn acme(&self) -> Option<&AcmeProvider> {
         VHostTarget::acme(self)
@@ -1030,8 +1079,16 @@ impl ProxyTarget {
             IpAddr::V4(_) => self.public_v4.contains(gw_id),
             IpAddr::V6(v6) => self.public_v6.contains(&v6),
         };
-        wan || (self.private.contains(&dst)
-            && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src)))
+        wan || self.accepts_as_private(subnets, src, dst)
+    }
+
+    /// Whether this is a dial of one of our own private addresses from the
+    /// network that address is on. IPv4 gives such a dial the same arrival
+    /// gateway as a forwarded WAN one — the box sees its own LAN IPv4 either
+    /// way — so the source address is what tells them apart.
+    fn accepts_as_private(&self, subnets: &OrdSet<IpNet>, src: IpAddr, dst: IpAddr) -> bool {
+        self.private.contains(&dst)
+            && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src))
     }
 
     /// Whether the box gateways `client`, which source preservation requires:
@@ -1063,6 +1120,36 @@ impl ProxyTarget {
     }
 }
 
+/// Where a connection came from and landed: `(arrival gateway, that gateway's
+/// subnets, source, local address)`.
+struct Arrival {
+    gateway: GatewayId,
+    subnets: OrdSet<IpNet>,
+    src: IpAddr,
+    dst: IpAddr,
+}
+
+fn arrival<A>(metadata: &<A as Accept>::Metadata) -> Option<Arrival>
+where
+    A: Accept + 'static,
+    <A as Accept>::Metadata: Visit<ExtractVisitor<GatewayInfo>>
+        + Visit<ExtractVisitor<TcpMetadata>>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let gw = extract::<GatewayInfo, _>(metadata)?;
+    let tcp = extract::<TcpMetadata, _>(metadata)?;
+    let ip_info = gw.info.ip_info.as_ref()?;
+    Some(Arrival {
+        gateway: gw.id.clone(),
+        subnets: ip_info.subnets.clone(),
+        src: tcp.peer_addr.ip(),
+        dst: tcp.local_addr.ip(),
+    })
+}
+
 impl<A> VHostTarget<A> for ProxyTarget
 where
     A: Accept + 'static,
@@ -1074,19 +1161,16 @@ where
 {
     type PreprocessRes = AcceptStream;
     fn filter(&self, metadata: &<A as Accept>::Metadata) -> bool {
-        let gw = extract::<GatewayInfo, _>(metadata);
-        let tcp = extract::<TcpMetadata, _>(metadata);
-        let (Some(gw), Some(tcp)) = (gw, tcp) else {
+        let Some(at) = arrival::<A>(metadata) else {
             return false;
         };
-        let Some(ip_info) = &gw.info.ip_info else {
+        self.accepts(&at.gateway, &at.subnets, at.src, at.dst)
+    }
+    fn filter_private(&self, metadata: &<A as Accept>::Metadata) -> bool {
+        let Some(at) = arrival::<A>(metadata) else {
             return false;
         };
-
-        let src = tcp.peer_addr.ip();
-        let dst = tcp.local_addr.ip();
-
-        self.accepts(&gw.id, &ip_info.subnets, src, dst)
+        self.accepts_as_private(&at.subnets, at.src, at.dst)
     }
     fn acme(&self) -> Option<&AcmeProvider> {
         self.acme.as_ref()
@@ -1526,8 +1610,11 @@ impl<A: Accept + 'static> GetAcmeProvider for GetVHostAcmeProvider<A> {
                     if x.parse::<IpAddr>().is_ok() {
                         return Some(acc);
                     }
-                    let (t, _) = m.get(&Some(x.clone()))?.iter().find(|(_, e)| e.alive())?;
-                    let acme = t.0.acme()?;
+                    let acme = m
+                        .get(&Some(x.clone()))?
+                        .iter()
+                        .filter(|(_, e)| e.alive())
+                        .find_map(|(t, _)| t.0.acme())?;
                     Some(if let Some(acc) = acc {
                         if acme == acc {
                             // all must match
@@ -1577,16 +1664,18 @@ fn passthrough_stub_config(crypto_provider: &Arc<CryptoProvider>) -> Result<Serv
 /// The handler holds the cert-resolution chain as `inner` and only invokes
 /// it when the matched target terminates TLS, or when the connection is the
 /// ACME `acme-tls/1` ALPN challenge (which has to be answered locally).
-pub struct VHostTlsHandler<I, A: Accept + 'static> {
-    inner: I,
+pub struct VHostTlsHandler<Acme, RootCa, A: Accept + 'static> {
+    acme: Acme,
+    root_ca: RootCa,
     crypto_provider: Arc<CryptoProvider>,
     mapping: Watch<Mapping<A>>,
     preprocessed: Option<Preprocessed<A>>,
 }
-impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
+impl<Acme: Clone, RootCa: Clone, A: Accept + 'static> Clone for VHostTlsHandler<Acme, RootCa, A> {
     fn clone(&self) -> Self {
         Self {
-            inner: self.inner.clone(),
+            acme: self.acme.clone(),
+            root_ca: self.root_ca.clone(),
             crypto_provider: self.crypto_provider.clone(),
             mapping: self.mapping.clone(),
             // Per-connection state — never carried across clones; each
@@ -1596,12 +1685,13 @@ impl<I: Clone, A: Accept + 'static> Clone for VHostTlsHandler<I, A> {
     }
 }
 
-impl<'a, A, I> TlsHandler<'a, A> for VHostTlsHandler<I, A>
+impl<'a, A, Acme, RootCa> TlsHandler<'a, A> for VHostTlsHandler<Acme, RootCa, A>
 where
     A: Accept + 'a,
     <A as Accept>::Metadata:
         Visit<ExtractVisitor<GatewayInfo>> + Visit<ExtractVisitor<TcpMetadata>> + Send + Sync,
-    I: TlsHandler<'a, A> + Send,
+    Acme: TlsHandler<'a, A> + Send,
+    RootCa: TlsHandler<'a, A> + Send,
 {
     async fn get_config(
         &'a mut self,
@@ -1611,11 +1701,10 @@ where
         let sni = host_key(hello.server_name());
 
         let routed = self.mapping.peek(|m| {
-            m.get(&sni)
-                .into_iter()
-                .flatten()
-                .filter(|(_, e)| e.alive())
-                .find(|(t, _)| t.0.filter(metadata))
+            let alive = || m.get(&sni).into_iter().flatten().filter(|(_, e)| e.alive());
+            alive()
+                .find(|(t, _)| t.0.filter_private(metadata))
+                .or_else(|| alive().find(|(t, _)| t.0.filter(metadata)))
                 .map(|(t, e)| (t.clone(), e.ctx.clone()))
         });
 
@@ -1629,7 +1718,7 @@ where
             // only from the controller-wide cache of in-flight orders, so this
             // still refuses every name we are not ourselves ordering for.
             if acme_challenge {
-                return self.inner.get_config(hello, metadata).await;
+                return self.acme.get_config(hello, metadata).await;
             }
             return None;
         };
@@ -1643,13 +1732,29 @@ where
             return Some(TlsHandlerAction::Passthrough);
         }
 
-        // ACME challenge for a terminating target: answer locally from the inner
-        // chain.
+        // ACME challenge for a terminating target: answer it ourselves.
         if acme_challenge {
-            return self.inner.get_config(hello, metadata).await;
+            return self.acme.get_config(hello, metadata).await;
         }
 
-        let action = self.inner.get_config(hello, metadata).await?;
+        let action = if target.0.acme().is_some() {
+            // This address is served the certificate its authority issued or
+            // nothing at all. The local root CA would answer for any name asked
+            // of it, so falling back to it hands a client that asked for a
+            // publicly trusted certificate one signed by a chain shared with
+            // every other address on this server — under a name the UI still
+            // labels with the authority. Refuse the connection instead.
+            self.acme.get_config(hello, metadata).await?
+        } else {
+            // No authority on this address: the local root CA serves it, as it
+            // does every LAN address. A certificate the authority issued for
+            // this name is still preferred where one exists, so a domain
+            // reachable both ways presents the same certificate either way.
+            match self.acme.get_config(hello, metadata).await {
+                Some(action) => action,
+                None => self.root_ca.get_config(hello, metadata).await?,
+            }
+        };
         let cfg = match action {
             TlsHandlerAction::Tls(cfg) => cfg,
             other => return Some(other),
@@ -1663,10 +1768,7 @@ where
 struct VHostListener<M, A>(
     TlsListener<
         A,
-        VHostTlsHandler<
-            ChainedHandler<Arc<AcmeTlsHandler<M, GetVHostAcmeProvider<A>>>, RootCaTlsHandler<M>>,
-            A,
-        >,
+        VHostTlsHandler<Arc<AcmeTlsHandler<M, GetVHostAcmeProvider<A>>>, RootCaTlsHandler<M>, A>,
     >,
 )
 where
@@ -1775,6 +1877,7 @@ impl<A: Accept> VHostServer<A> {
         crypto_provider: Arc<CryptoProvider>,
         branding: CertBranding,
         acme_cache: AcmeTlsAlpnCache,
+        report_acme_failure: ReportOrderFailure,
     ) -> Self
     where
         for<'a> M: HasModel<Model = Model<M>>
@@ -1800,20 +1903,19 @@ impl<A: Accept> VHostServer<A> {
                 let mut listener = VHostListener(TlsListener::new(
                     listener,
                     VHostTlsHandler {
-                        inner: ChainedHandler(
-                            Arc::new(AcmeTlsHandler {
-                                db: db.clone(),
-                                acme_cache,
-                                crypto_provider: crypto_provider.clone(),
-                                get_provider: GetVHostAcmeProvider(mapping.clone()),
-                                in_progress: Watch::new(BTreeMap::new()),
-                            }),
-                            RootCaTlsHandler {
-                                db,
-                                crypto_provider: crypto_provider.clone(),
-                                branding,
-                            },
-                        ),
+                        acme: Arc::new(AcmeTlsHandler {
+                            db: db.clone(),
+                            acme_cache,
+                            crypto_provider: crypto_provider.clone(),
+                            get_provider: GetVHostAcmeProvider(mapping.clone()),
+                            in_progress: Watch::new(BTreeMap::new()),
+                            report_failure: Some(report_acme_failure),
+                        }),
+                        root_ca: RootCaTlsHandler {
+                            db,
+                            crypto_provider: crypto_provider.clone(),
+                            branding,
+                        },
                         crypto_provider,
                         mapping,
                         preprocessed: None,
@@ -2072,12 +2174,14 @@ mod port_map_tests {
         }
     }
 
+    /// Every entry here is a public leg — a private one carries no public
+    /// gateway, so it contributes no port map at all.
     fn targets<'a>(
         entries: impl IntoIterator<Item = (Option<&'a str>, u16, ProxyTarget)>,
-    ) -> BTreeMap<(Option<InternedString>, u16), ProxyTarget> {
+    ) -> BTreeMap<VHostKey, ProxyTarget> {
         entries
             .into_iter()
-            .map(|(host, port, target)| ((host.map(InternedString::intern), port), target))
+            .map(|(host, port, target)| ((host.map(InternedString::intern), port, true), target))
             .collect()
     }
 
@@ -2267,6 +2371,33 @@ mod accept_filter_tests {
 
         // A different gateway is never WAN-accepted on IPv4.
         assert!(!t.accepts(&gw("other"), &no_subnets, src, v4));
+    }
+
+    /// A domain reachable both ways is two targets. IPv4 hands a forwarded WAN
+    /// dial and a local one the same arrival gateway, so the public leg claims
+    /// both — the source address is what separates them, and the private leg's
+    /// claim is the stronger one.
+    #[test]
+    fn a_lan_dial_of_a_dual_exposure_domain_belongs_to_the_private_leg() {
+        let g = gw("eth0");
+        let no_subnets = OrdSet::new();
+        let lan_dst = ip("192.168.1.2");
+        let public_leg = target(&["eth0"], &[], &[]);
+        let private_leg = target(&[], &[], &["192.168.1.2"]);
+
+        let lan_src = ip("192.168.1.50");
+        assert!(private_leg.accepts_as_private(&no_subnets, lan_src, lan_dst));
+        assert!(!public_leg.accepts_as_private(&no_subnets, lan_src, lan_dst));
+        assert!(
+            public_leg.accepts(&g, &no_subnets, lan_src, lan_dst),
+            "the public leg cannot tell a local dial from a forwarded one, \
+             which is why the private leg is preferred"
+        );
+
+        let wan_src = ip("203.0.113.9");
+        assert!(!private_leg.accepts_as_private(&no_subnets, wan_src, lan_dst));
+        assert!(!private_leg.accepts(&g, &no_subnets, wan_src, lan_dst));
+        assert!(public_leg.accepts(&g, &no_subnets, wan_src, lan_dst));
     }
 
     // LAN accept via `private` is matched by the exact local `dst` (so it is

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -443,23 +443,12 @@ impl VHostController {
         })
     }
 
-    /// Reconcile best-effort upstream port mappings for `owner`'s public vhosts.
-    /// `desired` maps `(box IP to map from, external port)` to `(internal port,
-    /// candidate gateways, hostnames)`. A `Some(hostname)` is mapped via PCP
-    /// HOSTNAME — the gateway treats the hostname as part of the mapping's identity
-    /// and demultiplexes the shared external port by TLS SNI, so one service adding
-    /// or removing a hostname never disturbs another's on the same port. A `None`
-    /// is a bare-IP (`*` vhost) forward: no SNI, so a plain pinhole to the box's own
-    /// IP where the OS reverse proxy listens. Like the rest of the port-map layer
-    /// this is best-effort: a gateway that can't honor it leaves a manual forward.
-    /// Reconcile every upstream IPv4 port map `owner`'s vhosts need, derived from
-    /// the vhost `targets` themselves — the controller owns the whole port-map
+    /// Reconcile every upstream port map `owner`'s vhosts need, derived from the
+    /// vhost `targets` themselves — the controller owns the whole port-map
     /// lifecycle, so callers hand over the same `ProxyTarget` set they use to bind
-    /// the listeners and compute nothing. For each target public on IPv4
-    /// (`public_v4`), each of that gateway's box IPv4s gets a mapping keyed by the
-    /// vhost's hostname: `Some(host)` is a PCP HOSTNAME mapping (SNI demux), `None`
-    /// is a bare-IP (`*` vhost) pinhole. IPv6 GUAs carry no NAT, so they get no
-    /// mapping here. Always call this every update — an owner whose target set went
+    /// the listeners and compute nothing. Best-effort like the rest of the
+    /// port-map layer: a gateway that can't honor a mapping leaves a manual
+    /// forward. Always call this every update — an owner whose target set went
     /// empty withdraws its prior mappings via the per-owner diff.
     pub fn reconcile_port_maps(
         &self,
@@ -467,104 +456,14 @@ impl VHostController {
         targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
     ) {
         let ip_info = self.interfaces.watcher.ip_info();
-        // `(box IP, ext port) -> (internal port, ordered PCP gateway candidates,
-        // hostnames)`. Gateways stay an ordered Vec (the port-mapper tries them in
-        // preference order and takes the first that binds); hostnames are a set —
-        // `None` is the bare-IP/GUA pinhole, `Some(h)` an SNI route, and neither
-        // repeats nor cares about order.
-        let mut desired: BTreeMap<
-            (IpAddr, u16),
-            (
-                u16,
-                Vec<(IpAddr, Option<u32>)>,
-                BTreeSet<Option<InternedString>>,
-            ),
-        > = BTreeMap::new();
-        for ((maybe_host, external), target) in targets {
-            // IPv4: forward the port to the box's LAN IPv4 — a PCP HOSTNAME mapping
-            // (SNI demux) for a domain, a plain pinhole for a bare `*` vhost.
-            for gw_id in &target.public_v4 {
-                let Some(info) = ip_info.get(gw_id) else {
-                    continue;
-                };
-                let Some(gw_ip_info) = &info.ip_info else {
-                    continue;
-                };
-                let gateways = candidate_gateways(info);
-                if gateways.is_empty() {
-                    continue;
-                }
-                for subnet in &gw_ip_info.subnets {
-                    let IpAddr::V4(local_ip) = subnet.addr() else {
-                        continue;
-                    };
-                    desired
-                        .entry((IpAddr::V4(local_ip), *external))
-                        .or_insert_with(|| (*external, gateways.clone(), BTreeSet::new()))
-                        .2
-                        .insert(maybe_host.clone());
-                }
-            }
-            // IPv6: the box's own GUA is the listener (no NAT), so open a firewall
-            // pinhole for GUA:port. No SNI demux over v6 (every host has its own
-            // GUA, nothing to share), so these are always hostname-less.
-            for gua in &target.public_v6 {
-                let Some(info) = ip_info.iter().map(|(_, i)| i).find(|info| {
-                    info.ip_info.as_ref().map_or(false, |i| {
-                        i.subnets.iter().any(|s| s.addr() == IpAddr::V6(*gua))
-                    })
-                }) else {
-                    continue;
-                };
-                let v6_gateways: Vec<(IpAddr, Option<u32>)> = candidate_gateways(info)
-                    .into_iter()
-                    .filter(|(g, _)| g.is_ipv6())
-                    .collect();
-                if v6_gateways.is_empty() {
-                    continue;
-                }
-                desired
-                    .entry((IpAddr::V6(*gua), *external))
-                    .or_insert_with(|| (*external, v6_gateways, BTreeSet::new()))
-                    .2
-                    .insert(None);
-            }
-        }
-        // v6 HTTP->HTTPS redirect: for a GUA exposing 443, ask the gateway for an
-        // 80->443 redirect pinhole, unless 80 is already a real pinhole on that GUA.
-        // (No IPv4 equivalent — the upstream gateway serves the port-80 redirect.)
-        let redirects: Vec<(Ipv6Addr, Vec<(IpAddr, Option<u32>)>)> = desired
-            .iter()
-            .filter_map(|((ip, port), (_, gateways, _))| match ip {
-                IpAddr::V6(gua) if *port == 443 => Some((*gua, gateways.clone())),
-                _ => None,
-            })
-            .filter(|(gua, _)| !desired.contains_key(&(IpAddr::V6(*gua), 80)))
-            .collect();
-        for (gua, gateways) in redirects {
-            desired
-                .entry((IpAddr::V6(gua), 80))
-                .or_insert((443, gateways, BTreeSet::from([None])));
-        }
-        self.sync_port_maps(owner, desired);
+        self.sync_port_maps(owner, desired_port_maps(targets, &ip_info));
     }
 
-    fn sync_port_maps(
-        &self,
-        owner: HostMapOwner,
-        desired: BTreeMap<
-            (IpAddr, u16),
-            (
-                u16,
-                Vec<(IpAddr, Option<u32>)>,
-                BTreeSet<Option<InternedString>>,
-            ),
-        >,
-    ) {
+    fn sync_port_maps(&self, owner: HostMapOwner, desired: DesiredPortMaps) {
         let want: BTreeSet<(IpAddr, u16, Option<InternedString>)> = desired
             .iter()
-            .flat_map(|((ip, port), (_, _, hostnames))| {
-                hostnames.iter().map(move |h| (*ip, *port, h.clone()))
+            .flat_map(|((ip, port), (_, hostnames))| {
+                hostnames.keys().map(move |h| (*ip, *port, h.clone()))
             })
             .collect();
         let had = self
@@ -576,8 +475,8 @@ impl VHostController {
                 None => self.port_map.remove(*ip, *port),
             }
         }
-        for ((ip, port), (internal, gateways, hostnames)) in &desired {
-            for hostname in hostnames {
+        for ((ip, port), (gateways, hostnames)) in &desired {
+            for (hostname, internal) in hostnames {
                 match hostname {
                     Some(h) => self.port_map.ensure_hostname(
                         *ip,
@@ -600,6 +499,125 @@ impl VHostController {
             }
         });
     }
+}
+
+/// The port ACME's TLS-ALPN-01 challenge is dialed at. Fixed by the protocol —
+/// the validator ignores whatever port the name is actually served on.
+const ACME_CHALLENGE_PORT: u16 = 443;
+
+/// The upstream port maps a set of vhost targets calls for: `(box IP to map
+/// from, external port) -> (ordered PCP gateway candidates, hostname -> box-side
+/// port)`. Gateways stay an ordered Vec — the port-mapper tries them in
+/// preference order and takes the first that binds. A `Some(hostname)` is
+/// mapped via PCP HOSTNAME: the gateway treats the hostname as part of the
+/// mapping's identity and demultiplexes the shared external port by TLS SNI, so
+/// one service adding or removing a hostname never disturbs another's on the
+/// same port — and each name carries its own box-side port. A `None` is a
+/// bare-IP (`*` vhost) forward or an IPv6 GUA pinhole: no SNI, so a plain
+/// pinhole to the box's own IP where the OS reverse proxy listens.
+type DesiredPortMaps = BTreeMap<
+    (IpAddr, u16),
+    (
+        Vec<(IpAddr, Option<u32>)>,
+        BTreeMap<Option<InternedString>, u16>,
+    ),
+>;
+
+/// For each target public on IPv4 (`public_v4`), each of that gateway's box
+/// IPv4s gets a mapping keyed by the vhost's hostname. IPv6 GUAs carry no NAT,
+/// so they get a firewall pinhole at the same port instead.
+fn desired_port_maps(
+    targets: &BTreeMap<(Option<InternedString>, u16), ProxyTarget>,
+    ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
+) -> DesiredPortMaps {
+    let mut desired = DesiredPortMaps::new();
+    for ((maybe_host, external), target) in targets {
+        // IPv4: forward the port to the box's LAN IPv4 — a PCP HOSTNAME mapping
+        // (SNI demux) for a domain, a plain pinhole for a bare `*` vhost.
+        for gw_id in &target.public_v4 {
+            let Some(info) = ip_info.get(gw_id) else {
+                continue;
+            };
+            let Some(gw_ip_info) = &info.ip_info else {
+                continue;
+            };
+            let gateways = candidate_gateways(info);
+            if gateways.is_empty() {
+                continue;
+            }
+            for subnet in &gw_ip_info.subnets {
+                let IpAddr::V4(local_ip) = subnet.addr() else {
+                    continue;
+                };
+                desired
+                    .entry((IpAddr::V4(local_ip), *external))
+                    .or_insert_with(|| (gateways.clone(), BTreeMap::new()))
+                    .1
+                    .insert(maybe_host.clone(), *external);
+                // The domain's own port carries no ACME challenge, so route the
+                // challenge port to it as well or the order can never complete.
+                // By name only — the challenge is selected by SNI, and the
+                // unnamed forward there is the OS's own. `or_insert` so a real
+                // binding on that port keeps it, in any visit order.
+                if let Some(hostname) = maybe_host
+                    && target.acme.is_some()
+                    && *external != ACME_CHALLENGE_PORT
+                {
+                    desired
+                        .entry((IpAddr::V4(local_ip), ACME_CHALLENGE_PORT))
+                        .or_insert_with(|| (gateways.clone(), BTreeMap::new()))
+                        .1
+                        .entry(Some(hostname.clone()))
+                        .or_insert(*external);
+                }
+            }
+        }
+        // IPv6: the box's own GUA is the listener (no NAT), so open a firewall
+        // pinhole for GUA:port. No SNI demux over v6, so these are always
+        // hostname-less — which is also why the challenge port gets no v6
+        // counterpart: a GUA belongs to the gateway and every host on the box
+        // shares it, so claiming :443 on one would claim it for all of them.
+        // A domain public over both families validates over IPv4; one public
+        // only over IPv6 has no path for its challenge.
+        for gua in &target.public_v6 {
+            let Some(info) = ip_info.iter().map(|(_, i)| i).find(|info| {
+                info.ip_info.as_ref().map_or(false, |i| {
+                    i.subnets.iter().any(|s| s.addr() == IpAddr::V6(*gua))
+                })
+            }) else {
+                continue;
+            };
+            let v6_gateways: Vec<(IpAddr, Option<u32>)> = candidate_gateways(info)
+                .into_iter()
+                .filter(|(g, _)| g.is_ipv6())
+                .collect();
+            if v6_gateways.is_empty() {
+                continue;
+            }
+            desired
+                .entry((IpAddr::V6(*gua), *external))
+                .or_insert_with(|| (v6_gateways, BTreeMap::new()))
+                .1
+                .insert(None, *external);
+        }
+    }
+    // v6 HTTP->HTTPS redirect: for a GUA exposing 443, ask the gateway for an
+    // 80->443 redirect pinhole, unless 80 is already a real pinhole on that GUA.
+    // (No IPv4 equivalent — the upstream gateway serves the port-80 redirect.)
+    let redirects: Vec<(Ipv6Addr, Vec<(IpAddr, Option<u32>)>)> = desired
+        .iter()
+        .filter_map(|((ip, port), (gateways, _))| match ip {
+            IpAddr::V6(gua) if *port == 443 => Some((*gua, gateways.clone())),
+            _ => None,
+        })
+        .filter(|(gua, _)| !desired.contains_key(&(IpAddr::V6(*gua), 80)))
+        .collect();
+    for (gua, gateways) in redirects {
+        desired
+            .entry((IpAddr::V6(gua), 80))
+            .or_insert((gateways, BTreeMap::from([(None, 443)])));
+    }
+    desired
 }
 
 /// Union of all ProxyTargets' bind requirements for a VHostServer.
@@ -1478,6 +1496,17 @@ fn host_key(server_name: Option<&str>) -> Option<InternedString> {
         .map(InternedString::from)
 }
 
+/// A TLS-ALPN-01 challenge names the host it is validating, and the name is the
+/// whole authorization: it is what the challenge is answered against. A dial
+/// that names nothing is an ordinary connection whatever it advertises, and
+/// treating it as a challenge would hand it to a handler that answers by name.
+fn is_acme_challenge<'a>(
+    server_name: Option<&str>,
+    mut alpn: impl Iterator<Item = &'a [u8]>,
+) -> bool {
+    server_name.is_some() && alpn.any(|a| a == ACME_TLS_ALPN_NAME)
+}
+
 pub struct GetVHostAcmeProvider<A: Accept + 'static>(pub Watch<Mapping<A>>);
 impl<A: Accept + 'static> Clone for GetVHostAcmeProvider<A> {
     fn clone(&self) -> Self {
@@ -1590,7 +1619,18 @@ where
                 .map(|(t, e)| (t.clone(), e.ctx.clone()))
         });
 
+        let acme_challenge =
+            is_acme_challenge(hello.server_name(), hello.alpn().into_iter().flatten());
+
         let Some((target, ctx)) = routed else {
+            // TLS-ALPN-01 is always validated at :443, but the name being
+            // validated may only be served on some other port, so its challenge
+            // lands on a server that doesn't route it. The inner handler answers
+            // only from the controller-wide cache of in-flight orders, so this
+            // still refuses every name we are not ourselves ordering for.
+            if acme_challenge {
+                return self.inner.get_config(hello, metadata).await;
+            }
             return None;
         };
 
@@ -1604,14 +1644,8 @@ where
         }
 
         // ACME challenge for a terminating target: answer locally from the inner
-        // chain. Reached only for a host we serve, so a challenge for anything
-        // else is refused above rather than answered with a fresh leaf.
-        if hello
-            .alpn()
-            .into_iter()
-            .flatten()
-            .any(|a| a == ACME_TLS_ALPN_NAME)
-        {
+        // chain.
+        if acme_challenge {
             return self.inner.get_config(hello, metadata).await;
         }
 
@@ -1937,6 +1971,25 @@ mod host_key_tests {
         assert_eq!(host_key(Some("fd00:3::1")), None);
     }
 
+    /// A challenge is answered by name, so a dial that names nothing is never
+    /// one — otherwise it reaches a handler with no name to check, which
+    /// declines, and the next handler in the chain answers with a local
+    /// certificate.
+    #[test]
+    fn a_challenge_without_a_name_is_not_a_challenge() {
+        let acme = || [ACME_TLS_ALPN_NAME].into_iter();
+        assert!(is_acme_challenge(Some("example.com"), acme()));
+        assert!(!is_acme_challenge(None, acme()));
+        assert!(!is_acme_challenge(
+            Some("example.com"),
+            [b"h2".as_slice()].into_iter()
+        ));
+        assert!(!is_acme_challenge(
+            Some("example.com"),
+            std::iter::empty::<&[u8]>()
+        ));
+    }
+
     #[test]
     fn a_name_keys_to_itself() {
         assert_eq!(
@@ -1953,6 +2006,178 @@ mod host_key_tests {
             host_key(Some("server-name")),
             Some(InternedString::intern("server-name"))
         );
+    }
+}
+
+#[cfg(test)]
+mod port_map_tests {
+    use std::str::FromStr;
+
+    use super::*;
+    use crate::db::model::public::{GatewayType, IpInfo, NetworkInterfaceType};
+
+    const GATEWAY: &str = "wg0";
+    const BOX_IP: &str = "10.13.13.5";
+    const GUA: &str = "2001:db8::5";
+
+    /// A StartTunnel gateway: on-link, so NetworkManager reports no next hop and
+    /// `candidate_gateways` derives the relay from the subnet.
+    fn ip_info() -> OrdMap<GatewayId, NetworkInterfaceInfo> {
+        let mut info = OrdMap::new();
+        info.insert(
+            GatewayId::from(InternedString::intern(GATEWAY)),
+            NetworkInterfaceInfo {
+                name: None,
+                secure: None,
+                ip_info: Some(Arc::new(IpInfo {
+                    name: InternedString::intern(GATEWAY),
+                    scope_id: 0,
+                    device_type: Some(NetworkInterfaceType::Wireguard),
+                    subnets: ["10.13.13.5/24", "2001:db8::5/64"]
+                        .into_iter()
+                        .map(|s| s.parse::<IpNet>().unwrap())
+                        .collect(),
+                    lan_ip: Default::default(),
+                    wan_ip: None,
+                    ntp_servers: Default::default(),
+                    dns_servers: Default::default(),
+                })),
+                gateway_type: GatewayType::InboundOutbound,
+                port_map: Default::default(),
+                dns_update: Default::default(),
+            },
+        );
+        info
+    }
+
+    fn target(acme: bool, v6: bool) -> ProxyTarget {
+        ProxyTarget {
+            public_v4: [GatewayId::from(InternedString::intern(GATEWAY))]
+                .into_iter()
+                .collect(),
+            public_v6: if v6 {
+                [GUA.parse().unwrap()].into_iter().collect()
+            } else {
+                BTreeSet::new()
+            },
+            private: BTreeSet::new(),
+            acme: acme.then(|| AcmeProvider::from_str("letsencrypt").unwrap()),
+            addr: "10.0.3.2:443".parse().unwrap(),
+            addr_v6: None,
+            add_x_forwarded_headers: false,
+            auth: None,
+            connect_ssl: Err(AlpnInfo::Reflect),
+            passthrough: false,
+            preserve_source_ip: false,
+        }
+    }
+
+    fn targets<'a>(
+        entries: impl IntoIterator<Item = (Option<&'a str>, u16, ProxyTarget)>,
+    ) -> BTreeMap<(Option<InternedString>, u16), ProxyTarget> {
+        entries
+            .into_iter()
+            .map(|(host, port, target)| ((host.map(InternedString::intern), port), target))
+            .collect()
+    }
+
+    /// The hostname -> box-side port routes mapped at `(ip, external)`.
+    fn routes(desired: &DesiredPortMaps, ip: &str, external: u16) -> Vec<(String, u16)> {
+        let key: (IpAddr, u16) = (ip.parse().unwrap(), external);
+        desired
+            .get(&key)
+            .map(|(_, hosts)| {
+                hosts
+                    .iter()
+                    .map(|(h, port)| (h.as_ref().map_or("*".into(), |h| h.to_string()), *port))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// The challenge is dialed at :443 whatever port the domain serves on, so
+    /// the domain's own route is not enough on its own.
+    #[test]
+    fn an_acme_domain_off_443_also_routes_the_challenge_port() {
+        let desired = desired_port_maps(
+            &targets([(Some("electrum.example.com"), 50002, target(true, false))]),
+            &ip_info(),
+        );
+
+        assert_eq!(
+            routes(&desired, BOX_IP, 50002),
+            [("electrum.example.com".to_string(), 50002)],
+        );
+        assert_eq!(
+            routes(&desired, BOX_IP, 443),
+            [("electrum.example.com".to_string(), 50002)],
+        );
+    }
+
+    /// Each name carries its own box-side port, so two domains on one external
+    /// port do not collapse onto whichever was reconciled first.
+    #[test]
+    fn each_acme_domain_keeps_its_own_challenge_route() {
+        let desired = desired_port_maps(
+            &targets([
+                (Some("electrum.example.com"), 50002, target(true, false)),
+                (Some("turn.example.com"), 5349, target(true, false)),
+            ]),
+            &ip_info(),
+        );
+
+        assert_eq!(
+            routes(&desired, BOX_IP, 443),
+            [
+                ("electrum.example.com".to_string(), 50002),
+                ("turn.example.com".to_string(), 5349),
+            ],
+        );
+    }
+
+    /// The challenge port is only claimed for a name whose certificate we hold,
+    /// and never for the bare-IP vhost, whose :443 forward belongs to the OS.
+    #[test]
+    fn nothing_else_claims_the_challenge_port() {
+        let desired = desired_port_maps(
+            &targets([
+                (Some("plain.example.com"), 50002, target(false, false)),
+                (None, 8443, target(true, false)),
+            ]),
+            &ip_info(),
+        );
+
+        assert!(routes(&desired, BOX_IP, 443).is_empty());
+    }
+
+    /// A domain that really is served on :443 keeps its own route there.
+    #[test]
+    fn a_real_443_binding_owns_the_port_it_serves() {
+        let desired = desired_port_maps(
+            &targets([
+                (Some("example.com"), 443, target(true, false)),
+                (Some("example.com"), 50002, target(true, false)),
+            ]),
+            &ip_info(),
+        );
+
+        assert_eq!(
+            routes(&desired, BOX_IP, 443),
+            [("example.com".to_string(), 443)],
+        );
+    }
+
+    /// IPv6 pinholes carry no name and no port translation: a GUA on :443 still
+    /// gets the 80 -> 443 redirect and nothing else.
+    #[test]
+    fn ipv6_pinholes_are_unchanged() {
+        let desired = desired_port_maps(
+            &targets([(Some("example.com"), 443, target(true, true))]),
+            &ip_info(),
+        );
+
+        assert_eq!(routes(&desired, GUA, 443), [("*".to_string(), 443)]);
+        assert_eq!(routes(&desired, GUA, 80), [("*".to_string(), 443)]);
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/vhost.rs
+++ b/shared-libs/crates/start-core/src/net/vhost.rs
@@ -326,9 +326,8 @@ impl VHostController {
         })
     }
 
-    /// Notifies the operator, once per name until a certificate lands, that
-    /// ACME issuance is failing. The address refuses connections while that is
-    /// true, so nothing else would say why.
+    /// Once per name until a certificate lands: the address refuses
+    /// connections meanwhile, and nothing else would say why.
     fn report_acme_failure(&self) -> ReportOrderFailure {
         let db = self.db.clone();
         Arc::new(move |sans, error| {
@@ -531,25 +530,16 @@ impl VHostController {
     }
 }
 
-/// A vhost entry's identity: `(hostname, external port, serves the public
-/// exposure)`. A name reachable both from the LAN and from the internet has one
-/// entry per side, so that only the public one carries a certificate authority.
+/// `(hostname, external port, is the public leg)`. A name reachable both ways
+/// has one entry per side; only the public one carries an authority.
 pub type VHostKey = (Option<InternedString>, u16, bool);
 
-/// The port ACME's TLS-ALPN-01 challenge is dialed at. Fixed by the protocol —
-/// the validator ignores whatever port the name is actually served on.
+/// Where TLS-ALPN-01 is validated, whatever port the name is served on.
 const ACME_CHALLENGE_PORT: u16 = 443;
 
-/// The upstream port maps a set of vhost targets calls for: `(box IP to map
-/// from, external port) -> (ordered PCP gateway candidates, hostname -> box-side
-/// port)`. Gateways stay an ordered Vec — the port-mapper tries them in
-/// preference order and takes the first that binds. A `Some(hostname)` is
-/// mapped via PCP HOSTNAME: the gateway treats the hostname as part of the
-/// mapping's identity and demultiplexes the shared external port by TLS SNI, so
-/// one service adding or removing a hostname never disturbs another's on the
-/// same port — and each name carries its own box-side port. A `None` is a
-/// bare-IP (`*` vhost) forward or an IPv6 GUA pinhole: no SNI, so a plain
-/// pinhole to the box's own IP where the OS reverse proxy listens.
+/// `(box IP, external port) -> (gateway candidates in preference order,
+/// hostname -> box-side port)`. `Some(hostname)` is a PCP HOSTNAME mapping the
+/// gateway SNI-demuxes; `None` is a bare-IP forward or a GUA pinhole.
 type DesiredPortMaps = BTreeMap<
     (IpAddr, u16),
     (
@@ -558,9 +548,6 @@ type DesiredPortMaps = BTreeMap<
     ),
 >;
 
-/// For each target public on IPv4 (`public_v4`), each of that gateway's box
-/// IPv4s gets a mapping keyed by the vhost's hostname. IPv6 GUAs carry no NAT,
-/// so they get a firewall pinhole at the same port instead.
 fn desired_port_maps(
     targets: &BTreeMap<VHostKey, ProxyTarget>,
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
@@ -589,11 +576,9 @@ fn desired_port_maps(
                     .or_insert_with(|| (gateways.clone(), BTreeMap::new()))
                     .1
                     .insert(maybe_host.clone(), *external);
-                // The domain's own port carries no ACME challenge, so route the
-                // challenge port to it as well or the order can never complete.
-                // By name only — the challenge is selected by SNI, and the
-                // unnamed forward there is the OS's own. `or_insert` so a real
-                // binding on that port keeps it, in any visit order.
+                // Nothing answers the challenge on the domain's own port. By
+                // name only: the unnamed forward there is the OS's own, and
+                // `or_insert` leaves a real binding on it alone.
                 if let Some(hostname) = maybe_host
                     && target.acme.is_some()
                     && *external != ACME_CHALLENGE_PORT
@@ -609,11 +594,7 @@ fn desired_port_maps(
         }
         // IPv6: the box's own GUA is the listener (no NAT), so open a firewall
         // pinhole for GUA:port. No SNI demux over v6, so these are always
-        // hostname-less — which is also why the challenge port gets no v6
-        // counterpart: a GUA belongs to the gateway and every host on the box
-        // shares it, so claiming :443 on one would claim it for all of them.
-        // A domain public over both families validates over IPv4; one public
-        // only over IPv6 has no path for its challenge.
+        // hostname-less — and a GUA is shared, so no challenge port either.
         for gua in &target.public_v6 {
             let Some(info) = ip_info.iter().map(|(_, i)| i).find(|info| {
                 info.ip_info.as_ref().map_or(false, |i| {
@@ -830,11 +811,8 @@ pub trait VHostTarget<A: Accept>: std::fmt::Debug + Eq {
         true
     }
     /// Whether this target answers `metadata` as one of the box's own private
-    /// addresses, which takes precedence over answering it as a public one. A
-    /// name can be served both ways at once — the same domain resolving to a
-    /// LAN address inside the network and a public one outside it — and on
-    /// IPv4 both arrive on the same gateway, so a target that claims the
-    /// connection here is the one that owns it.
+    /// addresses. Preferred over a plain [`filter`](Self::filter) match, which
+    /// on IPv4 cannot tell a local dial from a forwarded one.
     #[allow(unused_variables)]
     fn filter_private(&self, metadata: &<A as Accept>::Metadata) -> bool {
         false
@@ -1082,10 +1060,8 @@ impl ProxyTarget {
         wan || self.accepts_as_private(subnets, src, dst)
     }
 
-    /// Whether this is a dial of one of our own private addresses from the
-    /// network that address is on. IPv4 gives such a dial the same arrival
-    /// gateway as a forwarded WAN one — the box sees its own LAN IPv4 either
-    /// way — so the source address is what tells them apart.
+    /// A dial of one of our own private addresses from that address's network.
+    /// On IPv4 the source is all that separates it from a forwarded one.
     fn accepts_as_private(&self, subnets: &OrdSet<IpNet>, src: IpAddr, dst: IpAddr) -> bool {
         self.private.contains(&dst)
             && (subnets.iter().any(|s| s.contains(&src)) || is_private_ip(src))
@@ -1120,8 +1096,6 @@ impl ProxyTarget {
     }
 }
 
-/// Where a connection came from and landed: `(arrival gateway, that gateway's
-/// subnets, source, local address)`.
 struct Arrival {
     gateway: GatewayId,
     subnets: OrdSet<IpNet>,
@@ -1580,10 +1554,8 @@ fn host_key(server_name: Option<&str>) -> Option<InternedString> {
         .map(InternedString::from)
 }
 
-/// A TLS-ALPN-01 challenge names the host it is validating, and the name is the
-/// whole authorization: it is what the challenge is answered against. A dial
-/// that names nothing is an ordinary connection whatever it advertises, and
-/// treating it as a challenge would hand it to a handler that answers by name.
+/// A challenge names the host it validates. One that names nothing is an
+/// ordinary connection, whatever it advertises.
 fn is_acme_challenge<'a>(
     server_name: Option<&str>,
     mut alpn: impl Iterator<Item = &'a [u8]>,
@@ -1712,11 +1684,8 @@ where
             is_acme_challenge(hello.server_name(), hello.alpn().into_iter().flatten());
 
         let Some((target, ctx)) = routed else {
-            // TLS-ALPN-01 is always validated at :443, but the name being
-            // validated may only be served on some other port, so its challenge
-            // lands on a server that doesn't route it. The inner handler answers
-            // only from the controller-wide cache of in-flight orders, so this
-            // still refuses every name we are not ourselves ordering for.
+            // Validation is at :443 whatever port the name is served on, so a
+            // challenge lands here. Answered only from our orders in flight.
             if acme_challenge {
                 return self.acme.get_config(hello, metadata).await;
             }
@@ -1738,18 +1707,12 @@ where
         }
 
         let action = if target.0.acme().is_some() {
-            // This address is served the certificate its authority issued or
-            // nothing at all. The local root CA would answer for any name asked
-            // of it, so falling back to it hands a client that asked for a
-            // publicly trusted certificate one signed by a chain shared with
-            // every other address on this server — under a name the UI still
-            // labels with the authority. Refuse the connection instead.
+            // The authority's certificate or nothing: the root CA would answer
+            // for the name with a chain shared by every address on this server.
             self.acme.get_config(hello, metadata).await?
         } else {
-            // No authority on this address: the local root CA serves it, as it
-            // does every LAN address. A certificate the authority issued for
-            // this name is still preferred where one exists, so a domain
-            // reachable both ways presents the same certificate either way.
+            // The authority's certificate where one exists, so a name served
+            // both ways presents the same one either way; the root CA else.
             match self.acme.get_config(hello, metadata).await {
                 Some(action) => action,
                 None => self.root_ca.get_config(hello, metadata).await?,
@@ -2073,10 +2036,8 @@ mod host_key_tests {
         assert_eq!(host_key(Some("fd00:3::1")), None);
     }
 
-    /// A challenge is answered by name, so a dial that names nothing is never
-    /// one — otherwise it reaches a handler with no name to check, which
-    /// declines, and the next handler in the chain answers with a local
-    /// certificate.
+    /// Otherwise it reaches a handler with no name to check, which declines,
+    /// and the root CA answers.
     #[test]
     fn a_challenge_without_a_name_is_not_a_challenge() {
         let acme = || [ACME_TLS_ALPN_NAME].into_iter();
@@ -2122,8 +2083,7 @@ mod port_map_tests {
     const BOX_IP: &str = "10.13.13.5";
     const GUA: &str = "2001:db8::5";
 
-    /// A StartTunnel gateway: on-link, so NetworkManager reports no next hop and
-    /// `candidate_gateways` derives the relay from the subnet.
+    /// On-link like StartTunnel: no next hop, so the relay comes from the subnet.
     fn ip_info() -> OrdMap<GatewayId, NetworkInterfaceInfo> {
         let mut info = OrdMap::new();
         info.insert(
@@ -2174,8 +2134,7 @@ mod port_map_tests {
         }
     }
 
-    /// Every entry here is a public leg — a private one carries no public
-    /// gateway, so it contributes no port map at all.
+    /// All public legs; a private one has no public gateway to map.
     fn targets<'a>(
         entries: impl IntoIterator<Item = (Option<&'a str>, u16, ProxyTarget)>,
     ) -> BTreeMap<VHostKey, ProxyTarget> {
@@ -2185,7 +2144,6 @@ mod port_map_tests {
             .collect()
     }
 
-    /// The hostname -> box-side port routes mapped at `(ip, external)`.
     fn routes(desired: &DesiredPortMaps, ip: &str, external: u16) -> Vec<(String, u16)> {
         let key: (IpAddr, u16) = (ip.parse().unwrap(), external);
         desired
@@ -2199,8 +2157,6 @@ mod port_map_tests {
             .unwrap_or_default()
     }
 
-    /// The challenge is dialed at :443 whatever port the domain serves on, so
-    /// the domain's own route is not enough on its own.
     #[test]
     fn an_acme_domain_off_443_also_routes_the_challenge_port() {
         let desired = desired_port_maps(
@@ -2218,8 +2174,6 @@ mod port_map_tests {
         );
     }
 
-    /// Each name carries its own box-side port, so two domains on one external
-    /// port do not collapse onto whichever was reconciled first.
     #[test]
     fn each_acme_domain_keeps_its_own_challenge_route() {
         let desired = desired_port_maps(
@@ -2239,8 +2193,6 @@ mod port_map_tests {
         );
     }
 
-    /// The challenge port is only claimed for a name whose certificate we hold,
-    /// and never for the bare-IP vhost, whose :443 forward belongs to the OS.
     #[test]
     fn nothing_else_claims_the_challenge_port() {
         let desired = desired_port_maps(
@@ -2254,7 +2206,6 @@ mod port_map_tests {
         assert!(routes(&desired, BOX_IP, 443).is_empty());
     }
 
-    /// A domain that really is served on :443 keeps its own route there.
     #[test]
     fn a_real_443_binding_owns_the_port_it_serves() {
         let desired = desired_port_maps(
@@ -2271,8 +2222,6 @@ mod port_map_tests {
         );
     }
 
-    /// IPv6 pinholes carry no name and no port translation: a GUA on :443 still
-    /// gets the 80 -> 443 redirect and nothing else.
     #[test]
     fn ipv6_pinholes_are_unchanged() {
         let desired = desired_port_maps(
@@ -2373,10 +2322,8 @@ mod accept_filter_tests {
         assert!(!t.accepts(&gw("other"), &no_subnets, src, v4));
     }
 
-    /// A domain reachable both ways is two targets. IPv4 hands a forwarded WAN
-    /// dial and a local one the same arrival gateway, so the public leg claims
-    /// both — the source address is what separates them, and the private leg's
-    /// claim is the stronger one.
+    /// IPv4 hands a forwarded dial and a local one the same gateway, so the
+    /// public leg claims both; the private leg's claim is the stronger one.
     #[test]
     fn a_lan_dial_of_a_dual_exposure_domain_belongs_to_the_private_leg() {
         let g = gw("eth0");


### PR DESCRIPTION
Closes part of #3717 — the two fixes you specified, plus the companions each of them needs and the follow-ups from review.

## What was happening

A domain's ACME provider is attached to the vhost target for whatever SSL port its binding got (`net_controller.rs:518`), and a package can never hold 443 (`may_claim` in `forward.rs`). Each `VHostServer` answers by name for its own port only, so a TLS-ALPN-01 probe to `<name>:443` reached nothing — and the resolution chain then fell through to `RootCaTlsHandler`, which mints a leaf for any name it is asked for.

## 1. An ACME domain with no certificate fails the connection

The vhost now holds the ACME and root-CA handlers itself instead of chaining them, and decides from the target the connection actually routed to: an address with an authority is served that authority's certificate or nothing; an address without one falls back to the local root CA as any LAN address does. Declining *is* the refusal — nothing is chained below — so `ChainedHandler` and the reject action an earlier draft needed are gone.

**The alert was never reaching the wire.** On the refusal path `mid.io` is still `BTBuffer::Buffering`, so `write_all` of the fatal `unrecognized_name` went into an in-memory buffer and the client saw a bare TCP close. `stop_buffering()` first. Already true on master; refusing puts far more connections through that path, so it stops being cosmetic.

**A failing renewal must not take the domain down.** `should_use_cert` turns false 30 days before expiry so a renewal is attempted; that certificate is still publicly trusted. Without this, fail-closed would turn every failing renewal into a 30-day outage with a valid certificate sitting in the DB. The cached certificate is now the answer of last resort until it actually expires — including when the provider was removed from the server's settings while a domain still names it.

## 2. A domain on another port also asks for the challenge port

`reconcile_port_maps`' desired map carried **one** internal port per `(box IP, external port)` shared by every hostname on it, so it could not express `443/SNI=a → 50002` and `443/SNI=b → 5349` at once; two ACME domains would have collapsed onto whichever was reconciled first. It now carries a box-side port per hostname, and an ACME target on a port other than 443 additionally asks for `443/SNI=<name> → <its port>`. A real 443 binding keeps that route, in any visit order.

**No relay change.** `port_map/server/mod.rs:397` already sets `target = SocketAddrV4::new(peer, internal_port)` independently of the external port, `SniRoute.target` persists an arbitrary port, and the relay's own UI is not on 443. Verified through `SniDemux::register`.

The derivation is now the free function `desired_port_maps`, mirroring `desired_listeners` — which is what makes it testable.

## 3. Answering a challenge for a name a server does not route

Not one of your two, and separable. Your fix (2) reaches a gateway that speaks PCP with the Start9 `HOSTNAME` extension — StartTunnel. The other case in the issue (coturn on `5349`, directly routed, siblings holding real LE certs so 443 demonstrably reaches the box) has no such gateway: the challenge arrives at the box's own 443 listener, which does not route that name.

So an `acme-tls/1` ClientHello for an SNI a server does not route is answered from the controller-wide cache of orders in flight. Nothing else populates that cache, so this still refuses every name we are not ourselves ordering for.

## 4. Split DNS keeps its local side (your call)

A name reachable both ways now gets **one vhost entry per side**, and only the public one carries an authority. The two are told apart by the source address — IPv4 hands a forwarded WAN dial and a local one the same arrival gateway, so a target that claims a connection as one of our own private addresses wins over one that claims it on the gateway alone (`filter_private`, preferred in the routing lookup; this is what stops the choice depending on insertion order). The local side is served the server's own certificate, or the authority's where one has been issued — the same certificate either way, as `private-domains.md` promises.

`GetVHostAcmeProvider` had to move with it: it took the *first* alive target for a name, which with two legs would have found the private one and never ordered a certificate at all. It now takes the provider from whichever leg carries one.

## 5. The refusal says why (your call)

The first failure to obtain a certificate for a name raises a `Warning` notification naming the domain and the reason. Every retry while it stands is silent, and the per-order entry is dropped once a certificate lands, so the next failure after a success speaks again. Wired as a callback from `VHostController` (which holds the concrete DB) so `AcmeTlsHandler` stays generic. New keys in all five locales.

## 6. No authority where the service holds the certificate (your call)

The Certificate Authority column read the domain's stored config for every address, including one whose container serves its own TLS and which StartOS never terminates — so a passthrough address claimed an authority that has nothing to do with the certificate a client actually checks. It now reports from the binding: `Self signed`. And `add-public-domain` refuses an authority for a host with no binding StartOS terminates, which covers the CLI as well; the form already hid the selector where no binding on the host is ours.

## Trade-offs still worth stating

- **Refusal is a fatal alert, not a degraded certificate.** During first boot, DNS propagation, the 60s failure backoff and up to a 24h `Retry-After`, a public ACME address is *down*, not degraded. Its LAN side (4) and the notification (5) are what keep that from being silent or total.
- **Remote admin lockout is still possible.** An admin who put a Let's Encrypt domain on the admin host, disabled the bare public IP, and has no private domain for it loses their only remote entry point until issuance succeeds. LAN and `.local` are unaffected.
- **No IPv6 challenge route.** A GUA belongs to the gateway and every host on the box shares it, so claiming `[gua]:443` for one domain would claim it for all of them. A dual-stack domain validates over IPv4; one public only over IPv6 has no path for its challenge.
- **The add-domain checks still test the interface's own port**, not 443, so they can go all-green on a domain that then refuses. Documented in `clearnet.md`; probing 443 for an ACME domain would change the RPC result shape and the modal, so I left it out. Worth keeping #3717 open for that.

## Testing

`cargo test --features=test --lib` — 605 pass; `check:ui` clean; `cargo check -p startwrt-core` clean (the `TlsHandlerAction` variant it constructs is untouched). New:

- `tls.rs::a_refused_connection_gets_a_tls_alert` — real loopback handshake through a `TlsListener`; asserts the client sees `AlertReceived(UnrecognisedName)` rather than a bare close (this pins the `stop_buffering` fix), and that a handler serving a certificate still completes.
- `vhost.rs::port_map_tests` — five cases over `desired_port_maps`, including two ACME domains keeping distinct box-side ports at 443, a real 443 binding winning, and nothing else claiming 443.
- `vhost.rs::a_lan_dial_of_a_dual_exposure_domain_belongs_to_the_private_leg` — pins the precedence in (4), including the fact that the public leg *also* matches a LAN dial, which is why precedence is needed.
- `vhost.rs::a_challenge_without_a_name_is_not_a_challenge` — a dial with no SNI is not a challenge. An adversarial review pass caught that without this, (3) handed the Root CA chain to `openssl s_client -alpn acme-tls/1 -noservername` against an unrouted port: the ACME handler bails on the missing name *before* it can refuse, and the chain then reached `RootCaTlsHandler` — the exact leak this PR is about.
- `ssl.rs::the_renewal_window_is_unexpired_but_due_for_renewal` — the 30-day window is unexpired but due.

Not covered in-repo: end-to-end issuance (needs public DNS + a reachable relay) and the PCP `443 → 50002` handshake against a live `tunnelbox`. I can run the latter on a VM pair if you want it before merge.
