### PR TITLE
fix(wrt): don't blank published-port endpoints when a WAN setting fai…

### DIFF
--- a/projects/start-wrt/API_CONTRACT.md
+++ b/projects/start-wrt/API_CONTRACT.md
@@ -415,6 +415,8 @@ enum WanIpv6Mode {
 
 #[derive(Serialize)]
 struct WanIpv6Response {
+    /// A wan6 proto startwrt doesn't manage (e.g. a hand-configured `6in4`)
+    /// is reported as Disabled, not an error; the config is left untouched.
     mode: WanIpv6Mode,
     /// Static mode
     address: Option<String>,

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to StartWRT are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2]
+## [1.1.0]
 
 ### Removed
 
@@ -103,6 +103,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   WAN interface, so an update fires the moment the connection comes back up
   (e.g. after a modem reboot or PPPoE reconnect) instead of waiting for the
   next scheduled check.
+
+- **Published Ports endpoints no longer disappear when a WAN setting can't be
+  read.** A network interface hand-configured with a protocol StartWRT doesn't
+  manage (e.g. a `6in4` tunnel on `wan6`) made the WAN/LAN IPv6 settings
+  endpoints error, and the Published Ports page treated that one failure as
+  fatal — every port's IPv4 endpoint showed `—` even though the forwards were
+  active. Unmanaged protocols now read back gracefully (reported as IPv6
+  disabled) and are preserved untouched on disk, and the page now loads each
+  WAN setting independently, so one failure can no longer blank out the
+  endpoint list.
 
 ## [1.0.1]
 

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -1278,6 +1278,30 @@ config service 'wan'
     }
 
     #[tokio::test]
+    async fn ipv6_get_unmanaged_proto() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("network"),
+            "\
+config interface 'wan'
+\toption device 'eth1'
+\toption proto 'dhcp'
+
+config interface 'wan6'
+\toption device '@wan'
+\toption proto '6in4'
+",
+        )
+        .unwrap();
+        let ctx = TestContext(dir.path().to_path_buf());
+
+        // A hand-configured proto startwrt doesn't manage reads back as
+        // Disabled — it used to fail typed parsing and error the endpoint.
+        let res = ipv6_get(ctx).await.unwrap();
+        assert_eq!(res.mode, WanIpv6Mode::Disabled);
+    }
+
+    #[tokio::test]
     async fn ipv6_set_disabled() {
         let dir = tempfile::tempdir().unwrap();
         setup_network(dir.path());

--- a/projects/start-wrt/backend/uciedit/src/openwrt.rs
+++ b/projects/start-wrt/backend/uciedit/src/openwrt.rs
@@ -128,6 +128,11 @@ pub enum InterfaceProto {
     #[strum(serialize = "6rd")]
     SIXRD,
     WIREGUARD,
+    /// Any proto startwrt doesn't manage (e.g. a hand-configured `6in4`),
+    /// preserved verbatim so typed reads of such sections don't error and
+    /// untouched writes round-trip the original value.
+    #[strum(default)]
+    UNKNOWN(String),
 }
 
 #[derive(Debug, Default, TypedSection)]

--- a/projects/start-wrt/backend/uciedit/src/tests.rs
+++ b/projects/start-wrt/backend/uciedit/src/tests.rs
@@ -661,3 +661,23 @@ fn test_appended_section_readable_without_roundtrip() {
     let read_back: Bar = config.sections[0].get().unwrap();
     assert_eq!(read_back, section);
 }
+
+#[test]
+fn test_unknown_interface_proto_roundtrip() {
+    use crate::openwrt::{InterfaceProto, NetworkInterface};
+
+    // A proto startwrt doesn't manage (e.g. a hand-configured 6in4 tunnel)
+    // must parse instead of erroring, and write back verbatim.
+    let original = r"config interface 'wan6'
+    option device '@wan'
+    option proto '6in4'
+";
+
+    let arena = Arena::new();
+    let mut config = Config::parse_str(&arena, original).unwrap();
+    let iface: NetworkInterface = config.sections[0].get().unwrap();
+    assert_eq!(iface.proto, InterfaceProto::UNKNOWN("6in4".to_string()));
+
+    config.sections[0].set(&iface).unwrap();
+    assert!(config.dump_str().contains("option proto '6in4'"));
+}

--- a/projects/start-wrt/web/src/app/routes/published-ports/index.ts
+++ b/projects/start-wrt/web/src/app/routes/published-ports/index.ts
@@ -74,25 +74,28 @@ export default class PublishedPorts {
   }
 
   private async loadDependencies() {
+    // Each call degrades independently: one failing WAN/LAN endpoint must not
+    // reject the whole batch and leave ipv4EndpointHost/ipv6Available unset
+    // (which suppressed every IPv4 endpoint in the table).
     const [wanIpv6, lanIpv6, ddns, wanIpv4] = await Promise.all([
-      this.api.wanIpv6Get(),
-      this.api.lanIpv6Get(),
-      this.api.wanDdnsGet(),
-      this.api.wanIpv4Get(),
+      this.api.wanIpv6Get().catch(() => null),
+      this.api.lanIpv6Get().catch(() => null),
+      this.api.wanDdnsGet().catch(() => null),
+      this.api.wanIpv4Get().catch(() => null),
     ])
 
     this.loadVpnProfiles()
     // IPv6 port forwarding requires WAN IPv6 + LAN IPv6, and crucially a real
     // global address delegated to the WAN — without a GUA prefix no LAN device
     // can be reachable, so ULA/link-local-only WANs must not offer IPv6.
-    const wanGua = wanIpv6.assigned_ipv6
+    const wanGua = wanIpv6?.assigned_ipv6
     const wanHasGua = wanGua ? isGua(wanGua) : false
-    const lanIpv6Enabled = lanIpv6.slaac || lanIpv6.dhcpv6
+    const lanIpv6Enabled = !!lanIpv6 && (lanIpv6.slaac || lanIpv6.dhcpv6)
     this.ipv6Available.set(wanHasGua && lanIpv6Enabled)
 
     // Use DDNS hostname if available, otherwise WAN IP
-    const ddnsHostname = ddns.enabled ? ddns.hostname || null : null
-    this.ipv4EndpointHost.set(ddnsHostname || wanIpv4.assigned_ip)
+    const ddnsHostname = ddns?.enabled ? ddns.hostname || null : null
+    this.ipv4EndpointHost.set(ddnsHostname || wanIpv4?.assigned_ip || null)
   }
 
   private async loadVpnProfiles() {


### PR DESCRIPTION
…ls to load

A hand-configured wan6 proto startwrt doesn't manage (e.g. a 6in4 tunnel) failed InterfaceProto's typed parse, erroring wan.ipv6-get and lan.ipv6-get. The Published Ports page loaded its four WAN/LAN settings in one bare Promise.all, so that single failure left ipv4EndpointHost unset and every row's IPv4 endpoint rendered as an em dash.

- uciedit: give InterfaceProto a #[strum(default)] UNKNOWN(String) variant so unmanaged protos parse instead of erroring and round-trip verbatim on write; wan.ipv6-get now reports them as mode=disabled (noted in API_CONTRACT.md).
- web: load each published-ports page dependency independently (per-call catch), so one failing endpoint degrades only its own feature instead of suppressing all IPv4 endpoints and leaving ipv6Available at its default.