### PR TITLE
fix(ci): alpha apt publish collects artifact directories as debs

### DIFF
--- a/.github/workflows/apt-publish-alpha.yml
+++ b/.github/workflows/apt-publish-alpha.yml
@@ -91,7 +91,7 @@ jobs:
             exit 1
           fi
           echo "Publishing:"
-          find debs -name '*.deb' | sort | sed 's/^/  /'
+          find debs -type f -name '*.deb' | sort | sed 's/^/  /'
 
       - uses: ./.github/actions/publish-apt
         with:

--- a/debian/publish.sh
+++ b/debian/publish.sh
@@ -107,9 +107,11 @@ sync_down "dists/${SUITE}/" "$REPO_DIR/dists/${SUITE}/"
 DEB_FILES=()
 for arg in "$@"; do
     if [ -d "$arg" ]; then
+        # `gh run download` leaves a directory per artifact, and the product
+        # workflows name theirs `<product>_<arch>.deb`.
         while IFS= read -r -d '' f; do
             DEB_FILES+=("$f")
-        done < <(find "$arg" -name '*.deb' -print0)
+        done < <(find "$arg" -type f -name '*.deb' -print0)
     elif [ -f "$arg" ]; then
         DEB_FILES+=("$arg")
     else


### PR DESCRIPTION
The **Publish alpha apt suite** job has never once published. Since Aug 15 every run dies the same way ([latest](https://github.com/Start9Labs/start-technologies/actions/runs/32077646038/job/95534104646)):

```
dpkg-deb: error: error reading archive magic version number from file debs/start-cli_aarch64.deb: Is a directory
```

`gh run download -D debs` extracts each artifact into a **directory named after the artifact**, and start-cli/start-tunnel/start-registry name theirs `<product>_${{ matrix.arch }}.deb`. So the runner holds `debs/start-cli_aarch64.deb/start-cli-1.1.1-80d46fe_aarch64.deb` — a directory whose name ends in `.deb`, containing the real package. `debian/publish.sh`'s collection `find` had no `-type f`, so it collected the directories too and handed the first one to `dpkg-deb --field`.

The collection step's own listing shows it: 18 lines for 9 packages, alternating directory and file.

## Changes

- `debian/publish.sh` — `-type f` on the collection `find`.
- `.github/workflows/apt-publish-alpha.yml` — same predicate on the diagnostic listing, which is why the log misreported what was about to be published.

## Verification

Reproduced and A/B'd locally: nine real zstd debs built with `debian/build.sh`'s control template (`Architecture:` amd64/arm64/riscv64, filenames `_x86_64`/`_aarch64`/`_riscv64`), staged exactly as `gh run download` leaves them, `s3cmd` stubbed with an argv-logging fake bucket.

- **Before:** identical error, exit 2, and a `find` listing matching the CI log line for line.
- **After:** exit 0 — 9 pool objects under `pool-alpha/main/s/<pkg>/`, three non-empty per-arch indices (3 entries each), signed `Release`/`Release.gpg`/`InRelease`.
- A real `apt-get update` against the produced tree verifies the InRelease signature, resolves all three packages, and `--print-uris` resolves each `Filename:` to a real object.

**`stable` is unaffected.** `manage-release.sh` passes explicit file paths, which take the `elif [ -f "$arg" ]` branch. Running the old and new scripts with `SUITE=stable` and file arguments produced identical published object lists, identical `Filename:` sets, and identical `s3cmd` argv.

Everything downstream of the collection loop was unexercised code on the alpha path — this is the first time any of it has run — so I exercised all of it locally rather than only the one line.

## Not changed here — worth a look

1. **Testers won't be *offered* new master builds between crate-version bumps.** `debian/build.sh` writes `Version: ${VERSION}` (the bare crate version; the commit lives only in the non-standard `Git-Hash:` field), so `dpkg-name` collapses every master build of `1.1.1` onto the same pool object under the same `Version:`. Verified with real apt: after republishing different bytes, `apt-cache policy` shows `Installed: 1.1.1 / Candidate: 1.1.1` and `apt upgrade` is a no-op. Fresh installs and `--reinstall` do get the new bytes. The obvious `~alpha+<hash>` fix is unsafe as-is — `promote_alpha_debs` copies the alpha deb's bytes verbatim into stable, and `1.1.1~alpha+abc` sorts *below* `1.1.1`.

2. **An empty index would wipe the pool, exit 0.** `dpkg-name`'s failure is silenced (`2>/dev/null || true`) and `dpkg-scanpackages --arch` filters by *filename* (`_(all|amd64)\.deb`), which the build filenames (`_x86_64.deb`) never match — the rename is load-bearing. If it ever doesn't happen, all three indices are written empty, signed, and `s3 sync --delete-removed` deletes every pool object while exiting 0. One line inside the scan subshell closes it: `[ -s "$BINARY_DIR/Packages" ] || exit 1`. Left out because it turns a legitimately arch-incomplete publish into a hard failure — your call, happy to add it.

3. **Confirm `APT_GPG_PRIVATE_KEY` has no passphrase.** `publish.sh` passes no `--pinentry-mode loopback`. Measured on a tty-less shell: a passphraseless key signs fine; a passphrase-protected one fails `gpg: signing failed: Inappropriate ioctl for device`, exit 2. It fails closed — signing precedes both uploads — but it would be the next red run.

Also still unproven by anything: the S3 **write** path. Only `s3cmd ls` has ever succeeded against the bucket (the Aug 14 runs 403'd), so `PutObject`/`DeleteObject`/ACL on `pool-alpha/` and `dists/alpha/` are exercised for the first time by this merge.
