### PR TITLE
fix(start-os): carry a 0.3.x CryptPad across as cryptpad-legacy

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -38,6 +38,14 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
+- **A CryptPad installed before the update is carried across as CryptPad
+  (Legacy), so the new CryptPad can be installed alongside it.** The 0.4.0
+  CryptPad wraps a release several years newer and stores its data in a
+  different layout, so nothing carries across automatically. Renaming the old
+  one lets both sit on your server at once: export your drive from CryptPad
+  (Legacy), import it into the new CryptPad, and uninstall the old one once you
+  are satisfied. This matches how Ghost, Synapse and Monero are handled.
+
 - **The NVIDIA images now use NVIDIA's open kernel modules, which support GeForce
   RTX 20-series, Quadro RTX and newer.** This is what makes current cards work at
   all — an RTX 50-series, an RTX PRO 6000 or an NVIDIA GB10 can only be driven by

--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -29,6 +29,8 @@ The following services cannot be migrated automatically. Review these before sta
 
 - **Synapse** — The old Synapse was Tor-only. The new Synapse is clearnet-only. These are different services now with no migration path.
 
+- **CryptPad** — The new CryptPad wraps a release several years newer and stores its data differently, so nothing carries across automatically. Your existing CryptPad survives the update as **CryptPad (Legacy)** and keeps working, which means you can install the new CryptPad alongside it: open CryptPad (Legacy), sign in, and use CryptPad's **Export** to download your drive, then import it into the new CryptPad. Uninstall CryptPad (Legacy) once you are satisfied — uninstalling deletes its data.
+
 - **Jam** — Jam's backend, JoinMarket, is being replaced by a separate reimplementation (JoinMarket NG) for technical and security reasons, making Jam defunct on StartOS v0.3.5.1 and unavailable on v0.4.0 until that backend matures and a new version of Jam is built for it. You should back up your seed, move out any spendable funds (fidelity-bond funds stay locked until expiry), and uninstall Jam prior to updating to v0.4.0.
 
 ### LAN addresses are changing

--- a/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
+++ b/shared-libs/crates/start-core/src/s9pk/v2/compat.rs
@@ -230,6 +230,9 @@ impl TryFrom<ManifestV1> for Manifest {
         if &*value.id == "monerod" {
             value.id = "monerod-legacy".parse()?;
         }
+        if &*value.id == "cryptpad" {
+            value.id = "cryptpad-legacy".parse()?;
+        }
         if &*value.id == "fedimintd" {
             value.id = "fedimint-guardian".parse()?;
         }


### PR DESCRIPTION
The 0.4.0 CryptPad package is about to be listed on the Community Registry. It shares the retired 0.3.x package's id (`cryptpad`) and wraps a release several years newer, storing its data in a completely different layout — one volume under `/data` rather than six under `/cryptpad/`.

Without a rename the two collide. The old package's `5.2.1` sorts below the new one, so `canMigrateFrom` accepts it, StartOS offers the new package as that install's update, and the operator ends up with a 2026 CryptPad pointed at a 5.2.1 data layout: an empty instance, the old pads stranded in orphaned volumes, and `down: IMPOSSIBLE` leaving no way back.

Renaming at conversion time is what `TryFrom<ManifestV1>` already does for Ghost, Synapse and Monero, so this adds four lines beside them. It is also the better answer than blocking the update from the package side, which was the alternative: both packages can sit on the server at once, so the operator exports from **CryptPad (Legacy)** and imports into the new CryptPad whenever they get to it, rather than having to export *before* updating the OS and hope they remembered.

The `(Legacy)` title suffix, `can_migrate_from: any()` and `can_migrate_to: none()` all already come from that same `TryFrom`, so nothing else was needed.

Also adds the corresponding entry to the 0.4.0 update guide alongside the other special-handling services, and a changelog line under the unreleased `0.4.0.2`.

## Sequencing

The CryptPad package is being held until 0.4.0.2 is released, so a box that migrates on a build without this change is not a case that arises in practice.
