### PR TITLE
fix(sdk): reject manifest fields the SDK does not define

### DIFF
--- a/projects/start-sdk/lib/manifest/setupManifest.ts
+++ b/projects/start-sdk/lib/manifest/setupManifest.ts
@@ -9,6 +9,23 @@ import { VersionGraph } from '../version/VersionGraph'
 import { version as sdkVersion } from '../../package.json'
 
 /**
+ * Retypes every key the SDK does not define, so declaring one is a compile
+ * error at that key rather than a field that silently does nothing. The
+ * replacement is a string literal rather than `never` purely so the error names
+ * what went wrong.
+ *
+ * TypeScript applies its excess-property check only when a fresh object literal
+ * meets a non-generic target, and `Manifest` is inferred from the argument — so
+ * without this an unknown field joins the inferred type, typechecks, and is
+ * then dropped on the way to the built manifest.
+ */
+type NoExtraKeys<Manifest> = {
+  [K in keyof Manifest]: K extends keyof SDKManifest
+    ? Manifest[K]
+    : 'Unknown manifest field — not declared in SDKManifest'
+}
+
+/**
  * @description Use this function to define critical information about your package
  *
  * @param manifest Static properties of the package
@@ -20,7 +37,7 @@ export function setupManifest<
     id: Id
     volumes: VolumesTypes[]
   } & SDKManifest,
->(manifest: Manifest & SDKManifest): Manifest {
+>(manifest: Manifest & SDKManifest & NoExtraKeys<Manifest>): Manifest {
   return manifest
 }
 


### PR DESCRIPTION
## The problem

`setupManifest` infers its parameter type from the argument, and TypeScript applies its excess-property check only when a fresh object literal meets a **non-generic** target. So an unknown field joined the inferred `Manifest`, compiled cleanly, and was then dropped on the way to the built manifest — it never reached the registry, and nothing ever said so.

That is how `docsUrls` came to sit in twelve packages across both registries doing nothing (now removed), and how `alerts` outlived its removal from the SDK in the packages that still declare it.

## The fix

One mapped type. Keys in `SDKManifest` keep their type; everything else is retyped, so the compiler names it:

```
error TS2322: Type 'string[]' is not assignable to type
  'string[] & "Unknown manifest field — not declared in SDKManifest"'.

24  export const bad = setupManifest({ ...base, docsUrls: ['https://x'] })
                                                ^
```

The replacement is a string literal rather than `never` purely for that message — `not assignable to type 'never'` is correct and tells a packager nothing. It does mean the literal itself would be accepted as a value, which seemed a fair trade.

`SDKManifest` has no index signature, so the check is exact. Optional declared fields (`plugins`, `osVersion`, `hardwareRequirements`, …) are unaffected.

## Verified

Typechecked against fourteen real packages with this SDK linked in — `hello-world`, `llama-cpp`, `immich`, `nextcloud`, `ollama`, `vllm`, `lnd`, `bitcoin-core/31.x`, `bitcoin-knots/29.x`, `bitcoin-cash-daemon`, `i2pd`, and three under review. Nine pass. Type inference is unchanged: nothing that depends on `Manifest['id']`, `Manifest['volumes'][number]`, or the images/dependencies threading was affected.

Of the five failures, **four are not this change** — they are `TS2554: Expected 1-2 arguments, but got 3`, from the `SubContainer.exec` signature change already landed in the unreleased 2.0.10. They are a migration those packages owe 2.0.10 regardless.

## The one thing worth a decision before merging

The fifth failure is what this change is for, and it shows where the cost lands. `navidrome-startos` fails on **its dependencies'** manifests, not its own:

```
node_modules/maloja-startos/startos/manifest/index.ts(22,3): error TS2322 …
node_modules/multi-scrobbler-startos/startos/manifest/index.ts(22,3): error TS2322 …
```

Both still declare `alerts`. A package's `tsconfig.json` includes `node_modules/**/startos`, so you typecheck your siblings' source — and a sibling that hasn't dropped a dead field breaks *your* build, for a file you don't control.

This isn't new behavior (the `exec` change breaks dependents' source the same way — `lnd` is currently failing on `node_modules/bitcoin-core-startos/…`), but it does mean this wants sequencing:

- **`alerts` should be swept first.** Two packages in our registries still declare it — `bisq2-startos` and `ppq-private-mode-startos`. Say the word and I'll clear them the same way `docsUrls` went.
- **The sibling repos we don't own** — `maloja-startos`, `multi-scrobbler-startos` — are on contributors' accounts and outside a sweep. They'd need the same edit, or the packages depending on them stay red until they get it.
- Landing this **with 2.0.10** rather than after would fold it into one migration for the packages the `exec` change already breaks, instead of two.

## No changelog entry

Omitted deliberately, per maintainer direction — flagging it so review doesn't read it as an oversight.
