### PR TITLE
fix(start-wrt): tell devices when IPv6 goes away — goodbye RAs on every teardown, verified device display, boot-time repair of diverged state

### DIFF
--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to StartWRT are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.2]
+## [1.1.0]
 
 ### Removed
 
@@ -53,7 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after switching the outbound back. The LAN IPv6 toggle is now the sole
   owner of that setting; with an IPv4-only VPN outbound, LAN devices still
   get local (ULA) IPv6 addresses while internet-bound IPv6 remains blocked
-  by the VPN kill switch, so nothing leaks around the tunnel.
+  by the VPN kill switch, so nothing leaks around the tunnel. That same
+  fault could also leave a router where the LAN IPv6 page read "Disabled"
+  while individual Security Profiles carried on handing out IPv6 addresses —
+  the page and the network disagreeing, with no way to bring them back into
+  line. Routers left in that state are now repaired automatically on the
+  first start after updating, which turns IPv6 off for those profiles too;
+  turn it back on from the LAN IPv6 page if you want it, and this time it
+  applies everywhere at once.
 
 - **Turning IPv6 off now tells your devices to drop their IPv6 addresses.**
   Devices choose their own IPv6 addresses from a prefix the router advertises,

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -55,6 +55,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   get local (ULA) IPv6 addresses while internet-bound IPv6 remains blocked
   by the VPN kill switch, so nothing leaks around the tunnel.
 
+- **Turning IPv6 off now tells your devices to drop their IPv6 addresses.**
+  Devices choose their own IPv6 addresses from a prefix the router advertises,
+  and the only way to take one back is to advertise it one last time as
+  expired. The router was restarting its advertisement service instead of
+  reloading it, which skips that goodbye entirely — so after disabling IPv6
+  (on the LAN, on a Security Profile, or on the WAN) devices carried on using
+  addresses that no longer worked, for up to 90 minutes, until the addresses
+  timed out on their own. The notice is now sent while the prefix is still
+  live. A device that is asleep or misses the notice still falls back to the
+  timeout.
+
+- **The Devices list no longer shows IPv6 addresses a device has given up.**
+  The router remembers a neighbouring address long after the device stops
+  using it, so a device could keep displaying an IPv6 address for hours after
+  it dropped it — most visibly after turning IPv6 off, where the address on
+  screen suggested nothing had changed. The router now confirms the device
+  still answers on an address before showing it, and leaves the field empty
+  when it does not.
+
 - **Published ports no longer reshuffle their order on every refresh.** The
   list is auto-refreshed every few seconds, and each refresh returned the
   rows in an arbitrary order, so the table visibly jumped around. Published

