### PR TITLE
docs(bitcoin-guides): give the wallet integrations real connection instructions

### DIFF
--- a/projects/start-docs/bitcoin-guides/src/README.md
+++ b/projects/start-docs/bitcoin-guides/src/README.md
@@ -14,11 +14,13 @@ StartOS makes this practical. Install a Bitcoin node from the StartOS Marketplac
 
 - **[Archival vs Pruned Nodes](archival-vs-pruned.md)** — The trade-offs between archival and pruned nodes, and how StartOS makes pruned nodes work seamlessly with multiple downstream services.
 
-- **[Electrum Servers](electrum-servers.md)** — What an Electrum server is, why you need one, and which implementations are available on StartOS.
+- **[Electrum Servers](electrum-servers.md)** — What an Electrum server is, why most wallets need one, and whether you can do without.
 
-- **[Bitcoin Wallets](bitcoin-wallets.md)** — An index of on-chain wallets that connect to your own Bitcoin node or Electrum server, with platforms, connection methods, and links to upstream docs.
+- **[Connecting a Wallet](connecting-wallets.md)** — The steps every wallet has in common: getting the address, why every connection is SSL, and how to make your wallet trust your server's certificate.
 
-- **[Lightning Wallets](lightning-wallets.md)** — Native apps and self-hosted web tools for managing your LND or Core Lightning node, including RTL, ThunderHub, Zeus, Alby Hub, and more.
+- **[Bitcoin Wallets](bitcoin-wallets.md)** — On-chain wallets that connect to your own Bitcoin node or Electrum server, with the platforms each supports and where its connection settings live.
+
+- **[Lightning Wallets](lightning-wallets.md)** — How LND and Core Lightning hand a wallet its connection, and the apps and dashboards that take it — Zeus, BitBanana, RTL, LNbits, Alby Hub, and more.
 
 - **[Migrating LND to StartOS](lnd-migration.md)** — How to transfer your LND node from Umbrel, myNode, or another StartOS server without closing channels.
 

--- a/projects/start-docs/bitcoin-guides/src/SUMMARY.md
+++ b/projects/start-docs/bitcoin-guides/src/SUMMARY.md
@@ -6,6 +6,7 @@
 
 - [Archival vs Pruned Nodes](archival-vs-pruned.md)
 - [Electrum Servers](electrum-servers.md)
+- [Connecting a Wallet](connecting-wallets.md)
 - [Bitcoin Wallets](bitcoin-wallets.md)
 - [Lightning Wallets](lightning-wallets.md)
 - [Migrating LND to StartOS](lnd-migration.md)

--- a/projects/start-docs/bitcoin-guides/src/bitcoin-wallets.md
+++ b/projects/start-docs/bitcoin-guides/src/bitcoin-wallets.md
@@ -1,187 +1,249 @@
 # Bitcoin Wallets
 
-An index of Bitcoin wallets that support connecting to your own Bitcoin node (via RPC) or your own Electrum server (such as Fulcrum). Each entry lists supported platforms, connection method, Tor support, and links to upstream documentation.
+Bitcoin wallets that can be pointed at your own node — either through an Electrum server such as [Fulcrum](electrum-servers.md) or directly over Bitcoin RPC. Each entry gives the platforms, the connection method, and where the setting lives in that wallet.
 
-For Lightning wallets that connect to your own LND or Core Lightning node, see [Lightning Wallets](lightning-wallets.md).
-
-## Connection Methods
-
-There are two ways a wallet can connect to your self-hosted Bitcoin infrastructure:
-
-- **Bitcoin RPC** — The wallet connects directly to your Bitcoin node using its JSON-RPC interface. This gives the wallet full access to your node's blockchain data without any additional indexing service.
-- **Electrum server** — The wallet connects to an Electrum-protocol server (such as Fulcrum) that sits in front of your Bitcoin node. The Electrum server indexes the blockchain and provides fast address lookups. Most wallets use this method.
+Read [Connecting a Wallet](connecting-wallets.md) first: the address, the port, the SSL requirement, and the certificate step are the same for every wallet on this page, and are not repeated in each entry. For Lightning, see [Lightning Wallets](lightning-wallets.md).
 
 ## Summary
 
