### PR TITLE
fix(sdk): enforce action input patterns on every path, not just the form

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -100,6 +100,17 @@
 
 ### Fixed
 
+- **A text field's `patterns` are now enforced on every path into an action,
+  not only by the web form.** The regexes reached the browser and nothing else,
+  so an action invoked over `start-cli` or RPC arrived at the handler with a
+  value that had never been tested — a field's own declaration that a value is
+  invalid was ignored precisely where no human was reading the form. The check
+  now lives in the input spec's parser, which `Action.run` already applies to
+  the submitted input. It mirrors the form: a pattern is **anchored** unless it
+  already is, so `[a-z]+` constrains the whole value rather than a substring,
+  and an **empty value passes**, left to `required`. Covers `Value.text`,
+  `Value.textarea`, `List.text` and their dynamic variants
+
 - **A build whose `start-cli s9pk list-ingredients` fails now stops instead of
   silently repacking the previous s9pk.** That command produces the s9pk's
   entire source-dependency list, `javascript/index.js` included — nothing else

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -221,6 +221,31 @@ export const configure = sdk.Action.withInput(
 
 The five arguments to `withInput` are: action ID, metadata (static object or async function), input spec, prefill function, and handler.
 
+### Validating Input
+
+A text field's `patterns` are checked before your handler runs, on **every** path into the action — the form, `start-cli package action run`, and a direct RPC call alike. A value that fails one is rejected with that pattern's `description`, so the caller sees the same message wherever they came from.
+
+```typescript
+sessionTimeout: Value.text({
+  name: i18n('Session Timeout'),
+  required: false,
+  default: null,
+  patterns: [
+    {
+      regex: '^([0-9]+(s|m|h))+$',
+      description: i18n('Must be a number followed by s, m, or h'),
+    },
+  ],
+}),
+```
+
+Two details worth knowing, both inherited from how the form has always behaved:
+
+- **A pattern is anchored.** `[a-z]+` matches the whole value, not a substring — write it as though `^` and `$` were there, because they are added if you leave them off.
+- **An empty value skips its patterns**, and is left to `required`. An optional field the user leaves blank is not made invalid by a pattern it could never satisfy.
+
+Anything a pattern can't express — a cross-field rule, a value that has to exist on disk — still belongs in the handler, where a `throw` surfaces to the caller the same way.
+
 ### Generating Values in a Form
 
 When a form field holds a secret, don't generate it in package code. `Value.text` accepts a `RandomString` spec — `{ charset, len }` — in two places, and StartOS does the generating:

--- a/shared-libs/ts-modules/start-core/lib/actions/input/builder/list.ts
+++ b/shared-libs/ts-modules/start-core/lib/actions/input/builder/list.ts
@@ -7,6 +7,7 @@ import {
   ValueSpecList,
   ValueSpecListOf,
 } from '../inputSpecTypes'
+import { withPatterns } from './patternCheck'
 import { z } from '../../../zExport'
 
 /**
@@ -83,7 +84,7 @@ export class List<
       generate?: null | RandomString
     },
   ) {
-    const validator = z.array(z.string())
+    const validator = z.array(withPatterns(z.string(), aSpec.patterns))
     return new List<string[]>(() => {
       const spec = {
         type: 'text' as const,
@@ -161,7 +162,10 @@ export class List<
         spec,
       }
 
-      return { spec: built, validator }
+      return {
+        spec: built,
+        validator: z.array(withPatterns(z.string(), aSpec.patterns)),
+      }
     }, validator)
   }
 

--- a/shared-libs/ts-modules/start-core/lib/actions/input/builder/patternCheck.ts
+++ b/shared-libs/ts-modules/start-core/lib/actions/input/builder/patternCheck.ts
@@ -1,0 +1,35 @@
+import { Pattern } from '../inputSpecTypes'
+import { z } from '../../../zExport'
+
+/**
+ * Anchors a pattern the way Angular's `Validators.pattern` does for a string
+ * regex — `^` and `$` are added unless already present. A spec's `regex` is
+ * authored against that behavior, so an unanchored test here would accept
+ * values the form rejects.
+ */
+function anchor(regex: string): RegExp {
+  return new RegExp(
+    `${regex.startsWith('^') ? '' : '^'}${regex}${regex.endsWith('$') ? '' : '$'}`,
+  )
+}
+
+/**
+ * Applies a text field's declared `patterns` to its parser, so the guarantee
+ * holds for callers that never render the form — `start-cli`, RPC, anything
+ * driving an action directly.
+ *
+ * An empty string passes every pattern and is left to `required`, matching the
+ * form, where `Validators.pattern` short-circuits on an empty value. Without
+ * that, an optional field left blank would fail its own pattern.
+ */
+export function withPatterns(
+  parser: z.ZodType<string>,
+  patterns: Pattern[] | undefined,
+): z.ZodType<string> {
+  return (patterns ?? []).reduce((acc, { regex, description }) => {
+    const anchored = anchor(regex)
+    return acc.refine(value => value === '' || anchored.test(value), {
+      message: description,
+    })
+  }, parser)
+}

--- a/shared-libs/ts-modules/start-core/lib/actions/input/builder/value.ts
+++ b/shared-libs/ts-modules/start-core/lib/actions/input/builder/value.ts
@@ -12,6 +12,7 @@ import {
 } from '../inputSpecTypes'
 import { DefaultString } from '../inputSpecTypes'
 import { _, once } from '../../../util'
+import { withPatterns } from './patternCheck'
 import { z } from '../../../zExport'
 import { DeepPartial } from '../../../types'
 
@@ -333,7 +334,7 @@ export class Value<
      */
     generate?: RandomString | null
   }) {
-    const validator = asRequiredParser(z.string(), a)
+    const validator = asRequiredParser(withPatterns(z.string(), a.patterns), a)
     return new Value<AsRequired<string, Required>>(
       async () => ({
         spec: {
@@ -399,7 +400,7 @@ export class Value<
             generate: a.generate ?? null,
             ...a,
           },
-          validator: asRequiredParser(z.string(), a),
+          validator: asRequiredParser(withPatterns(z.string(), a.patterns), a),
         }
       },
       z.string().nullable(),
@@ -463,7 +464,7 @@ export class Value<
      */
     immutable?: boolean
   }) {
-    const validator = asRequiredParser(z.string(), a)
+    const validator = asRequiredParser(withPatterns(z.string(), a.patterns), a)
     return new Value<AsRequired<string, Required>>(async () => {
       const built: ValueSpecTextarea = {
         description: null,
@@ -523,7 +524,7 @@ export class Value<
             immutable: false,
             ...a,
           },
-          validator: asRequiredParser(z.string(), a),
+          validator: asRequiredParser(withPatterns(z.string(), a.patterns), a),
         }
       },
       z.string().nullable(),

--- a/shared-libs/ts-modules/start-core/lib/test/inputPatterns.test.ts
+++ b/shared-libs/ts-modules/start-core/lib/test/inputPatterns.test.ts
@@ -1,0 +1,139 @@
+import { InputSpec } from '../actions/input/builder/inputSpec'
+import { List } from '../actions/input/builder/list'
+import { Value } from '../actions/input/builder/value'
+
+const goDuration = {
+  regex: '^([0-9]+(s|m|h))+$',
+  description: 'Must be a number followed by s, m, or h',
+}
+
+/** Unanchored on purpose — the form anchors it, and so must the parser. */
+const lowercase = {
+  regex: '[a-z]+',
+  description: 'May only contain lower case letters',
+}
+
+async function parserFor(value: Value<any, any>) {
+  return (await value.build({} as any)).validator
+}
+
+describe('action input patterns', () => {
+  test('a conforming value parses', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Timeout',
+        required: true,
+        default: null,
+        patterns: [goDuration],
+      }),
+    )
+    expect(parser.parse('2h')).toBe('2h')
+  })
+
+  test('a non-conforming value is rejected with the pattern description', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Timeout',
+        required: true,
+        default: null,
+        patterns: [goDuration],
+      }),
+    )
+    expect(() => parser.parse('2min')).toThrow(goDuration.description)
+  })
+
+  test('an unanchored pattern is anchored, as Validators.pattern does', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Name',
+        required: true,
+        default: null,
+        patterns: [lowercase],
+      }),
+    )
+    expect(parser.parse('abc')).toBe('abc')
+    expect(() => parser.parse('abc1')).toThrow(lowercase.description)
+  })
+
+  test('an already-anchored pattern is not double-anchored', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Timeout',
+        required: true,
+        default: null,
+        patterns: [goDuration],
+      }),
+    )
+    expect(parser.parse('1h30m')).toBe('1h30m')
+  })
+
+  test('every pattern must hold', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Name',
+        required: true,
+        default: null,
+        patterns: [lowercase, { regex: '.{3,}', description: 'Too short' }],
+      }),
+    )
+    expect(parser.parse('abc')).toBe('abc')
+    expect(() => parser.parse('ab')).toThrow('Too short')
+  })
+
+  test('an empty value defers to required rather than failing the pattern', async () => {
+    const parser = await parserFor(
+      Value.text({
+        name: 'Timeout',
+        required: false,
+        default: null,
+        patterns: [goDuration],
+      }),
+    )
+    expect(parser.parse('')).toBe('')
+    expect(parser.parse(null)).toBe(null)
+  })
+
+  test('a field with no patterns is unconstrained', async () => {
+    const parser = await parserFor(
+      Value.text({ name: 'Any', required: true, default: null }),
+    )
+    expect(parser.parse('anything at all')).toBe('anything at all')
+  })
+
+  test('dynamic text resolves its patterns at build time', async () => {
+    const parser = await parserFor(
+      Value.dynamicText(async () => ({
+        name: 'Timeout',
+        required: true as const,
+        default: null,
+        patterns: [goDuration],
+      })),
+    )
+    expect(parser.parse('45m')).toBe('45m')
+    expect(() => parser.parse('45min')).toThrow(goDuration.description)
+  })
+
+  test('list items are held to their patterns', async () => {
+    const parser = await parserFor(
+      Value.list(List.text({ name: 'Timeouts' }, { patterns: [goDuration] })),
+    )
+    expect(parser.parse(['2h', '45m'])).toEqual(['2h', '45m'])
+    expect(() => parser.parse(['2h', '45min'])).toThrow(goDuration.description)
+  })
+
+  test('the whole input spec parses through its fields', async () => {
+    const built = await InputSpec.of({
+      timeout: Value.text({
+        name: 'Timeout',
+        required: false,
+        default: null,
+        patterns: [goDuration],
+      }),
+    }).build({} as any)
+
+    expect(built.validator.parse({ timeout: '2h' })).toEqual({ timeout: '2h' })
+    expect(() => built.validator.parse({ timeout: '2min' })).toThrow(
+      goDuration.description,
+    )
+  })
+})