--- a/projects/start-wrt/backend/ctrl/src/bins/daemon.rs
+++ b/projects/start-wrt/backend/ctrl/src/bins/daemon.rs
@@ -272,6 +272,11 @@ async fn inner_main() -> Result<(), Error> {
         if let Err(e) = crate::profiles::bootstrap_admin_profile("/etc/config").await {
             tracing::error!("Admin profile bootstrap failed: {e}");
         }
+        // Must follow bootstrap_admin_profile: the heal enumerates profiles from
+        // the `startwrt` config, so the admin profile has to be registered first.
+        if let Err(e) = crate::profiles::heal_ipv6_state("/etc/config").await {
+            tracing::error!("IPv6 state repair failed: {e}");
+        }
         if let Err(e) = crate::system::apply_remote_access(ServerContext::default()).await {
             tracing::error!("Remote access rule apply failed: {e}");
         }

--- a/projects/start-wrt/backend/ctrl/src/devices.rs
+++ b/projects/start-wrt/backend/ctrl/src/devices.rs
@@ -800,6 +800,129 @@ async fn ping_unreachable_macs(
     (unreachable, live_ipv4s)
 }
 
+/// GUA (`2000::/3`) or ULA (`fc00::/7`) — the two address classes [`pick_ipv6`]
+/// can return. Link-local and every other scope is filtered out downstream, so
+/// probing one would only cost a second for an address that is never displayed.
+fn is_displayable_ipv6(ip: &str) -> bool {
+    let Ok(addr) = ip.parse::<std::net::Ipv6Addr>() else {
+        return false;
+    };
+    crate::system::has_global_ipv6(std::slice::from_ref(&addr))
+        || matches!(addr.octets()[0], 0xfc | 0xfd)
+}
+
+/// IPv6 neighbor entries worth verifying: `(address, interface)` pairs whose
+/// liveness the kernel has not just confirmed.
+///
+/// The kernel keeps a `STALE` entry indefinitely while it sits below the GC
+/// threshold, so "present in the neighbor table" is not evidence the device
+/// still holds the address — it may have been dropped hours ago when a prefix
+/// went away. Anything already `REACHABLE` needs no probe (the kernel verified
+/// it within the last ~30 s), and neither does any MAC that has a `REACHABLE`
+/// entry for the same address family, since it is demonstrably answering NDP.
+///
+/// Unlike [`non_wifi_probe_candidates`] this does *not* skip WiFi clients:
+/// hostapd is authoritative for a station's presence, but says nothing about
+/// which IPv6 addresses it still owns.
+fn ipv6_probe_candidates(arp_entries: &[ArpEntry]) -> Vec<(String, String)> {
+    let reachable_macs: std::collections::HashSet<&str> = arp_entries
+        .iter()
+        .filter(|e| e.state == "REACHABLE" && e.ip.contains(':'))
+        .map(|e| e.mac.as_str())
+        .collect();
+
+    let mut seen = std::collections::HashSet::new();
+    let mut targets = Vec::new();
+    for entry in arp_entries {
+        if !entry.ip.contains(':') || !is_displayable_ipv6(&entry.ip) {
+            continue;
+        }
+        if entry.state == "REACHABLE" || reachable_macs.contains(entry.mac.as_str()) {
+            continue;
+        }
+        if !matches!(entry.state.as_str(), "STALE" | "DELAY" | "PROBE") {
+            continue;
+        }
+        if seen.insert(entry.ip.clone()) {
+            targets.push((entry.ip.clone(), entry.interface.clone()));
+        }
+    }
+    targets
+}
+
+/// Unicast-probe `targets`, then re-read the neighbor table and return every
+/// IPv6 address the kernel now reports as `REACHABLE`.
+///
+/// The verdict deliberately comes from the NUD state rather than the ping's
+/// exit code (the way [`ping_unreachable_macs`] judges IPv4). Sending to the
+/// address forces the kernel through neighbor discovery, and a device that
+/// still owns it answers the solicitation even when its firewall drops the
+/// echo request — which is the default on Windows for anything but a private
+/// network profile. Judging on echo replies would hide addresses devices
+/// genuinely hold. This is the same standard [`crate::ipv6_tracker`] applies.
+///
+/// Returns `None` when the neighbor table could not be re-read, which the
+/// caller treats as "no verification available" and fails open.
+async fn verify_ipv6_neighbors(
+    targets: Vec<(String, String)>,
+) -> Option<std::collections::HashSet<String>> {
+    use std::process::Stdio;
+
+    let mut children = Vec::new();
+    for (ip, iface) in &targets {
+        if let Ok(child) = tokio::process::Command::new("ping6")
+            .args(["-c", "1", "-W", "1", "-I", iface.as_str(), ip.as_str()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            children.push(child);
+        }
+    }
+    for mut child in children {
+        let _ = child.wait().await;
+    }
+
+    let output = tokio::process::Command::new("ip")
+        .args(["-6", "neigh", "show"])
+        .output()
+        .await
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(
+        parse_arp_output(&String::from_utf8_lossy(&output.stdout))
+            .into_iter()
+            .filter(|e| e.state == "REACHABLE")
+            .map(|e| e.ip)
+            .collect(),
+    )
+}
+
+/// The IPv6 addresses of a MAC that survive verification, in neighbor-table
+/// order so [`pick_ipv6`]'s GUA-over-ULA preference is unaffected.
+///
+/// An address is kept when the kernel confirmed it either in the initial
+/// snapshot or in the post-probe re-read. `verified == None` means verification
+/// was unavailable, in which case every candidate is kept — showing a possibly
+/// stale address beats blanking the field on a transient failure.
+fn live_ipv6_candidates<'a>(
+    arp_list: &[&'a ArpEntry],
+    verified: Option<&std::collections::HashSet<String>>,
+) -> Vec<&'a str> {
+    arp_list
+        .iter()
+        .filter(|e| e.ip.contains(':'))
+        .filter(|e| match verified {
+            None => true,
+            Some(live) => e.state == "REACHABLE" || live.contains(&e.ip),
+        })
+        .map(|e| e.ip.as_str())
+        .collect()
+}
+
 /// Among a MAC's IPv4 neighbor entries, pick the one most likely to be the
 /// device's current address. A device that just roamed to another VLAN leaves a
 /// stale entry on its old bridge; both entries share the MAC, so the list must
@@ -1027,6 +1150,10 @@ pub async fn list(_ctx: ServerContext) -> Result<Vec<Device>, Error> {
     // probe) are treated as unreachable. Runs concurrently with nlbw,
     // conntrack, and lease reads so it adds zero net latency.
     let (probe_targets, ipv6_only_macs) = non_wifi_probe_candidates(&initial_arp, &wifi_clients);
+    // IPv6 addresses get their own verification pass: a STALE NDP entry can
+    // outlive the address itself by hours, so the neighbor table alone is not
+    // evidence the device still holds what we are about to display.
+    let ipv6_probe_targets = ipv6_probe_candidates(&initial_arp);
 
     // Collect WireGuard interface names for querying active peers.
     // We need to extract this before the uci_result is consumed, but uci_result
@@ -1044,12 +1171,14 @@ pub async fn list(_ctx: ServerContext) -> Result<Vec<Device>, Error> {
 
     let (
         (unreachable_macs, live_ipv4s),
+        live_ipv6s,
         leases_output,
         nlbw_output,
         conntrack_output,
         wg_active_peers,
     ) = tokio::join!(
         ping_unreachable_macs(probe_targets),
+        verify_ipv6_neighbors(ipv6_probe_targets),
         read_all_dhcp_leases(),
         run_cmd("nlbw", &["-c", "json", "-g", "mac"]),
         run_cmd("conntrack", &["-L", "-o", "extended"]),
@@ -1261,12 +1390,10 @@ pub async fn list(_ctx: ServerContext) -> Result<Vec<Device>, Error> {
             .and_then(|h| h.ip.clone())
             .or_else(|| chosen_arp.map(|e| e.ip.clone()))
             .or_else(|| lease.map(|l| l.ip.clone()));
-        let ipv6 = pick_ipv6(
-            arp_list
-                .iter()
-                .filter(|e| e.ip.contains(':'))
-                .map(|e| e.ip.as_str()),
-        );
+        // Only addresses the device demonstrably still answers for — see
+        // live_ipv6_candidates. Unlike the IPv4 field there is no reservation or
+        // lease to fall back on, so an unverified address would be pure fiction.
+        let ipv6 = pick_ipv6(live_ipv6_candidates(&arp_list, live_ipv6s.as_ref()).into_iter());
 
         // Profile from VLAN tag, derived from the same chosen entry as the IPv4
         // address. Fall back to the first entry (e.g. an IPv6-only device with no
@@ -1871,6 +1998,99 @@ mod tests {
 
         // Empty → None.
         assert_eq!(pick_ipv6(std::iter::empty()), None);
+    }
+
+    fn arp_mac(ip: &str, mac: &str, state: &str) -> ArpEntry {
+        ArpEntry {
+            ip: ip.to_string(),
+            mac: mac.to_string(),
+            interface: "br-lan.101".to_string(),
+            state: state.to_string(),
+        }
+    }
+
+    #[test]
+    fn ipv6_probe_candidates_targets_only_unconfirmed_displayable_addresses() {
+        let entries = vec![
+            // Probed: a stale GUA and a stale ULA are exactly the addresses that
+            // can outlive the device's ownership of them.
+            arp_mac("2001:db8::5", "AA:AA:AA:00:00:01", "STALE"),
+            arp_mac("fd00::5", "AA:AA:AA:00:00:02", "STALE"),
+            // Not probed: the kernel confirmed this one within the last ~30 s.
+            arp_mac("2001:db8::6", "AA:AA:AA:00:00:03", "REACHABLE"),
+            // Not probed: same MAC as the REACHABLE entry above, so the device is
+            // demonstrably answering NDP — a second probe would tell us nothing.
+            arp_mac("2001:db8::7", "AA:AA:AA:00:00:03", "STALE"),
+            // Not probed: never displayed, so verifying it would be wasted time.
+            arp_mac("fe80::1", "AA:AA:AA:00:00:04", "STALE"),
+            arp_mac("fec0::1", "AA:AA:AA:00:00:05", "STALE"),
+            // Not probed: IPv4 has its own probe path.
+            arp_mac("192.168.10.5", "AA:AA:AA:00:00:06", "STALE"),
+            // Not probed: FAILED is not an "alive" state.
+            arp_mac("2001:db8::8", "AA:AA:AA:00:00:07", "FAILED"),
+        ];
+
+        let targets = ipv6_probe_candidates(&entries);
+        assert_eq!(
+            targets,
+            vec![
+                ("2001:db8::5".to_string(), "br-lan.101".to_string()),
+                ("fd00::5".to_string(), "br-lan.101".to_string()),
+            ],
+        );
+    }
+
+    #[test]
+    fn ipv6_probe_candidates_deduplicates_repeated_addresses() {
+        // The same address can appear on two bridges after a device roams; one
+        // probe settles it.
+        let a = arp_mac("2001:db8::5", "AA:AA:AA:00:00:01", "STALE");
+        let mut b = arp_mac("2001:db8::5", "AA:AA:AA:00:00:01", "STALE");
+        b.interface = "br-lan.102".to_string();
+        assert_eq!(ipv6_probe_candidates(&[a, b]).len(), 1);
+    }
+
+    #[test]
+    fn live_ipv6_candidates_drops_unverified_addresses() {
+        let stale_gua = arp_mac("2001:db8::5", "AA:AA:AA:00:00:01", "STALE");
+        let stale_ula = arp_mac("fd00::5", "AA:AA:AA:00:00:01", "STALE");
+        let v4 = arp_mac("192.168.10.5", "AA:AA:AA:00:00:01", "REACHABLE");
+        let list = vec![&stale_gua, &stale_ula, &v4];
+
+        // The GUA answered the probe, the ULA did not: the device dropped the
+        // ULA when its prefix went away, and the UI must stop claiming it.
+        let verified = ["2001:db8::5".to_string()].into_iter().collect();
+        assert_eq!(
+            live_ipv6_candidates(&list, Some(&verified)),
+            vec!["2001:db8::5"],
+        );
+
+        // Nothing verified → no IPv6 shown at all, rather than a fabricated one.
+        let none_verified = std::collections::HashSet::new();
+        assert!(live_ipv6_candidates(&list, Some(&none_verified)).is_empty());
+    }
+
+    #[test]
+    fn live_ipv6_candidates_keeps_initially_reachable_and_fails_open() {
+        let reachable = arp_mac("2001:db8::5", "AA:AA:AA:00:00:01", "REACHABLE");
+        let stale = arp_mac("fd00::5", "AA:AA:AA:00:00:01", "STALE");
+        let list = vec![&reachable, &stale];
+
+        // An entry the initial snapshot already confirmed is never probed, so it
+        // is absent from the verified set — it must survive on its own state.
+        let verified = std::collections::HashSet::new();
+        assert_eq!(
+            live_ipv6_candidates(&list, Some(&verified)),
+            vec!["2001:db8::5"],
+        );
+
+        // Verification unavailable (the re-read failed): keep everything, so a
+        // transient error blanks nobody's address. Order is preserved, so
+        // pick_ipv6 still prefers the GUA.
+        assert_eq!(
+            live_ipv6_candidates(&list, None),
+            vec!["2001:db8::5", "fd00::5"],
+        );
     }
 
     #[tokio::test]

--- a/projects/start-wrt/backend/ctrl/src/lan.rs
+++ b/projects/start-wrt/backend/ctrl/src/lan.rs
@@ -585,14 +585,11 @@ pub async fn ipv6_set<C: CtrlContext>(
                 if ctx.effectful() {
                     let ipv6_enabled = req.slaac || req.dhcpv6;
 
-                    // Restart odhcpd first so it can send a deprecation RA
-                    // (prefix lifetimes=0) while the network is still up.
-                    // Without this, disabling IPv6 leaves clients with stale
-                    // SLAAC addresses until they naturally expire.
-                    let _ = crate::run_quiet_async(
-                        tokio::process::Command::new("/etc/init.d/odhcpd").arg("restart"),
-                    )
-                    .await;
+                    // Withdraw the old prefix while it is still on the interface
+                    // — see deprecate_odhcpd_prefixes. Without this, disabling
+                    // IPv6 leaves clients holding SLAAC addresses until they
+                    // expire on their own.
+                    crate::deprecate_odhcpd_prefixes().await;
                     let _ = crate::run_quiet_async(
                         tokio::process::Command::new("/etc/init.d/network").arg("restart"),
                     )

--- a/projects/start-wrt/backend/ctrl/src/lib.rs
+++ b/projects/start-wrt/backend/ctrl/src/lib.rs
@@ -475,6 +475,36 @@ pub async fn run_quiet_async(
         .await
 }
 
+/// Make odhcpd re-read its config, and give it a moment to act on the change,
+/// **before** the network is torn down or reconfigured.
+///
+/// This is the only way to revoke an IPv6 prefix from LAN clients. SLAAC has no
+/// lease to expire, so a prefix is withdrawn by advertising it one last time
+/// with zero lifetimes (RFC 9096 §3.5). odhcpd emits that RA from
+/// `router_setup_interface(iface, false)`, which it reaches when a config reload
+/// finds RA newly disabled on an interface — i.e. on **SIGHUP**, which is what
+/// `/etc/init.d/odhcpd reload` sends. A `restart` does not: odhcpd's exit path
+/// tears down the process without touching the interfaces, so the old process
+/// dies silently and the new one starts with RA already off, having never told
+/// anyone. Clients then keep the address for the rest of its advertised valid
+/// lifetime (odhcpd caps this at 5400 s), which is why "IPv6 disabled" used to
+/// leave devices holding addresses for up to 90 minutes.
+///
+/// Two ordering constraints make this a helper rather than a one-line call:
+///
+/// * The UCI change must already be on disk — the reload is what reads it.
+/// * The prefix must still be on the interface, so this has to run *before*
+///   `network restart`/`reload`. There is nothing to wait on (`procd_send_signal`
+///   returns as soon as the signal is delivered, while the RA goes out later
+///   from odhcpd's event loop), so we settle for a fixed pause.
+///
+/// Best-effort by nature: odhcpd sends exactly one final RA, and a client that
+/// misses it — or is asleep — falls back to waiting out the valid lifetime.
+pub async fn deprecate_odhcpd_prefixes() {
+    let _ = run_quiet_async(tokio::process::Command::new("/etc/init.d/odhcpd").arg("reload")).await;
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+}
+
 pub fn init_logging(name: &str) {
     use std::ffi::CString;
 

--- a/projects/start-wrt/backend/ctrl/src/profiles.rs
+++ b/projects/start-wrt/backend/ctrl/src/profiles.rs
@@ -915,6 +915,12 @@ pub async fn reload_system_and_wifi_full() -> Result<(), Error> {
 }
 
 async fn reload_system_and_wifi_inner(restart_network: bool) -> Result<(), Error> {
+    // Before the network is touched: deleting a profile removes its interface
+    // and `ip6assign`, so this is the only moment its clients (still associated
+    // until `wifi` tears the SSID down, or wired on the VLAN) can be told to
+    // drop the prefix. See deprecate_odhcpd_prefixes. A no-op on profile
+    // create, beyond one extra RA.
+    crate::deprecate_odhcpd_prefixes().await;
     let network_action = if restart_network { "restart" } else { "reload" };
     let _ = crate::run_quiet_async(
         tokio::process::Command::new("/etc/init.d/network").arg(network_action),

--- a/projects/start-wrt/backend/ctrl/src/profiles.rs
+++ b/projects/start-wrt/backend/ctrl/src/profiles.rs
@@ -2977,6 +2977,136 @@ pub async fn bootstrap_admin_profile(uci_root: &str) -> Result<(), Error> {
     Ok(())
 }
 
+/// Repair IPv6 state that a pre-1.0.2 router could be left in, where the LAN
+/// says IPv6 is off while individual profiles carry on advertising it.
+///
+/// Before the `!profile.owns_lan` guard in [`rewrite_dhcp`], any profile rewrite
+/// re-derived `dhcp.lan.ra` from the *Admin* profile's outbound, and would write
+/// `disabled` there while touching nothing else. The result is a router where
+/// `dhcp.lan.ra = 'disabled'` — which is what `is_ipv6_enabled`, the LAN IPv6
+/// page, and the IPv6 published-port guard all read — but the profile VLANs
+/// still hold `ra 'server'` and their `ip6assign`, so they keep handing out
+/// addresses. The UI says one thing and the network does another, and nothing
+/// converges them: the guard stops the divergence arising, it cannot undo one
+/// that already has.
+///
+/// Detection is deliberately narrow. On current code this combination is
+/// unreachable: [`lan::ipv6_set`](crate::lan::ipv6_set) writes the LAN and every
+/// profile in one transaction, and [`rewrite_dhcp`] derives each profile's `ra`
+/// from [`is_ipv6_enabled`], which reads `dhcp.lan.ra`. Firing only on the
+/// impossible state therefore cannot clobber a legitimate configuration.
+///
+/// The repair reconciles *down*, toward off — the direction every other part of
+/// the system already believes. That makes reality match what the product is
+/// already asserting, and it is fully recoverable: the LAN IPv6 toggle now works
+/// correctly and turns everything back on together. Reconciling *up* would be a
+/// guess at intent that silently resumes advertising on VLANs the user has been
+/// told are quiet.
+///
+/// NOTE: if a per-profile IPv6 toggle is ever introduced (the ULA→GUA redesign
+/// contemplates one), "LAN off, profile on" becomes a legitimate state and this
+/// heal must be revisited or removed — it would otherwise silently fight it.
+///
+/// Idempotent: a no-op, with no reload, once the state is consistent.
+pub async fn heal_ipv6_state(uci_root: &str) -> Result<(), Error> {
+    let arena = Arena::new();
+    let mut cfgs = parse_all(uci_root, &arena, &["network", "dhcp", "startwrt"]).await?;
+    let repaired = heal_ipv6_state_in_cfgs(&mut cfgs)?;
+
+    if repaired.is_empty() {
+        return Ok(());
+    }
+
+    dump_all(uci_root, cfgs).await?;
+    drop(arena);
+
+    crate::activity::log(
+        "lan",
+        "ipv6-repaired",
+        true,
+        &format!(
+            "Turned IPv6 off for {} — the LAN IPv6 setting was off but these were still advertising",
+            repaired.join(", ")
+        ),
+        None,
+    );
+
+    // reload_system_full withdraws the prefixes from clients before netifd
+    // removes them (see deprecate_odhcpd_prefixes) and does the `network
+    // restart` netifd needs to actually drop an `ip6assign`. Only ever reached
+    // on the repair path, so a healthy router pays nothing.
+    reload_system_full().await?;
+
+    Ok(())
+}
+
+/// The config half of [`heal_ipv6_state`], split out so it can be tested
+/// without spawning init scripts. Returns the interfaces it changed, sorted;
+/// empty means the state was already consistent and nothing should be applied.
+fn heal_ipv6_state_in_cfgs(cfgs: &mut Configs) -> Result<Vec<String>, Error> {
+    // Nothing to repair while the LAN is serving IPv6: profiles advertising
+    // alongside it is the normal, consistent state.
+    if is_ipv6_enabled(cfgs) {
+        return Ok(Vec::new());
+    }
+
+    // Profile interfaces, minus the admin LAN — its `ip6assign` is handled
+    // separately below and its RA is what we just tested.
+    let profile_interfaces: BTreeSet<String> = cfgs["startwrt"]
+        .sections
+        .iter()
+        .filter_map(|s| s.get::<UciProfile>().ok())
+        .map(|p| p.interface)
+        .filter(|i| i != crate::lan::LAN_INTERFACE)
+        .collect();
+
+    let mut repaired = Vec::new();
+
+    for section in &mut cfgs["dhcp"].sections {
+        let Some(name) = section.name().map(|n| n.to_string()) else {
+            continue;
+        };
+        if !profile_interfaces.contains(&name) {
+            continue;
+        }
+        let Some(mut dhcp) = section.get_typed::<Dhcp>()? else {
+            continue;
+        };
+        if dhcp.ra.as_deref() == Some("server") || dhcp.dhcpv6.as_deref() == Some("server") {
+            dhcp.ra = Some("disabled".to_string());
+            dhcp.dhcpv6 = Some("disabled".to_string());
+            section.set(&dhcp)?;
+            repaired.push(name);
+        }
+    }
+
+    // Clear every stranded prefix assignment, the admin LAN's included: with RA
+    // off it serves no client, but it still holds an address on the bridge and
+    // would silently come back as a live prefix the moment RA returned.
+    for section in &mut cfgs["network"].sections {
+        let Some(name) = section.name().map(|n| n.to_string()) else {
+            continue;
+        };
+        let is_lan = name == crate::lan::LAN_INTERFACE;
+        if !is_lan && !profile_interfaces.contains(&name) {
+            continue;
+        }
+        let Some(mut iface) = section.get_typed::<NetworkInterface>()? else {
+            continue;
+        };
+        if iface.ip6assign.is_some() {
+            iface.ip6assign = None;
+            section.set(&iface)?;
+            if !repaired.contains(&name) {
+                repaired.push(name);
+            }
+        }
+    }
+
+    repaired.sort();
+    Ok(repaired)
+}
+
 #[derive(Debug, Parser, Serialize, Deserialize)]
 pub struct EditArgs {
     #[clap(flatten)]
@@ -3482,6 +3612,171 @@ mod tests {
     use rpc_toolkit::Context;
 
     use super::*;
+
+    /// Write a network/dhcp/startwrt fixture, run the config half of the IPv6
+    /// heal over it, and hand back what it changed plus the resulting files.
+    /// Uses the pure inner function, so no init script is ever spawned.
+    async fn run_ipv6_heal(
+        network: &str,
+        dhcp: &str,
+        startwrt: &str,
+    ) -> (Vec<String>, String, String) {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("network"), network).unwrap();
+        std::fs::write(dir.path().join("dhcp"), dhcp).unwrap();
+        std::fs::write(dir.path().join("startwrt"), startwrt).unwrap();
+
+        let arena = Arena::new();
+        let mut cfgs = parse_all(dir.path(), &arena, &["network", "dhcp", "startwrt"])
+            .await
+            .unwrap();
+        let repaired = heal_ipv6_state_in_cfgs(&mut cfgs).unwrap();
+        dump_all(dir.path(), cfgs).await.unwrap();
+        drop(arena);
+
+        (
+            repaired,
+            std::fs::read_to_string(dir.path().join("network")).unwrap(),
+            std::fs::read_to_string(dir.path().join("dhcp")).unwrap(),
+        )
+    }
+
+    /// A router left in the pre-1.0.2 diverged state: the LAN says IPv6 is off,
+    /// both profile VLANs are still advertising, every ip6assign survives.
+    const HEAL_NETWORK_DIVERGED: &str = "\
+config interface 'lan'
+\toption device 'br-lan.1'
+\toption proto 'static'
+\toption ipaddr '192.168.1.1'
+\toption ip6assign '60'
+
+config interface 'guest'
+\toption device 'br-lan.101'
+\toption proto 'static'
+\toption ipaddr '192.168.101.1'
+\toption ip6assign '64'
+
+config interface 'iot'
+\toption device 'br-lan.102'
+\toption proto 'static'
+\toption ipaddr '192.168.102.1'
+\toption ip6assign '64'
+";
+
+    const HEAL_STARTWRT: &str = "\
+config profile lan
+\toption fullname 'Admin'
+\toption interface 'lan'
+\toption vlan_tag '1'
+\toption outbound 'wan'
+
+config profile guest
+\toption fullname 'Guest'
+\toption interface 'guest'
+\toption vlan_tag '101'
+\toption outbound 'wan'
+
+config profile iot
+\toption fullname 'IoT'
+\toption interface 'iot'
+\toption vlan_tag '102'
+\toption outbound 'wan'
+";
+
+    fn heal_dhcp(lan_ra: &str, profile_ra: &str) -> String {
+        format!(
+            "\
+config dhcp 'lan'
+\toption interface 'lan'
+\toption start '2'
+\toption limit '198'
+\toption leasetime '12h'
+\toption ra '{lan_ra}'
+\toption dhcpv6 '{lan_ra}'
+
+config dhcp 'guest'
+\toption interface 'guest'
+\toption start '2'
+\toption limit '198'
+\toption leasetime '12h'
+\toption ra '{profile_ra}'
+\toption dhcpv6 '{profile_ra}'
+
+config dhcp 'iot'
+\toption interface 'iot'
+\toption start '2'
+\toption limit '198'
+\toption leasetime '12h'
+\toption ra '{profile_ra}'
+\toption dhcpv6 '{profile_ra}'
+"
+        )
+    }
+
+    #[tokio::test]
+    async fn heal_ipv6_converges_the_diverged_state() {
+        let (repaired, network, dhcp) = run_ipv6_heal(
+            HEAL_NETWORK_DIVERGED,
+            &heal_dhcp("disabled", "server"),
+            HEAL_STARTWRT,
+        )
+        .await;
+
+        assert_eq!(repaired, vec!["guest", "iot", "lan"]);
+        assert!(
+            !network.contains("ip6assign"),
+            "every stranded prefix assignment must go, the admin LAN's included:\n{network}"
+        );
+        assert!(
+            !dhcp.contains("'server'"),
+            "no VLAN may still be advertising:\n{dhcp}"
+        );
+    }
+
+    #[tokio::test]
+    async fn heal_ipv6_leaves_a_working_configuration_alone() {
+        // The critical negative case. LAN IPv6 on, profiles advertising, every
+        // ip6assign in place — the normal consistent state, which the heal must
+        // never touch or it would break IPv6 for everyone on every boot.
+        let (repaired, network, dhcp) = run_ipv6_heal(
+            HEAL_NETWORK_DIVERGED,
+            &heal_dhcp("server", "server"),
+            HEAL_STARTWRT,
+        )
+        .await;
+
+        assert!(repaired.is_empty(), "healed a healthy router: {repaired:?}");
+        assert_eq!(network.matches("ip6assign").count(), 3);
+        assert_eq!(dhcp.matches("'server'").count(), 6);
+    }
+
+    #[tokio::test]
+    async fn heal_ipv6_is_a_noop_when_already_off_everywhere() {
+        let network = HEAL_NETWORK_DIVERGED.replace("\toption ip6assign '60'\n", "");
+        let network = network.replace("\toption ip6assign '64'\n", "");
+        let (repaired, network_out, dhcp) =
+            run_ipv6_heal(&network, &heal_dhcp("disabled", "disabled"), HEAL_STARTWRT).await;
+
+        assert!(repaired.is_empty(), "nothing to repair: {repaired:?}");
+        assert!(!network_out.contains("ip6assign"));
+        assert!(!dhcp.contains("'server'"));
+    }
+
+    #[tokio::test]
+    async fn heal_ipv6_is_idempotent() {
+        // Feed the first run's own output back in: the second pass must report
+        // no change, or the heal would restart the network on every boot.
+        let (first, network, dhcp) = run_ipv6_heal(
+            HEAL_NETWORK_DIVERGED,
+            &heal_dhcp("disabled", "server"),
+            HEAL_STARTWRT,
+        )
+        .await;
+        assert!(!first.is_empty());
+
+        let (second, _, _) = run_ipv6_heal(&network, &dhcp, HEAL_STARTWRT).await;
+        assert!(second.is_empty(), "second pass repaired again: {second:?}");
+    }
 
     #[test]
     fn test_window_contains_non_wrap() {

--- a/projects/start-wrt/backend/ctrl/src/profiles.rs
+++ b/projects/start-wrt/backend/ctrl/src/profiles.rs
@@ -870,6 +870,12 @@ pub async fn reload_system_full() -> Result<(), Error> {
 }
 
 async fn reload_system_inner(restart_network: bool) -> Result<(), Error> {
+    // Before the network is touched: if this edit turned a profile's RA off
+    // (moved it onto an IPv4-only VPN, say), this is the only moment its clients
+    // can be told to drop the prefix — once netifd removes it there is nothing
+    // left to withdraw. See deprecate_odhcpd_prefixes. A no-op when nothing
+    // about IPv6 changed, beyond one extra RA.
+    crate::deprecate_odhcpd_prefixes().await;
     let network_action = if restart_network { "restart" } else { "reload" };
     let _ = crate::run_quiet_async(
         tokio::process::Command::new("/etc/init.d/network").arg(network_action),

--- a/projects/start-wrt/backend/ctrl/src/wan.rs
+++ b/projects/start-wrt/backend/ctrl/src/wan.rs
@@ -672,6 +672,10 @@ pub async fn ipv6_set<C: CtrlContext>(
                     None,
                 );
                 if ctx.effectful() {
+                    // Disabling WAN IPv6 (or switching mode) drops the delegated
+                    // prefix the LAN was subnetting; withdraw it from clients
+                    // while it still exists. See deprecate_odhcpd_prefixes.
+                    crate::deprecate_odhcpd_prefixes().await;
                     restart_network().await;
                     let _ = crate::run_quiet_async(
                         tokio::process::Command::new("/etc/init.d/odhcpd").arg("restart"),

--- a/projects/start-wrt/docs/src/devices.md
+++ b/projects/start-wrt/docs/src/devices.md
@@ -12,7 +12,7 @@ Navigate to `Network > Devices` to see the device list. A search box above the l
 - **Connection** — How the device connects: Ethernet, Wi-Fi 2.4GHz, Wi-Fi 5GHz, or VPN.
 - **Security Profile** — The [Security Profile](security-profiles.md) the device is assigned to.
 - **MAC address** — The device's unique hardware identifier.
-- **IP address** — The device's IPv4 and IPv6 addresses. A lock icon indicates a reserved (static) IPv4 address.
+- **IP address** — The device's IPv4 and IPv6 addresses. A lock icon indicates a reserved (static) IPv4 address. The IPv6 address is shown only while the device is confirmed to still be using it, so the field is empty for a device that has dropped its IPv6 address or has none.
 - **Data and Speed** — Cumulative data usage and real-time upload/download speed for online devices.
 
 ## Device Detail Page

--- a/projects/start-wrt/docs/src/lan.md
+++ b/projects/start-wrt/docs/src/lan.md
@@ -36,6 +36,9 @@ Configure IPv6 addressing on the LAN.
 > While any enabled [Published Ports](published-ports.md) rule forwards over IPv6, IPv6 cannot be disabled — devices would lose the addresses those rules depend on. Disable or delete those rules first.
 
 > [!NOTE]
+> If you are updating from an older version, this page may have read **Disabled** while some [Security Profiles](security-profiles.md) were still handing out IPv6 addresses. That is corrected on the first start after the update: IPv6 is turned off for those profiles too, and the correction is recorded in [Activity](settings.md). Enable IPv6 here to turn it back on — it now applies to the LAN and every profile together.
+
+> [!NOTE]
 > Because devices choose their own IPv6 addresses, disabling IPv6 asks them to drop the ones they hold rather than taking the addresses away directly. Devices that are connected at the time drop them immediately. A device that is asleep, off the network, or misses the notice keeps its address until it expires on its own — up to about 90 minutes — and reconnecting or rebooting it clears the address right away.
 
 > [!NOTE]

--- a/projects/start-wrt/docs/src/lan.md
+++ b/projects/start-wrt/docs/src/lan.md
@@ -36,4 +36,7 @@ Configure IPv6 addressing on the LAN.
 > While any enabled [Published Ports](published-ports.md) rule forwards over IPv6, IPv6 cannot be disabled — devices would lose the addresses those rules depend on. Disable or delete those rules first.
 
 > [!NOTE]
+> Because devices choose their own IPv6 addresses, disabling IPv6 asks them to drop the ones they hold rather than taking the addresses away directly. Devices that are connected at the time drop them immediately. A device that is asleep, off the network, or misses the notice keeps its address until it expires on its own — up to about 90 minutes — and reconnecting or rebooting it clears the address right away.
+
+> [!NOTE]
 > If the Admin profile routes through an IPv4-only [Outbound VPN](outbound-vpn.md), LAN devices still receive their IPv6 addresses, but IPv6 internet traffic is blocked by the kill switch so it cannot leak around the tunnel. IPv6 connectivity resumes when the profile routes through an IPv6-capable VPN or directly to the Internet.


### PR DESCRIPTION
## Summary

Turning IPv6 off in StartWRT didn't actually tell anyone. Devices choose their
own IPv6 addresses from a prefix the router advertises (SLAAC) — there is no
lease to revoke, so the only way to take addresses back is to advertise the
prefix one last time with zero lifetimes (RFC 9096 §3.5, the "goodbye RA").
StartWRT never sent it, the Devices page kept displaying the dead addresses it
found in the neighbor table, and routers bitten by the pre-1.1.0 admin-LAN bug
(#3504 fixed the cause, in the same unreleased version as this PR) were left
*permanently* advertising IPv6 that the UI reported as disabled.

Found on a production router showing exactly that: LAN → IPv6 "Disabled",
devices happily holding live ULAs. Four commits — honesty in what we show,
honesty in what we tear down, and a one-time repair for state the old bug
already corrupted.

## 1. `fix(start-wrt): only show IPv6 addresses devices still answer for` (7b28c0146)

- The Devices list read IPv6 straight from `ip -6 neigh`; a `STALE` entry
  survives below the kernel GC threshold indefinitely, so a dropped address
  kept displaying for hours — most visibly right after disabling IPv6, where
  the UI suggested nothing had changed.
- Unconfirmed (STALE/DELAY/PROBE) entries are now probed (`ping6 -c1 -W1`,
  parallel, folded into the page's existing `tokio::join!` so no added
  latency) and judged on the **NUD state after a neighbor-table re-read, not
  the echo reply** — Windows firewalls drop echo but still answer the
  neighbor solicitation the ping triggers. Fails open if the re-read fails.
- Only GUA/ULA addresses are considered displayable. Side effect worth
  knowing: an offline device can't answer, so its IPv6 column is now blank —
  which is the honest answer.

## 2. `fix(start-wrt): withdraw IPv6 prefixes from clients before tearing them down` (d9fab2658)

- Every disable path restarted odhcpd — and odhcpd only emits the goodbye RA
  from its **reload** (SIGHUP) path; its exit path tears the process down
  without touching interfaces. So no teardown ever sent it, and clients kept
  dead addresses until the advertised lifetime ran out (odhcpd caps it at
  5400 s ≈ 90 min).
- New `deprecate_odhcpd_prefixes()` helper: `odhcpd reload` + a 1 s pause,
  called **before** the network is reconfigured (the prefix must still be on
  the interface for the goodbye to reference) on the paths that can drop one:
  `lan::ipv6_set`, `wan::ipv6_set`, and `profiles::reload_system_inner`.
- Best-effort by protocol design: odhcpd sends exactly one goodbye, and a
  sleeping client falls back to the lifetime timeout — i.e. to today's
  behavior. The fixed pause exists because there is nothing to await
  (`procd` returns when SIGHUP is delivered; the RA leaves odhcpd's event
  loop later), and a miss degrades gracefully rather than breaking.

## 3. `fix(start-wrt): repair IPv6 state left diverged by the pre-1.0.2 admin-LAN bug` (cbc271bc6)

- Firmware ≤ 1.0.1 could set `dhcp.lan.ra='disabled'` while profile VLANs
  kept `ra='server'` + `ip6assign` — UI says off, network keeps advertising,
  and nothing ever converges it. The `owns_lan` guard (merged in #3504)
  prevents new divergence but cannot undo it on routers already bitten.
- `heal_ipv6_state` runs once at daemon start (after
  `bootstrap_admin_profile`), fires **only** on the currently-impossible
  "LAN off + profile advertising" signature, reconciles *down* (matching
  what the UI has been asserting; reconciling up would guess at intent),
  clears stranded `ip6assign`s, logs an Activity entry, sends the goodbye
  RAs, and reloads. Idempotent; a healthy router pays nothing — no reload,
  no RA.
- Config logic is split into a pure `heal_ipv6_state_in_cfgs` for testing.
  Carries a NOTE: if a per-profile IPv6 toggle ever lands, this heal must be
  revisited — "LAN off, profile on" becomes legitimate.

## 4. `fix(start-wrt): withdraw IPv6 prefixes on profile create/delete reloads too` (22c7e154d)

- `reload_system_and_wifi_inner` (profile create/delete) is a fourth
  teardown path that can drop a prefix — deleting a profile removes its
  interface and `ip6assign` — and commit 2 missed it. Same one-line
  treatment, sent while the profile's clients can still hear it (before the
  SSID is torn down; wired VLAN members stay connected regardless). A no-op
  on profile create beyond one extra RA.

## Testing

- 8 new unit tests: probe-candidate selection (REACHABLE skip, link-local /
  site-local / IPv4 / FAILED exclusion, dedup), verified filtering,
  fail-open; and for the healer the full square — converges the diverged
  state, **leaves a working configuration alone**, no-op when already off,
  idempotent (run 1's output fed back in). 489/489 `startwrt-core` + 17/17
  `uciedit` green on current master.
- `deprecate_odhcpd_prefixes` itself is untested, consistent with how the
  file treats init-script side effects throughout.
- Not yet bench-verified on hardware. Suggested spot-check: enable then
  disable LAN IPv6 with a client attached and watch it drop its addresses
  within seconds (previously ~90 min); confirm the Devices page clears the
  IPv6 column; on a router restored from a diverged 1.0.1 backup, confirm
  the one-time heal fires and logs to Activity.

## Deliberately out of scope

- **The `ra_default` hole**: a wan-routed, ULA-only profile advertises router
  lifetime 0, so its clients get no v6 default route. Must **not** be
  "fixed" by setting `ra_default=1` alone — that hands clients a default
  route with no v6 egress path (no `masq6`) and turns "no IPv6 internet"
  into per-connection stalls. The RA and the egress path move together in
  the ULA→GUA redesign.
- Recovery without this PR exists and stays valid: toggle LAN IPv6 on →
  save → off → save converges a diverged router by hand.

## Merge notes

- Independent — not stacked on anything; backend + docs only, **no image
  rebuild needed** (a binary deploy via `make start-wrt-update` suffices).
- Changelog entries sit under the shared `## [1.1.0]` heading (same rename
  every open StartWRT PR carries; **no manifest bump here** — the feature
  PRs #3623/#3607/#3634 own it). The healer note deliberately *extends* the
  existing "Enabling LAN IPv6" 1.1.0 entry rather than adding a separate
  fix line, since both ship in the same release. Entry anchors were chosen
  to be conflict-free against every open PR.
- Docs updated in the commits: `devices.md` (IPv6 shown only while
  confirmed), `lan.md` (auto-repair NOTE + the "devices choose their own
  addresses" revocation caveat with the ~90 min fallback).
