### PR TITLE
docs(packaging): say how a public domain is enabled across a host's bindings

### DIFF
--- a/projects/start-sdk/docs/src/interfaces.md
+++ b/projects/start-sdk/docs/src/interfaces.md
@@ -6,6 +6,8 @@
 
 Your package declares _what_ it exposes. The **user** decides _where_ it is reachable. An interface is bound to the server's [gateways](/start-os/gateways.html), and the user enables or disables each resulting address individually from the service's **Interfaces** tab. LAN addresses (the `.local` hostname, the LAN IP) are enabled by default; public IPv4 addresses are **off** by default.
 
+**A public domain belongs to the host, but is enabled per binding.** The user adds it naming one internal port, and its addresses — the plain one and, where the binding has `addSsl`, the TLS one — are enabled on **that** binding straight away. Every other binding on the same `MultiHost` also gains the domain, but **off by default**, to be switched on individually like any other address. So a host that binds two ports needs the domain enabled twice, and a package that starts binding a second port later does not inherit the user's earlier choice for it.
+
 Two consequences worth internalizing before you write any interface code:
 
 - **`type` is a label, not a control.** `'ui'`, `'api'`, and `'p2p'` tell the user what an interface is _for_. They do not select a transport, grant public access, or imply anything about how the interface is reached.


### PR DESCRIPTION
The **Network Reachability** section of the interfaces page says which addresses are on by default, but says nothing about public domains — so the behavior when one host binds more than one port is left to be discovered.

What actually happens: the user adds the domain naming one internal port, and its addresses are enabled on **that** binding immediately. Every other binding on the same `MultiHost` also gains the domain, but **off by default**, to be switched on individually like any other address.

Two consequences that are easy to trip over and are now stated:

- A host binding two ports needs the domain enabled twice.
- A package that starts binding a second port in a later release does not inherit the user's earlier choice for it.

Found while adding a second listener to `coturn-startos`. The second binding's domain addresses were off, which reads as the domain not having applied at all — especially since a package's own reachability health check reports whether an address is *enabled*, so it can be green while nothing can reach the port.

Docs-only; no code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)