### PR DESCRIPTION
## The problem

A text field's `patterns` reached the browser and nothing else. `Validators.pattern` is applied in [`form.service.ts:178`](../blob/master/projects/start-os/web/ui/src/app/services/form.service.ts#L178), and `Pattern.regex` had no other runtime consumer anywhere in `start-core` — Rust or TypeScript. So an action invoked through `start-cli package action run`, or any direct RPC call, arrived at the handler with a value that had never been tested, and the handler wrote it.

The field's own declaration was the only statement that the value was invalid, and it was ignored precisely where no human was reading the form. Its doc comment promises otherwise, without qualification:

> A list of regular expressions to which the text must conform to pass validation.

## The fix

Apply the patterns in the input spec's parser. `Action.run` already runs that parser over the submitted input:

```ts
options.input = prevInputSpec.validator.parse(options.input)
```

so the check lands on every caller rather than one client, and nothing new is threaded through the call path.

**It mirrors the form exactly**, including the two behaviours a hand-rolled check gets wrong:

- **A pattern is anchored** at both ends unless it already is — what Angular does for a string regex. `[a-z]+` therefore constrains the whole value, not a substring. Testing it unanchored on this side would accept values the form rejects, which is a worse bug than not checking at all: the two paths would disagree about the same spec.
- **An empty value passes every pattern** and is left to `required`, matching `Validators.pattern`'s short-circuit on an empty control. Without it, an optional field left blank would fail a pattern it could never satisfy.