-| Wallet                              | Platforms                           | Connects to     | Tor |
-| ----------------------------------- | ----------------------------------- | --------------- | --- |
-| [BitBoxApp](#bitboxapp)             | Android, iOS, Linux, macOS, Windows | Electrum server | Yes |
-| [Bitcoin Keeper](#bitcoin-keeper)   | Android, iOS                        | Electrum server | Yes |
-| [Blockstream App](#blockstream-app) | Android, iOS, Linux, macOS, Windows | Electrum server | Yes |
-| [BlueWallet](#bluewallet)           | Android, iOS                        | Electrum server | Yes |
-| [Bull Wallet](#bull-wallet)         | Android, iOS                        | Electrum server | Yes |
-| [BTCPay Server](#btcpay-server)     | Web (self-hosted)                   | Bitcoin RPC     | Yes |
-| [Electrum](#electrum)               | Android, Linux, macOS, Windows      | Electrum server | Yes |
-| [Envoy](#envoy)                     | Android, iOS                        | Electrum server | Yes |
-| [FullyNoded](#fullynoded)           | iOS, macOS                          | Bitcoin RPC     | Yes |
-| [Liana](#liana)                     | Linux, macOS, Windows               | Both            | No  |
-| [Nunchuk](#nunchuk)                 | Android, iOS, Linux, macOS, Windows | Both            | Yes |
-| [Sparrow](#sparrow)                 | Linux, macOS, Windows               | Both            | Yes |
-| [Trezor Suite](#trezor-suite)       | Linux, macOS, Windows               | Electrum server | Yes |
-| [Wasabi](#wasabi)                   | Linux, macOS, Windows               | Bitcoin RPC     | Yes |
+### Apps you run on your own devices
 
-## BitBoxApp
+| Wallet                              | Platforms                           | Connects to     | Tor            |
+| ----------------------------------- | ----------------------------------- | --------------- | -------------- |
+| [BitBoxApp](#bitboxapp)             | Android, iOS, Linux, macOS, Windows | Electrum server | Yes            |
+| [Bitcoin Keeper](#bitcoin-keeper)   | Android, iOS                        | Electrum server | Yes            |
+| [Blockstream App](#blockstream-app) | Android, iOS, Linux, macOS, Windows | Electrum server | Yes            |
+| [BlueWallet](#bluewallet)           | Android, iOS                        | Electrum server | Via Orbot      |
+| [Bull Wallet](#bull-wallet)         | Android, iOS                        | Electrum server | Yes            |
+| [Electrum](#electrum)               | Android, Linux, macOS, Windows      | Electrum server | Yes            |
+| [Envoy](#envoy)                     | Android, iOS                        | Electrum server | Yes            |
+| [FullyNoded](#fullynoded)           | iOS, macOS                          | Bitcoin RPC     | Yes            |
+| [Liana](#liana)                     | Linux, macOS, Windows               | Both            | External proxy |
+| [Nunchuk](#nunchuk)                 | Android, iOS, Linux, macOS, Windows | Both            | Yes            |
+| [Sparrow](#sparrow)                 | Linux, macOS, Windows               | Both            | Built-in       |
+| [Trezor Suite](#trezor-suite)       | Android, iOS, Linux, macOS, Windows | Electrum server | Yes            |
+| [Wasabi](#wasabi)                   | Linux, macOS, Windows               | Bitcoin RPC     | Built-in       |
+
+### Wallets that run on your server
+
+These install from the StartOS Marketplace and reach Bitcoin over the server's internal network, so there is no address, port, or certificate to configure — and no wallet traffic leaving your house at all. Each one's own instructions in StartOS cover its setup.
+
+| Wallet                          | Connects to |
+| ------------------------------- | ----------- |
+| [BTCPay Server](#btcpay-server) | Bitcoin RPC |
+| [Jam](#jam)                     | Bitcoin RPC |
+
+## Apps you run on your own devices
+
+### BitBoxApp
 
 - **Platforms:** Android, iOS, Linux, macOS, Windows
 - **Connects to:** Electrum server
-- **Tor:** Yes — supports Tor proxy and .onion addresses natively
+- **Certificate:** Handled in-app — it offers to fetch your server's certificate
 
-The BitBoxApp is the companion software for BitBox hardware wallets. It supports connecting to your own Electrum server via the app's advanced settings.
+The companion app for BitBox hardware wallets, and usable on its own. Of the wallets here it has the smoothest path to a private server: it fetches and trusts the certificate itself, with no OS-level or file-level step.
+
+**To connect:**
+
+1. Go to **Settings → Advanced settings → Connect your own full node**.
+2. Paste the host and port from your **Electrum (SSL)** interface address as `host:port`. Upstream warns not to substitute 50001 or 50002 for the port your node reports — on StartOS that warning is exactly right.
+3. Choose **Download remote certificate** when prompted, then **Check** to test, then **Add**.
+
+For Tor, enable the Tor proxy under **Advanced settings** first (`127.0.0.1:9050`, or `127.0.0.1:9150` for Tor Browser's), restart the app fully, then add the `.onion` endpoint. If the check fails immediately after enabling Tor, the proxy has not finished connecting — restart and retry.
 
 - [BitBoxApp downloads](https://bitbox.swiss/download/)
 - [Connecting to your own full node](https://support.bitbox.swiss/connecting-the-bitboxapp-to-your-own-full-node)
 
-## Bitcoin Keeper
+### Bitcoin Keeper
 
 - **Platforms:** Android, iOS
 - **Connects to:** Electrum server
-- **Tor:** Yes
 
-Bitcoin Keeper is an open-source mobile wallet with multisig support. It provides an Electrum Server Management interface for connecting to your own server.
+An open-source mobile wallet built around multisig and inheritance, with an Electrum server management screen for pointing it at a server of your own. Add your **Electrum (SSL)** address there; Keeper requires SSL, which is what StartOS serves.
 
 - [Bitcoin Keeper website](https://bitcoinkeeper.app/)
 - [Source code](https://github.com/bithyve/bitcoin-keeper)
 
-## Blockstream App
+### Blockstream App
 
 - **Platforms:** Android, iOS, Linux, macOS, Windows
 - **Connects to:** Electrum server
-- **Tor:** Yes — built-in "Connect with Tor" toggle
 
-Blockstream App supports connecting to your own Electrum server and has a built-in Tor toggle for private connections.
+Formerly Blockstream Green. It supports a personal Electrum server and has a built-in Tor toggle, so no separate proxy is needed.
+
+**To connect (desktop):**
+
+1. Open **App Settings** (the gear icon) and choose **Network**.
+2. Turn on **Connect with Tor** if you are using a `.onion` address.
+3. Go back, then open **Custom servers and validation** and turn on **Choose the Electrum servers you trust**.
+4. Paste your address into **Bitcoin Electrum Server**.
+
+**To connect (mobile):** open **App Settings**, turn on **Connect with Tor** if needed, turn on **Personal Electrum Server**, paste the address into **Bitcoin Electrum server**, and **Save**.
+
+> [!NOTE]
+> Recent versions expose a TLS toggle for personal Electrum servers — leave it on, since StartOS serves TLS only. Whether the app will accept a certificate signed by your server's own authority has not been verified against a StartOS server; if it refuses, a custom domain with an ACME certificate sidesteps the question entirely.
 
 - [Blockstream App downloads](https://blockstream.com/app/)
 
-## BlueWallet
+### BlueWallet
 
 - **Platforms:** Android, iOS
 - **Connects to:** Electrum server
-- **Tor:** Yes — native Tor on both Android and iOS
 
-BlueWallet is a popular mobile Bitcoin wallet that supports connecting to your own Electrum server. It can scan QR codes for Tor-based node connections.
+A popular and approachable mobile wallet. Set the server under **Settings → Network → Electrum server** — either type the host and port, or use **Scan or import a file** to scan the QR code from your Electrum interface. Save, then restart the app.
+
+> [!WARNING]
+> BlueWallet over Tor has a long history of connecting once and then dropping, with no error that explains why. Orbot must be installed and running before it will work at all, and even then StartOS users report repeat disconnections. If you are connecting from outside your home and BlueWallet will not stay up, that is a known rough edge rather than something misconfigured on your server — Sparrow and Nunchuk are the usual fallbacks.
 
 - [BlueWallet website](https://bluewallet.io/)
-- [Electrum server configuration](https://github.com/BlueWallet/BlueWallet/wiki/Electrum-servers-pool)
+- [Electrum servers pool](https://github.com/BlueWallet/BlueWallet/wiki/Electrum-servers-pool)
 
-## Bull Wallet
+### Bull Wallet
 
 - **Platforms:** Android, iOS
 - **Connects to:** Electrum server
-- **Tor:** Yes
 
-Bull Wallet by Bull Bitcoin is a privacy-focused mobile wallet that combines on-chain Bitcoin, Lightning (via Boltz atomic swaps), and Liquid support. It supports connecting to your own Electrum server and works as a companion app for hardware wallets with watch-only imports and air-gapped signing (Coldcard Q).
+Bull Bitcoin's mobile wallet, combining on-chain Bitcoin, Lightning (via Boltz swaps), and Liquid. It supports a custom Electrum server and works as a companion for hardware wallets, with watch-only imports and air-gapped signing for the Coldcard Q.
 
 - [Bull Wallet website](https://www.bullbitcoin.com/blog/bull-by-bull-bitcoin)
 - [Source code](https://github.com/SatoshiPortal/bullbitcoin-mobile)
 
-## BTCPay Server
-
-- **Platforms:** Web (self-hosted)
-- **Connects to:** Bitcoin RPC
-- **Tor:** Yes — built-in Tor support in the Docker deployment
-
-BTCPay Server is a self-hosted payment processor, but it also includes a full on-chain Bitcoin wallet backed by your Bitcoin node. The built-in wallet supports hot wallets, watch-only wallets (xpub import with external signing via PSBT), coin selection, and payment batching. BTCPay Server is also available as a service on the StartOS Marketplace.
-
-BTCPay Server also supports Lightning — see [Lightning Wallets](lightning-wallets.md#btcpay-server).
-
-- [BTCPay Server website](https://btcpayserver.org/)
-- [Wallet documentation](https://docs.btcpayserver.org/Wallet/)
-
-## Electrum
+### Electrum
 
 - **Platforms:** Android, Linux, macOS, Windows
 - **Connects to:** Electrum server
-- **Tor:** Yes — supports SOCKS5 proxy for Tor connections
+- **Certificate:** Needs a file placed by hand
 
-Electrum is the original Electrum-protocol wallet. Connecting to your own Electrum server is a core feature — simply specify your server address in the network settings.
+The original Electrum-protocol wallet, and the one wallet here that will not connect to a StartOS server until you give it your root CA on disk. The reason and the full procedure are on [Connecting a Wallet](connecting-wallets.md#the-electrum-desktop-wallet) — do that first, then set the server under **Tools → Network** as `<host>:<port>:s` with **Connection mode** set to _Connect only to a single server_.
 
 - [Electrum downloads](https://electrum.org/#download)
 - [Using Electrum through Tor](https://electrum.readthedocs.io/en/latest/tor.html)
 
-## Envoy
+### Envoy
 
 - **Platforms:** Android, iOS
 - **Connects to:** Electrum server
-- **Tor:** Yes — built-in Tor toggle ("Improved Privacy" mode)
 
-Envoy is the companion app for the Passport hardware wallet by Foundation Devices, but also works as a standalone wallet. It supports connecting to your own Electrum server with native Tor support.
+The companion app for Foundation's Passport hardware wallet, also usable standalone, with a built-in Tor toggle. Add your **Electrum (SSL)** address in Envoy's settings; a red shield in the app means it cannot reach the custom server you configured.
 
 - [Envoy downloads](https://foundation.xyz/envoy/)
-- [Envoy setup documentation](https://docs.foundation.xyz/envoy/setup/)
+- [Envoy settings](https://docs.foundation.xyz/envoy/envoy-menu/settings/)
 
-## FullyNoded
+### FullyNoded
 
 - **Platforms:** iOS, macOS
 - **Connects to:** Bitcoin RPC
-- **Tor:** Yes — integrated Tor support
+- **Certificate:** None needed over Tor
 
-FullyNoded connects directly to your Bitcoin node over Tor using the RPC interface. No Electrum server required. Connection can be configured via QR code or manual entry.
+Talks to Bitcoin directly over its RPC interface, with Tor integrated — no Electrum server involved. Because it connects to a `.onion` address, which StartOS serves without TLS, there is no certificate step.
+
+**To connect:** run **Generate RPC User Credentials** on the Bitcoin service, then add a node in FullyNoded with Bitcoin's `.onion` RPC address and those credentials.
 
 - [FullyNoded website](https://fullynoded.app/)
 - [Connect your node](https://fonta1n3.github.io/FullyNoded/Docs/Bitcoin-Core/Connect.html)
 
-## Liana
+### Liana
 
 - **Platforms:** Linux, macOS, Windows
-- **Connects to:** Both — Electrum server and Bitcoin RPC
-- **Tor:** No — external Tor proxy required for remote connections
+- **Connects to:** Electrum server or Bitcoin RPC
 
-Liana is focused on timelocked recovery and inheritance use cases. It supports both Electrum server and Bitcoin RPC connections, and can install a pruned Bitcoin node automatically for local use.
+Built around timelocked recovery and inheritance — spending paths that unlock after a period of inactivity. It takes either backend, and will install a pruned node of its own if you have none; on StartOS, point it at the node you already run instead. Tor needs an external proxy.
 
 - [Liana website](https://wizardsardine.com/liana/)
 - [Source code](https://github.com/wizardsardine/liana)
 
-## Nunchuk
+### Nunchuk
 
 - **Platforms:** Android, iOS, Linux, macOS, Windows
-- **Connects to:** Both — Electrum server and Bitcoin RPC
-- **Tor:** Yes
+- **Connects to:** Electrum server or Bitcoin RPC
 
-Nunchuk is a multisig-focused wallet available on all major platforms. It supports connecting to your own Electrum server or Bitcoin node.
+A multisig- and inheritance-focused wallet on every major platform, and one of the more reliable choices for a private server.
+
+**To connect:** open **Network Settings** — under your profile on mobile, and on desktop under **Settings → Network settings**, reached from your profile picture — then put your address in **Mainnet server**, keeping the `ssl://` prefix:
+
+```
+ssl://adjective-noun.local:50002
+```
+
+For a `.onion` address, also turn on **Enable TOR proxy** on the same screen, and make sure Tor is running on the device. Save and restart Nunchuk.
 
 - [Nunchuk website](https://nunchuk.io/)
-- [Custom node connection (v0.9.7)](https://medium.com/nunchuk/nunchuk-0-9-7-6b74b3848c3d)
+- [Source code](https://github.com/nunchuk-io/nunchuk-desktop)
 
-## Sparrow
+### Sparrow
 
 - **Platforms:** Linux, macOS, Windows
-- **Connects to:** Both — Electrum server and Bitcoin RPC
-- **Tor:** Yes — bundled internal Tor proxy that activates automatically for .onion addresses
+- **Connects to:** Electrum server or Bitcoin RPC
+- **Certificate:** Accepts one, or takes a `.crt` file in its server settings
+- **Tor:** Bundled — `.onion` addresses work with no proxy setup
 
-Sparrow is a full-featured desktop wallet widely regarded as the power-user choice. It supports both Bitcoin RPC and Electrum server connections. When you enter a .onion address, Sparrow automatically routes through its built-in Tor proxy.
+The power-user desktop wallet, and the least painful of the desktop options to point at a StartOS server: it will connect to an unrecognised certificate, and it routes `.onion` addresses through its own Tor daemon automatically.
+
+**To connect:**
+
+1. Go to **File → Preferences → Server** (on first run Sparrow takes you straight there).
+2. Choose **Private Electrum**.
+3. Enter the host in **URL** and the port from your Electrum interface address.
+4. Turn **Use SSL** on.
+5. Click **Test Connection**.
+
+Optionally supply your root CA in the certificate field on the same screen. Sparrow will connect without it, but pinning the authority means a swapped certificate is caught rather than silently accepted.
+
+If you are using your own Tor daemon rather than Sparrow's — or routing through a proxy for another reason — enable **Use Proxy** with `localhost` and port `9050`. Leave it off otherwise.
+
+To use Bitcoin RPC instead, choose **Bitcoin Core** on the same screen and supply the RPC address with the credentials from **Generate RPC User Credentials**.
 
 - [Sparrow downloads](https://sparrowwallet.com/download/)
-- [Connect to your node](https://sparrowwallet.com/docs/connect-node.html)
+- [Connect to Bitcoin Core](https://sparrowwallet.com/docs/connect-node.html)
 
-## Trezor Suite
+### Trezor Suite
 
-- **Platforms:** Linux, macOS, Windows
+- **Platforms:** Linux, macOS, Windows (desktop), Android, iOS (mobile)
 - **Connects to:** Electrum server
-- **Tor:** Yes — desktop app supports .onion addresses for custom backends
 
-Trezor Suite is the companion software for Trezor hardware wallets. The desktop app supports connecting to a custom Electrum server backend. The web app and mobile app (Trezor Suite Lite) do not support custom backends.
+The companion software for Trezor hardware wallets. A custom Electrum backend replaces Trezor's own servers, so your addresses stop being queried against them.
+
+**To connect:** go to **Settings → Networks**, click the sliders icon next to Bitcoin, and enter your server in `host:port:protocol` form with `s` for SSL:
+
+```
+adjective-noun.local:50002:s
+```
+
+For a `.onion` address, turn on Tor in Trezor Suite first — it will prompt you if you have not.
 
 - [Trezor Suite downloads](https://trezor.io/trezor-suite)
-- [Connect Trezor Suite to your own node](https://trezor.io/learn/security-privacy/how-trezor-keeps-you-safe/connect-trezor-suite-to-your-node)
 - [Full node via Electrum server](https://trezor.io/learn/supported-assets/bitcoin/full-node-via-electrum-server)
 
-## Wasabi
+### Wasabi
 
 - **Platforms:** Linux, macOS, Windows
 - **Connects to:** Bitcoin RPC
-- **Tor:** Yes — Tor is built-in and enabled by default for all network traffic
+- **Tor:** Built-in and on by default for all traffic
 
-Wasabi Wallet is a privacy-focused desktop wallet. It routes all traffic through Tor by default and supports connecting to your own Bitcoin node via RPC.
+A privacy-focused desktop wallet built around coinjoin. It finds your transactions using BIP158 block filters rather than an address index, so it wants Bitcoin's RPC rather than an Electrum server — and it needs block filters turned on, which is an option under Bitcoin's **Other Settings**.
 
 - [Wasabi downloads](https://wasabiwallet.io/)
-- [Bitcoin full node integration](https://docs.wasabiwallet.io/using-wasabi/BitcoinFullNode.html)
+- [Using a Bitcoin full node](https://docs.wasabiwallet.io/using-wasabi/BitcoinFullNode.html)
+
+## Wallets that run on your server
+
+### BTCPay Server
+
+- **Connects to:** Bitcoin RPC
+
+A self-hosted payment processor with a capable on-chain wallet attached: hot wallets, watch-only wallets from an xpub with PSBT signing elsewhere, coin selection, and payment batching. Install it and it wires itself to Bitcoin — there is nothing to configure.
+
+BTCPay also handles Lightning; see [Lightning Wallets](lightning-wallets.md#btcpay-server).
+
+- [BTCPay Server website](https://btcpayserver.org/)
+- [Wallet documentation](https://docs.btcpayserver.org/Wallet/)
+
+### Jam
+
+- **Connects to:** Bitcoin RPC
+
+A web interface for JoinMarket: collaborative transactions that break the common-input heuristic, and the option to earn fees by offering liquidity to other traders. Tor runs inside it, so market connectivity needs no setup.
+
+Jam imports its wallet into Bitcoin and rescans the chain, so it needs an archival node — see [Archival vs Pruned Nodes](archival-vs-pruned.md).
+
+- [Jam documentation](https://jamdocs.org/)

--- a/projects/start-docs/bitcoin-guides/src/connecting-wallets.md
+++ b/projects/start-docs/bitcoin-guides/src/connecting-wallets.md
@@ -1,0 +1,134 @@
+# Connecting a Wallet
+
+Every wallet that talks to your own node needs the same four things: an address, a port, a way to trust your server's certificate, and — if you are away from home — a route in. This page covers all four once, so the per-wallet pages only have to tell you where the settings live.
+
+Start here, then look up your wallet in [Bitcoin Wallets](bitcoin-wallets.md) or [Lightning Wallets](lightning-wallets.md).
+
+## Which connection do you need?
+
+Two different things on your server can serve a wallet, and which one you want depends on the wallet.
+
+|                              | **Electrum server**                 | **Bitcoin RPC**                                                            |
+| ---------------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| What it is                   | Fulcrum, indexing your Bitcoin node | Your Bitcoin node's own JSON-RPC API                                       |
+| Install                      | Bitcoin **and** Fulcrum             | Bitcoin only                                                               |
+| Extra disk                   | Hundreds of GB for the index        | None                                                                       |
+| Importing an existing wallet | Seconds                             | Walks the whole chain — hours, and impossible past a pruned node's horizon |
+| Used by                      | Most wallets                        | FullyNoded, Wasabi, BTCPay Server                                          |
+
+Most wallets speak the Electrum protocol, so most people install [Fulcrum](electrum-servers.md) and never think about RPC. Bitcoin RPC is the right answer when a wallet only supports it, or when you want to avoid the index's disk cost and are not importing wallets with long histories.
+
+Some wallets — Sparrow, Nunchuk, Liana — will take either. Prefer the Electrum server if you have one running: address lookups come from a purpose-built index instead of a chain scan.
+
+## Getting the address
+
+On your server, open your Electrum server and copy an address from its **Electrum (SSL)** interface. Bitcoin's **RPC** interface works the same way.
+
+The address already contains the host and the port, in the form `ssl://<host>:<port>`. Copy it; do not retype it from memory.
+
+> [!WARNING]
+> **Take the port from the address.** StartOS assigns the external port when the service is installed and never changes it afterwards, so it is a property of your server rather than of the software. 50002 is a preference, not a guarantee. Wallet guides that tell you to enter 50001 or 50002 are describing a hand-configured server, not this one.
+
+Which address you copy depends on where the wallet is:
+
+- **LAN IP** (`192.168.x.x`) — a phone or laptop on your home network. The most reliable choice.
+- **`.local` hostname** (`adjective-noun.local`) — the same, but it survives your router handing the server a new IP. Needs mDNS, which some networks and VPNs block.
+- **`.onion`** — reachable from anywhere, no port forwarding, no domain. Requires Tor at both ends.
+- **Custom domain** — reachable from anywhere and faster than Tor. Requires setting one up.
+
+See [Reaching your server from outside your home](#reaching-your-server-from-outside-your-home) below for the last two.
+
+## Every address is `ssl://`
+
+StartOS terminates TLS in front of the Electrum server and exposes **only** the encrypted endpoint. There is no plaintext port to connect to from off the server, on any address — LAN, `.local`, Tor, and custom domains alike.
+
+So in your wallet, SSL/TLS has to be **on**. How you say that varies:
+
+| Wallet expresses SSL as             | Examples                               |
+| ----------------------------------- | -------------------------------------- |
+| A checkbox                          | Sparrow (_Use SSL_), BlueWallet        |
+| An `:s` suffix on the server string | Electrum (`host:port:s`), Trezor Suite |
+| An `ssl://` prefix                  | Nunchuk                                |
+| Always on, no setting               | BitBoxApp, Bitcoin Keeper              |
+
+> [!NOTE]
+> Getting this wrong rarely produces an error that says so. Sparrow reports "Retries exhausted"; most wallets just show a spinner or a red dot. If a connection fails and you have not explicitly turned SSL on, that is the first thing to check.
+>
+> This also means older walkthroughs no longer apply. Guides that tell you to append `:t` (plain TCP) or connect to port 50001 were written when StartOS exposed a plaintext Electrum port. It does not.
+
+## Making your wallet trust the certificate
+
+The certificate StartOS serves is issued by **your server's own root certificate authority** — one it generated for itself when you set it up. It is a real certificate and it is doing real work, but no wallet has heard of the authority that signed it, so every wallet has to be told to trust it once.
+
+There are four ways that happens, and which one applies is a property of the wallet:
+
+1. **The wallet uses your device's trust store.** Install the StartOS Root CA on the device, exactly as you did to reach the dashboard in your browser — see [Trusting Your Root CA](/start-os/trust-ca.html). Nothing further in the wallet.
+
+2. **The wallet offers to fetch and pin the certificate.** The BitBoxApp does this: it shows a **Download remote certificate** step before it will check the connection. Accept it.
+
+3. **The wallet keeps its own certificate store.** Sparrow has a certificate field in its server settings; Electrum reads a file you place on disk. See [The Electrum desktop wallet](#the-electrum-desktop-wallet) below.
+
+4. **You attached a custom domain with an ACME certificate.** Then the certificate is signed by a public authority, every wallet already trusts it, and there is nothing to do.
+
+> [!NOTE]
+> Tor does not exempt you from this. A web interface reached at a `.onion` address is served over plain HTTP, because Tor already encrypts and authenticates the connection — which is why the Root CA guide says you don't need it for Tor. The Electrum interface is different: it is TLS on every address, including `.onion`, so a wallet connecting over Tor still has to trust the certificate.
+
+## The Electrum desktop wallet
+
+Electrum is the one wallet that needs a file placed by hand, and it is worth understanding why, because the failure is silent.
+
+Electrum checks a server against a bundled list of public certificate authorities. When that check fails it looks at _how_ it failed: a server presenting a **self-signed certificate** is one Electrum will pin on the spot and connect to. Your server does not present a self-signed certificate — it presents one _signed by your server's own authority_, which is a different failure, and Electrum treats it as a server it cannot use. It never gets as far as offering to pin anything.
+
+The fix is to give Electrum the authority instead of the certificate. Electrum loads the file at `certs/<host>` as a trust anchor, so putting your root CA there makes the whole chain verify — and keeps working when your server renews its certificate, which pinning would not.
+
+1. Download your root CA from `http://<your-server>/static/local-root-ca.crt` — plain HTTP, and the same file the browser guide gives you.
+
+2. **Delete any file already sitting at `<data-dir>/certs/<host>`.** A leftover from an earlier attempt stops everything below from working and reports nothing. An empty file is the worst case: to Electrum it means "this server is publicly signed", so it goes back to the public authority list and fails again.
+
+3. Save the certificate as `<data-dir>/certs/<host>`, **with no file extension**. `<host>` must match exactly what you type into Electrum — reaching the same server at `192.168.1.5` and at `my-server.local` needs one file under each name.
+
+4. In Electrum, go to **Tools → Network**. Set **Connection mode** to _Connect only to a single server_ so Electrum cannot fall back to a public one, and enter the server as `<host>:<port>:s`, taking the port from the interface address.
+
+`<data-dir>` is:
+
+| Platform | Path                                     |
+| -------- | ---------------------------------------- |
+| Linux    | `~/.electrum`                            |
+| macOS    | `~/Library/Application Support/Electrum` |
+| Windows  | `%APPDATA%\Electrum`                     |
+
+To connect over Tor as well, switch to the **Proxy** tab, enable the proxy, and point it at `127.0.0.1` port `9050` (or `9150` if you are using Tor Browser's).
+
+> [!TIP]
+> Do this once per address you use, not once per session. If Electrum stops connecting after a while, check whether your root CA has expired — Electrum deletes the pinned file when the certificate in it is out of date, and then falls back to failing against the public authority list.
+
+## Reaching your server from outside your home
+
+On your home network, the LAN IP or `.local` address is all you need. To reach your node while away, pick one:
+
+- **Tor.** Install the **Tor** service from the marketplace, then add an onion address to the Electrum interface. No port forwarding, no domain, no static IP — but Tor is slow, and the wallet needs its own Tor connection: a SOCKS proxy on desktop (`127.0.0.1:9050`), or Orbot on mobile. Some wallets bundle their own Tor and need no proxy setup at all. See [Tor](/start-os/tor.html).
+
+- **A custom domain.** Attach one to the interface and, if you request an ACME certificate, every wallet trusts it with no further setup. Faster and more reliable than Tor. See [Public Access](/start-os/public-access.html).
+
+- **A VPN back to your home network.** Then the LAN address keeps working as though you were home — though `.local` names often do not survive a VPN, so use the IP. See [Remote Access](/start-os/remote-access.html).
+
+## Connecting over Bitcoin RPC instead
+
+A wallet that talks to Bitcoin directly needs an address from Bitcoin's **RPC** interface plus a username and password, which the Bitcoin service's **Generate RPC User Credentials** action mints for you. (Services running on the server never need this — they configure themselves.)
+
+StartOS serves that interface over TLS on LAN and clearnet addresses with the same certificate as everything else, so the trust step above applies here too. Onion addresses are served over plain HTTP and need no certificate.
+
+Expect wallet imports and rescans to be slow: a Bitcoin node keeps no per-address index, so finding an existing wallet's history means walking the block range. On a pruned node, history older than the prune horizon cannot be rescanned at all. Day-to-day use of a wallet that is already imported is unaffected.
+
+## When it doesn't connect
+
+| Symptom                                                             | Likely cause                                                                                                  |
+| ------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Generic failure, no mention of TLS ("Retries exhausted", a red dot) | SSL is off in the wallet, or the port is wrong                                                                |
+| Certificate, "untrusted", or "verification failed" error            | The device or wallet has not been given your root CA — see [above](#making-your-wallet-trust-the-certificate) |
+| Electrum refuses the server and nothing you change helps            | A stale file at `certs/<host>` — delete it and start again                                                    |
+| Worked yesterday, fails today, LAN address                          | Your router gave the server a new IP; use the `.local` name or re-copy the address                            |
+| Connects but shows no balance or a partial history                  | The Electrum server has not finished indexing — check its **Sync Progress** health check                      |
+| `.onion` address times out                                          | The wallet has no Tor route: no SOCKS proxy set, or Orbot is not running                                      |
+
+If the service itself is unhealthy, start there rather than in the wallet — an Electrum server still building its index answers slowly or not at all, and that looks exactly like a connection problem.

--- a/projects/start-docs/bitcoin-guides/src/connecting-wallets.md
+++ b/projects/start-docs/bitcoin-guides/src/connecting-wallets.md
@@ -77,7 +77,7 @@ There are four ways that happens, and which one applies is a property of the wal
 
 Electrum is the one wallet that needs a file placed by hand, and it is worth understanding why, because the failure is silent.
 
-Electrum checks a server against a bundled list of public certificate authorities. When that check fails it looks at _how_ it failed: a server presenting a **self-signed certificate** is one Electrum will pin on the spot and connect to. Your server does not present a self-signed certificate — it presents one _signed by your server's own authority_, which is a different failure, and Electrum treats it as a server it cannot use. It never gets as far as offering to pin anything.
+Electrum checks a server against a bundled list of public certificate authorities, and when that check fails it looks at _how_ it failed. A server presenting a **self-signed certificate** is one Electrum pins on the spot and connects to. Your server presents something different — a certificate signed by an intermediate, which is signed in turn by your server's own root authority — and that is a different failure, which Electrum treats as a server it cannot use. It never gets as far as offering to pin anything. The behaviour is tracked upstream as [spesmilo/electrum#7459](https://github.com/spesmilo/electrum/issues/7459).
 
 The fix is to give Electrum the authority instead of the certificate. Electrum loads the file at `certs/<host>` as a trust anchor, so putting your root CA there makes the whole chain verify — and keeps working when your server renews its certificate, which pinning would not.
 

--- a/projects/start-docs/bitcoin-guides/src/electrum-servers.md
+++ b/projects/start-docs/bitcoin-guides/src/electrum-servers.md
@@ -1,79 +1,42 @@
 # Electrum Servers
 
-An Electrum server sits between your Bitcoin node and your wallet. It indexes the blockchain so wallets can quickly look up balances, transaction history, and unspent outputs for any address — without scanning the entire chain themselves. Most Bitcoin wallets connect to your self-hosted infrastructure through an Electrum server rather than directly via Bitcoin RPC.
+An Electrum server sits between your Bitcoin node and your wallet, indexing the blockchain so wallets can look up balances, history, and unspent outputs for an address instantly. Most Bitcoin wallets reach a self-hosted node this way rather than over Bitcoin RPC.
 
-A Bitcoin node stores every block ever produced, but it does not maintain an index of which addresses own which coins. When a wallet asks "what is the balance of this address?", the node would have to scan the entire blockchain to answer. An Electrum server solves this by building a persistent index that maps addresses to their transactions and unspent outputs. Once the index is built, lookups are instant. The server speaks the Electrum protocol, a lightweight client-server protocol that wallets already know how to use.
+On StartOS that server is **Fulcrum**. Once it is installed and synced, see [Connecting a Wallet](connecting-wallets.md).
+
+## Why you need one
+
+A Bitcoin node stores every block ever produced, but it keeps no index of which addresses own which coins. Asked "what is the balance of this address?", it would have to walk the entire chain. An Electrum server solves that by building a persistent index from addresses to their transactions and unspent outputs, and serving it over the Electrum protocol — which wallets already know how to speak.
 
 ```
-┌──────────┐      Electrum       ┌─────────────────┐       RPC        ┌──────────────┐
-│  Wallet  │ ──── protocol ────▶ │ Electrum Server  │ ──────────────▶  │ Bitcoin Node  │
-└──────────┘                     │ (Fulcrum)        │                  │              │
-                                 │ address index    │                  │ full chain   │
-                                 └─────────────────┘                  └──────────────┘
+┌──────────┐    Electrum     ┌──────────────────┐      RPC       ┌───────────────┐
+│  Wallet  │ ─── protocol ──▶│  Electrum server │ ──── + P2P ───▶│ Bitcoin node  │
+└──────────┘                 │  address index   │                │  full chain   │
+                             └──────────────────┘                └───────────────┘
 ```
 
 1. Your **Bitcoin node** downloads and validates every block on the network.
 2. Your **Electrum server** reads blocks from the node and builds an address-level index.
 3. Your **wallet** connects to the Electrum server and queries balances, history, and UTXOs instantly.
 
-The initial index build requires scanning the full blockchain, which can take hours or days depending on the implementation and your hardware. After that, the server stays in sync incrementally as new blocks arrive.
+Building that index the first time means reading the whole chain, which takes hours. After that the server keeps up incrementally as blocks arrive.
 
-## Options on StartOS
+## Fulcrum
 
-### Fulcrum (Recommended)
+Fulcrum builds a **complete** address index, so every wallet query is answered from local data. Queries stay fast even for addresses with long transaction histories, which is where lighter Electrum servers struggle. It is actively maintained and widely deployed across the self-hosting community.
 
-- **Author:** Calin Culianu (cculianu)
-- **Language:** C++
-- **StartOS:** Available on the StartOS Marketplace
+The cost is disk and patience: the index runs to hundreds of gigabytes on top of the chain itself, and the first build takes many hours. Install it, then leave it overnight. Fulcrum's own instructions in StartOS carry its exact requirements and settings.
 
-Fulcrum is a high-performance Electrum server written in C++. It is the recommended Electrum server for StartOS.
+It also needs your Bitcoin node to be **archival** rather than pruned — see [Archival vs Pruned Nodes](archival-vs-pruned.md). StartOS prompts you on the Bitcoin service if anything needs changing.
 
-**Why Fulcrum:**
+Wait for Fulcrum's **Sync Progress** health check to report Synced before pointing a wallet at it. A wallet connected to a half-built index shows a partial balance, which is alarming and entirely temporary.
 
-- **Fast queries** — Once indexed, address lookups and UTXO queries are consistently fast, even for addresses with large transaction histories.
-- **Full address index** — Fulcrum builds a complete index of all addresses, so every wallet query is served from local data.
-- **Mature and stable** — Actively maintained, widely deployed across the Bitcoin self-hosting community.
-- **Broad wallet support** — Every wallet that speaks the Electrum protocol works with Fulcrum. See [Bitcoin Wallets](bitcoin-wallets.md) for a full list.
+- [Fulcrum source and documentation](https://github.com/cculianu/Fulcrum)
 
-**Trade-offs:**
+## Do you need one at all?
 
-- **Disk usage** — The full address index requires significant disk space (roughly 60-100 GB on top of the blockchain itself).
-- **Initial sync time** — Building the index from scratch takes time, typically several hours on modern hardware. Plan to let it run overnight after installation.
+Not if your wallet talks to Bitcoin directly. Sparrow, FullyNoded, Wasabi and BTCPay Server all connect over Bitcoin's RPC interface, with no indexer in the picture and no extra disk.
 
-### electrs
+The difference shows up when you **import an existing wallet**. An Electrum server finds its history in seconds; a bare Bitcoin node has to walk the block range, which takes hours and cannot reach past a pruned node's horizon. Day-to-day use of a wallet that is already imported is much the same either way.
 
-- **Author:** Blockstream
-- **Language:** Rust
-
-electrs is a lightweight Electrum server written in Rust. It takes a different approach than Fulcrum — instead of building a full persistent index, electrs uses a compact index and fetches some data from the Bitcoin node on demand.
-
-**Advantages:**
-
-- **Lower disk usage** — The compact index uses significantly less disk space than Fulcrum's full index.
-- **Faster initial sync** — The lighter index builds faster than a full address index.
-
-**Disadvantages:**
-
-- **Slower queries** — Some queries require on-the-fly lookups from the Bitcoin node, making them noticeably slower than Fulcrum, especially for addresses with many transactions.
-- **Not on the StartOS Marketplace** — electrs is not currently available as a service on StartOS.
-
-## Comparison
-
-| Feature          | Fulcrum              | electrs                    |
-| ---------------- | -------------------- | -------------------------- |
-| **Query speed**  | Fast (full index)    | Slower (partial on-demand) |
-| **Disk usage**   | ~60-100 GB for index | ~5-10 GB for index         |
-| **Initial sync** | Several hours        | Faster                     |
-| **StartOS**      | Yes                  | No                         |
-| **Maintenance**  | Active               | Active                     |
-
-For StartOS users, **Fulcrum is the clear choice** — it is the only Electrum server available on the StartOS Marketplace and provides the best query performance for everyday wallet use.
-
-## Connecting Wallets
-
-Once Fulcrum is installed and synced on your StartOS server, wallets connect to it using an Electrum server address. Most wallets need just two pieces of information:
-
-- **Host** — Your server's address (local IP on your LAN, `.local` hostname, `.onion` address over Tor, or a clearnet address via VPN or reverse tunnel)
-- **Port** — The Electrum protocol port (typically 50001 for TCP or 50002 for SSL)
-
-For wallet-specific connection instructions, see [Bitcoin Wallets](bitcoin-wallets.md).
+See [Connecting a Wallet](connecting-wallets.md#which-connection-do-you-need) for the full comparison.

--- a/projects/start-docs/bitcoin-guides/src/lightning-wallets.md
+++ b/projects/start-docs/bitcoin-guides/src/lightning-wallets.md
@@ -1,29 +1,55 @@
 # Lightning Wallets
 
-An index of Lightning wallets and management tools that support connecting to your own LND or Core Lightning node. This includes both native apps (mobile/desktop) and web-based tools that can be self-hosted or installed as services on StartOS.
+Wallets and management tools that drive a Lightning node you run yourself — LND or Core Lightning on StartOS. Some are apps on your phone or laptop; others install onto the server and are reached in a browser.
 
-For on-chain Bitcoin wallets that connect to your own Bitcoin node or Electrum server, see [Bitcoin Wallets](bitcoin-wallets.md).
+Connecting to a Lightning node is not like connecting to an Electrum server: instead of a host and a port, your node hands you a **single URI that already contains its address and a credential**. Start with [Connecting to your node](#connecting-to-your-node) below, then find your wallet. For on-chain wallets, see [Bitcoin Wallets](bitcoin-wallets.md).
 
-## Node Implementations
+## Node implementations
 
-The wallets and tools below connect to one or more of these Lightning node implementations:
+- **LND** — the most widely supported. Wallets connect over its REST or gRPC API, authenticating with a macaroon. Also supports [Lightning Node Connect](#lightning-node-connect), which reaches your node without opening ports or using Tor.
+- **Core Lightning (CLN)** — Blockstream's implementation. Wallets connect over CLNrest (its built-in REST plugin) or gRPC, authenticating with a rune. Ships with its own web dashboard on StartOS.
+- **Eclair** — ACINQ's implementation. Not packaged for StartOS; a couple of the tools below support it if you run one elsewhere.
 
-- **LND** — The most widely supported implementation. Wallets connect via its REST or gRPC API using a macaroon for authentication. LND also supports [Lightning Node Connect (LNC)](#lightning-node-connect), a secure remote connection method that works without opening ports or using Tor.
-- **Core Lightning (CLN)** — Blockstream's implementation. Wallets connect via CLNRest (the built-in REST plugin) or gRPC.
-- **Eclair** — ACINQ's implementation. Fewer wallets support it directly.
+## Connecting to your node
+
+### LND
+
+LND publishes two connection interfaces, **REST** and **gRPC LND Connect**. Each carries an `lndconnect://` URI that you copy or scan as a QR code, and which already contains the address, the certificate details the client needs, and your credential — so there is nothing else to fill in.
+
+> [!WARNING]
+> That URI embeds your **admin macaroon**, which is full control of the node and its funds. Treat it exactly like a password: never paste it into a chat, a screenshot, or a support ticket. LND's own instructions cover what to do if one is exposed.
+
+Which interface to use depends on the wallet:
+
+- **REST** — what most mobile wallets want. StartOS serves it with your server's own certificate, so leave certificate validation **on** in the wallet and install the [StartOS Root CA](/start-os/trust-ca.html) on the device, exactly as you did for the dashboard in your browser. A custom domain with an ACME certificate needs no such step.
+- **gRPC LND Connect** — for clients that speak gRPC. LND serves its own certificate here and the URI carries it, so the client can verify with nothing installed. That makes the URI long — copy it rather than scanning the QR, which will be dense and slow to read.
+
+To reach your node from outside your home, add an onion address or a custom domain to the interface first, then take the URI: it is only as reachable as the address inside it, so a LAN address in a wallet you carry around stops working the moment you leave.
+
+### Core Lightning
+
+Core Lightning authenticates with a **rune** rather than a macaroon, and its **CLNrest** interface publishes a URL with one already embedded — that single URL is usually all a wallet needs. If an app wants a rune supplied separately instead, the **Create Rune** action mints one.
+
+The URL's scheme tells the wallet which protocol to use:
+
+| Scheme             | Used for                                                              |
+| ------------------ | --------------------------------------------------------------------- |
+| `clnrest+https://` | LAN and clearnet addresses, where StartOS terminates TLS              |
+| `clnrest+http://`  | `.onion` addresses, where Tor already encrypts and no TLS is involved |
+
+As with LND's URI, the embedded rune is a credential — anything holding it can spend.
 
 ### Lightning Node Connect
 
-Lightning Node Connect (LNC) is a connection protocol by Lightning Labs that lets you securely reach your LND node from anywhere without opening ports or configuring Tor. It works by establishing an end-to-end encrypted connection through a relay server using a short pairing phrase. LNC requires [Lightning Terminal (litd)](#lightning-terminal) running alongside your LND node.
+Lightning Node Connect (LNC) is a Lightning Labs protocol that reaches your LND node through a relay using a short pairing phrase, end-to-end encrypted so the relay sees nothing. No port forwarding, no domain, no Tor.
 
-LNC is supported by [Zeus](#zeus) and [Lightning Terminal's web UI](https://terminal.lightning.engineering/).
+It requires [Lightning Terminal](#lightning-terminal) running alongside LND: generate a session with Admin permissions on Lightning Terminal's Connect page, then pair the wallet with the phrase or QR it shows. [Zeus](#zeus) and Lightning Labs' own [web terminal](https://terminal.lightning.engineering/) both support it.
 
 - [How LNC works](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/lightning-node-connect)
-- [Source code](https://github.com/lightninglabs/lightning-node-connect)
 
 ## Summary
 
-### Native Apps
+### Apps you run on your own devices
 
 | Wallet                    | Platforms    | LND        | CLN | Tor |
 | ------------------------- | ------------ | ---------- | --- | --- |
@@ -32,29 +58,30 @@ LNC is supported by [Zeus](#zeus) and [Lightning Terminal's web UI](https://term
 | [FullyNoded](#fullynoded) | iOS, macOS   | Yes        | Yes | Yes |
 | [Zeus](#zeus)             | Android, iOS | Yes        | Yes | Yes |
 
-### Web-Based (Self-Hosted)
+### Tools that run on your server
 
-These tools run as web applications on your server. Several are available as services on the StartOS Marketplace.
+| Tool                                      | LND | CLN | Eclair |
+| ----------------------------------------- | --- | --- | ------ |
+| [Alby Hub](#alby-hub)                     | Yes | No  | No     |
+| [BTCPay Server](#btcpay-server)           | Yes | Yes | Yes    |
+| [CLN Application](#cln-application)       | No  | Yes | No     |
+| [Lightning Terminal](#lightning-terminal) | Yes | No  | No     |
+| [LNbits](#lnbits)                         | Yes | Yes | Yes    |
+| [RTL](#rtl)                               | Yes | Yes | Yes    |
 
-| Tool                                      | LND | CLN | Eclair | StartOS |
-| ----------------------------------------- | --- | --- | ------ | ------- |
-| [Alby Hub](#alby-hub)                     | Yes | No  | No     | Yes     |
-| [BTCPay Server](#btcpay-server)           | Yes | Yes | Yes    | Yes     |
-| [CLN Application](#cln-application)       | No  | Yes | No     | Yes     |
-| [Lightning Terminal](#lightning-terminal) | Yes | No  | No     | Yes     |
-| [LNbits](#lnbits)                         | Yes | Yes | Yes    | Yes     |
-| [RTL](#rtl)                               | Yes | Yes | Yes    | Yes     |
-| [ThunderHub](#thunderhub)                 | Yes | No  | No     | Yes     |
+These install from the StartOS Marketplace and wire themselves to your node over the server's internal network — no URI to paste, no certificate to trust, and no credential leaving the machine. Each one's own instructions in StartOS cover its setup.
 
-## Native Apps
+## Apps you run on your own devices
 
 ### BitBanana
 
 - **Platforms:** Android
 - **Connects to:** LND, Core Lightning
-- **Tor:** Yes — native Tor support
+- **Tor:** Native
 
-BitBanana is the actively maintained successor to the Zap Android wallet. It connects to LND via lndconnect URI (REST) and to Core Lightning via cln-grpc. Supports BOLT 12, coin control, and NFC.
+The actively maintained successor to the Zap Android wallet, connecting to LND by `lndconnect://` URI over REST, and to Core Lightning over gRPC. Supports BOLT 12, coin control, and NFC.
+
+**To connect:** open LND's **REST** interface on your server and scan the QR into BitBanana.
 
 - [BitBanana website](https://bitbanana.app/)
 - [Connect a Lightning node](https://docs.bitbanana.app/setup/connect-a-lightning-node)
@@ -62,14 +89,12 @@ BitBanana is the actively maintained successor to the Zap Android wallet. It con
 ### BlueWallet
 
 - **Platforms:** Android, iOS
-- **Connects to:** LND (via LNDHub)
-- **Tor:** Yes — available in network settings
+- **Connects to:** LND, through LNDHub
 
-BlueWallet connects to LND through LNDHub, a middleware layer that sits on top of your LND node and provides account-based access. This makes it good for multi-user setups where one node serves several wallets. LNDHub requires LND and Redis as dependencies.
+BlueWallet does not talk to LND directly. It talks to **LNDHub**, an account layer in front of a node — which makes it a reasonable choice when one node serves several people, and a poor one if you want the wallet to _be_ your node.
 
 > [!NOTE]
->
-> BlueWallet shut down their hosted custodial LNDHub service in 2023, but the self-hosted open-source LNDHub software still works. You can also use the LNDHub extension in LNbits as an alternative backend.
+> BlueWallet's hosted LNDHub service shut down in 2023; the self-hosted software still works. On StartOS the practical route is [LNbits](#lnbits), whose LNDHub extension serves BlueWallet from your own node.
 
 - [BlueWallet website](https://bluewallet.io/)
 - [LNDHub documentation](https://bluewallet.io/lndhub/)
@@ -78,9 +103,9 @@ BlueWallet connects to LND through LNDHub, a middleware layer that sits on top o
 
 - **Platforms:** iOS, macOS
 - **Connects to:** LND, Core Lightning
-- **Tor:** Yes — Tor is a core design principle; all connections route through Tor
+- **Tor:** Integrated; everything routes through it
 
-FullyNoded is primarily a Bitcoin wallet, but also supports connecting to LND (via REST over Tor) and Core Lightning. Apple ecosystem only.
+Primarily a Bitcoin wallet — see [Bitcoin Wallets](bitcoin-wallets.md#fullynoded) — with Lightning support alongside. Because it connects over Tor to a `.onion` address, there is no certificate step.
 
 - [FullyNoded website](https://fullynoded.app/)
 - [Lightning documentation](https://fonta1n3.github.io/FullyNoded/Docs/Lightning.html)
@@ -89,101 +114,73 @@ FullyNoded is primarily a Bitcoin wallet, but also supports connecting to LND (v
 
 - **Platforms:** Android, iOS
 - **Connects to:** LND, Core Lightning, Eclair, LNDHub
-- **Tor:** Yes — native on Android; experimental on iOS
+- **Tor:** Native on Android; experimental on iOS
 
-Zeus is the most versatile mobile Lightning wallet, supporting three node implementations plus LNDHub accounts. It connects to LND via REST or [Lightning Node Connect (LNC)](#lightning-node-connect), Core Lightning via CLNRest, and Eclair via REST. Zeus can also run an embedded LND node on-device without a remote connection.
+The most capable mobile Lightning wallet, and the one with the most ways in. It can also run an embedded node on the phone itself, with no remote connection at all.
+
+**To connect,** in Zeus go to **Settings → Connect a node → +**, choose your implementation, and take the matching credential from your server:
+
+| Your node                        | Zeus implementation | Take from                                            |
+| -------------------------------- | ------------------- | ---------------------------------------------------- |
+| LND                              | LND                 | The **REST** interface's `lndconnect://` QR          |
+| Core Lightning                   | CLNRest             | The **CLNrest** interface URL, rune already embedded |
+| LND, without exposing an address | LNC                 | Lightning Terminal's Connect page                    |
+
+Enable Tor in Zeus only if you are actually using a `.onion` address. For a LAN or clearnet address, leave certificate validation on and install the [StartOS Root CA](/start-os/trust-ca.html) on the phone.
 
 - [Zeus website](https://zeusln.com/)
-- [Remote connection guides](https://docs.zeusln.app/category/remote-connections/)
+- [Connecting Zeus to StartOS](https://docs.zeusln.app/for-users/remote-connections/startos)
 
-## Web-Based (Self-Hosted)
+## Tools that run on your server
 
 ### Alby Hub
 
-- **Platforms:** Web (self-hosted), also available as a desktop app on Linux, macOS, Windows
-- **Connects to:** LND (external node via REST), or runs an embedded LDK node
-- **Tor:** Yes — works with Tor hidden services when self-hosted
-- **StartOS:** Available on the StartOS Marketplace
+- **Connects to:** LND, or its own embedded LDK node
 
-Alby Hub bridges Lightning to the Nostr ecosystem via the Nostr Wallet Connect (NWC) protocol. It can connect to your existing LND node or run its own embedded LDK node. Useful for connecting Lightning payments to Nostr clients, podcasting apps, and web applications.
+Bridges Lightning to the Nostr ecosystem through Nostr Wallet Connect (NWC), letting Nostr clients, podcasting apps, and web apps spend from your node under permissions you set per app. Also available as a desktop app if you would rather not self-host it.
 
 - [Alby Hub website](https://albyhub.com/)
 - [Setup guide](https://guides.getalby.com/user-guide/alby-hub)
-- [Source code](https://github.com/getAlby/hub)
 
 ### BTCPay Server
 
-- **Platforms:** Web (self-hosted)
 - **Connects to:** LND, Core Lightning, Eclair
-- **Tor:** Yes — built-in Tor support in the Docker deployment
-- **StartOS:** Available on the StartOS Marketplace
 
-BTCPay Server is a self-hosted payment processor for merchants. Its Lightning integration supports all three major node implementations. Use it to accept Lightning payments through invoices, point-of-sale, e-commerce plugins (WooCommerce, Shopify), and more.
-
-BTCPay Server also has a built-in on-chain wallet — see [Bitcoin Wallets](bitcoin-wallets.md#btcpay-server).
+A self-hosted payment processor: invoices, point-of-sale, and e-commerce plugins for WooCommerce, Shopify and others. Its Lightning integration supports all three implementations, and it also has a full on-chain wallet — see [Bitcoin Wallets](bitcoin-wallets.md#btcpay-server).
 
 - [BTCPay Server website](https://btcpayserver.org/)
 - [Lightning documentation](https://docs.btcpayserver.org/LightningNetwork/)
 
 ### CLN Application
 
-- **Platforms:** Web (self-hosted)
 - **Connects to:** Core Lightning only
-- **Tor:** Depends on host platform configuration
-- **StartOS:** Included with Core Lightning on the StartOS Marketplace
 
-The CLN Application is the official Blockstream-maintained web dashboard for Core Lightning nodes. It connects via CLNRest and provides a clean interface for channel management, payments, and node monitoring. On StartOS, it is bundled with the Core Lightning service.
+Blockstream's official web dashboard for Core Lightning. It is part of the Core Lightning service rather than a separate install, and is reached through that service's **Web UI** interface.
 
 - [Source code](https://github.com/ElementsProject/cln-application)
 
 ### Lightning Terminal
 
-- **Platforms:** Web (self-hosted and hosted)
 - **Connects to:** LND only
-- **Tor:** Yes
-- **StartOS:** Available on the StartOS Marketplace
 
-Lightning Terminal (LiT) is Lightning Labs' web dashboard for LND nodes. It bundles Loop (Lightning-to-on-chain swaps), Pool (liquidity marketplace), and Taproot Assets into a single interface. The underlying daemon (`litd`) also enables [Lightning Node Connect (LNC)](#lightning-node-connect), allowing secure remote access to your node without opening ports or using Tor.
-
-Lightning Labs also hosts a web UI at [terminal.lightning.engineering](https://terminal.lightning.engineering/) that connects to your node via LNC.
+Lightning Labs' dashboard for LND, bundling Loop (swaps between channel and on-chain funds), Pool (a liquidity marketplace), and Taproot Assets. Its daemon also provides [Lightning Node Connect](#lightning-node-connect), which is reason enough to install it even if you prefer another dashboard: LNC is what lets Zeus reach your node without an onion address or a domain.
 
 - [Lightning Terminal documentation](https://docs.lightning.engineering/lightning-network-tools/lightning-terminal/introduction)
-- [Source code](https://github.com/lightninglabs/lightning-terminal)
 
 ### LNbits
 
-- **Platforms:** Web (self-hosted)
 - **Connects to:** LND, Core Lightning, Eclair
-- **Tor:** Yes — can be exposed as a Tor hidden service
-- **StartOS:** Available on the StartOS Marketplace
 
-LNbits is an accounts and extensions platform that sits on top of your Lightning node. It creates isolated wallet accounts (useful for multi-user setups) and has a rich extension system including paywall, point-of-sale, tipping, and an LNDHub extension that lets you serve BlueWallet and Zeus users from your node.
+An accounts-and-extensions layer over your node. It carves out isolated wallets — useful for a household, a business, or anything you would rather not hand the admin macaroon — and its extensions cover paywalls, point-of-sale, tipping, and an LNDHub backend that serves [BlueWallet](#bluewallet) and Zeus from your own node.
 
 - [LNbits website](https://lnbits.com/)
 - [Backend wallet configuration](https://docs.lnbits.org/guide/wallets.html)
-- [Source code](https://github.com/lnbits/lnbits)
 
 ### RTL
 
-- **Platforms:** Web (self-hosted)
 - **Connects to:** LND, Core Lightning, Eclair
-- **Tor:** Yes — can be exposed as a Tor hidden service
-- **StartOS:** Available on the StartOS Marketplace
 
-RTL (Ride The Lightning) is the most widely supported web UI for Lightning node management. It supports all three major implementations and provides full channel management, payment tracking, routing fee configuration, and Loop/Pool integration.
+Ride The Lightning: the broadest node-management web UI, and the only one here that covers all three implementations. Channel management, payment history, routing fee configuration, and Loop/Pool integration.
 
 - [RTL website](https://www.ridethelightning.info/)
 - [Source code](https://github.com/Ride-The-Lightning/RTL)
-
-### ThunderHub
-
-- **Platforms:** Web (self-hosted)
-- **Connects to:** LND only
-- **Tor:** Yes — can be exposed as a Tor hidden service
-- **StartOS:** Available on the StartOS Marketplace
-
-ThunderHub is a modern web UI for LND nodes with strong channel balancing tools, multi-account support, and a polished interface. If you run LND, ThunderHub is a strong alternative to RTL.
-
-- [ThunderHub website](https://thunderhub.io/)
-- [Documentation](https://docs.thunderhub.io/)
-- [Source code](https://github.com/apotdevin/thunderhub)


### PR DESCRIPTION
The Bitcoin Guides' wallet pages were an index of links to upstream wallet docs. A user arriving from Fulcrum's instructions still had to work out the StartOS-specific half alone: which address to copy, that the endpoint is TLS-only on every address, and how to make a wallet trust a certificate signed by their own server's authority.

## New page: Connecting a Wallet

Carries the half that is the same for every wallet, so the per-wallet pages only say where the settings live:

- Choosing between an Electrum server and Bitcoin RPC, and what the choice costs.
- Taking the port from the interface address rather than assuming 50001/50002 — StartOS assigns it per server and never changes it.
- Why every address is `ssl://`, and how each wallet expresses "SSL on" (checkbox, `:s` suffix, `ssl://` prefix, or nothing).
- The four ways a wallet can be made to trust the root CA: device trust store, in-app fetch, the wallet's own cert store, or an ACME domain.
- Reaching the server from outside the house, and a troubleshooting table keyed on symptom.

Fulcrum and electrs each carried a copy of the Electrum desktop procedure in their own `instructions.md`. It lives here now, with the mechanism spelled out: Electrum auto-pins a certificate only when verification fails with `verify_code == 18` (depth-zero self-signed). StartOS serves a leaf signed by the device's root CA, which fails differently, so `is_server_ca_signed` re-raises and the server is rejected before any pinning is offered. Placing the root CA at `certs/<host>` works because Electrum loads that file as a trust anchor (`create_default_context(cafile=...)`), which is also why it survives certificate renewal.

## Rewritten pages

**Bitcoin Wallets** — each entry now gives the actual settings path, verified against that wallet's current upstream documentation: BitBoxApp's `Connect your own full node` and its `Download remote certificate` step, Blockstream App's desktop and mobile paths, Nunchuk's `Mainnet server` field, Sparrow's Private Electrum screen, Trezor Suite's `Settings → Networks`, Electrum's `Tools → Network`. Adds Jam. Drops the claim that Trezor Suite's mobile app cannot use a custom backend — upstream now documents it. Flags BlueWallet's long-standing Tor instability rather than leaving users to rediscover it.

**Lightning Wallets** — gains the connection material it was missing entirely: what an `lndconnect://` URI contains and which of LND's two interfaces to take it from, CLNrest's embedded rune and what its `clnrest+http`/`clnrest+https` scheme is telling the wallet, and where LNC fits.

**Electrum Servers** — electrs was attributed to Blockstream and described as unavailable on StartOS. It is romanz/electrs, and it is packaged, but on the community registry — so the page documents Fulcrum as the supported Electrum server and says only what electrs is. Server-side operating detail that belongs in Fulcrum's own instructions has been dropped rather than duplicated.

## Notes

- Targets `live-docs` because these pages are already published; `docs-backport.yml` lands the same commit on master.
- `mdbook build` is clean, cross-book links and every intra-book anchor were checked against the built HTML, and the external links were checked for a 200.
- Companion revision bumps to `fulcrum-startos` and `electrs-startos` strip the duplicated wallet instructions and link here instead.