Covers `Value.text`, `Value.textarea`, `List.text` and their dynamic variants — every builder that declares `patterns`. Colour and datetime are untouched: they declare none, and the form validates them by other means.

## How it was found, and how it was verified

Auditing `navidrome-startos` for the community registry. Its Session Timeout field declares `^([0-9]+(s|m|h))+$`. Over the CLI:

```sh
EV=$(start-cli -H https://<host> package action get-input navidrome settings --format json | jq -r .eventId)
echo '{"…","sessionTimeout":"2min"}' \
  | start-cli -H https://<host> package action run navidrome settings --event-id "$EV"
```

exited 0, wrote `"sessionTimeout": "2min"`, and — because the daemon reads that setting reactively — restarted straight into:

```
FATAL: Error parsing config: decoding failed due to the following error(s):
'SessionTimeout' time: unknown unit
```

Verified against a StartOS 0.4.0.1 box, with that package's own handler-side check disabled so the SDK was the only guard. The same call now fails before the handler runs:

```
Action Failed: [
  {
    "code": "custom",
    "path": ["sessionTimeout"],
    "message": "Must be a number followed by s, m, or h (e.g. \"45m\", \"2h\", or \"1h30m\")."
  }
]
```

`store.json` was left at its previous value — no partial write — and a valid value (`90m`) still saved and restarted the daemon cleanly.

Ten tests in `lib/test/inputPatterns.test.ts` pin the semantics, anchoring and the empty-value case included. The existing suite is unchanged: 98 passed, 9 skipped, same as before.

## Compatibility

A package whose regex is correct sees no change. Two cases do change, and both are the point of the PR:

- A package relying on bad input reaching its handler now gets the rejection the form has always produced.
- A package whose regex is wrong — most likely written unanchored on the assumption it was a substring match — was already behaving that way in the UI, so this makes the RPC path agree with what its users already saw.

## Not in this PR

`minLength` / `maxLength` have the same gap: the form applies `textLengthInRange`, the parser doesn't. Left out deliberately — matching a second validator's empty-value and null handling is its own piece of work, and I'd rather it not ride along with the one that had a live crash behind it. Happy to follow up.
