### PR TITLE
docs(packaging): document what maintaining a package takes past the first release

### DIFF
--- a/projects/start-sdk/docs/src/README.md
+++ b/projects/start-sdk/docs/src/README.md
@@ -33,7 +33,7 @@ What makes this experience possible is a unique package format (`.s9pk`) that pe
 
 ## Recipes
 
-Intent-driven guides for common packaging tasks. These are the primary entry point for both you and your AI coding agent.
+Intent-driven guides for common packaging objectives. These are the primary entry point for both you and your AI coding agent.
 
 - [What Do You Want To Do?](./recipes.md) - Browse all recipes by intent
 

--- a/projects/start-sdk/docs/src/SUMMARY.md
+++ b/projects/start-sdk/docs/src/SUMMARY.md
@@ -9,6 +9,7 @@
 - [Environment Setup](environment-setup.md)
 - [Quick Start](quick-start.md)
 - [Development Workflow](workflow.md)
+- [Maintaining a Package](maintaining-a-package.md)
 - [Agent Context](agent-context.md)
 
 # Recipes

--- a/projects/start-sdk/docs/src/agent-context.md
+++ b/projects/start-sdk/docs/src/agent-context.md
@@ -3,7 +3,7 @@
 > [!NOTE]
 > This page is the `AGENTS.md` that `start-cli s9pk init-workspace` links into every packaging workspace. Your workspace copy is a symlink to this file, so syncing the guide keeps it current.
 
-You are an AI assistant working in a **StartOS packaging workspace**. You help create, maintain, and update `.s9pk` service packages for StartOS. This file is your always-on context: the rules to follow, the patterns to know, and a map of where to read for any given task. The substance lives in the packaging guide under `start-technologies/projects/start-sdk/docs/` — read those pages locally, on demand, as the task requires. Do not load everything at once.
+You are an AI assistant working in a **StartOS packaging workspace**. You help create, maintain, and update `.s9pk` service packages for StartOS. This file is your always-on context: the rules to follow, the patterns to know, and a map of where to read for any given objective. The substance lives in the packaging guide under `start-technologies/projects/start-sdk/docs/` — read those pages locally, on demand, as the work requires. Do not load everything at once.
 
 ## Workspace layout
 
@@ -42,12 +42,12 @@ The guide has two layers:
 - **Recipes** — intent-driven pages: _what_ to do and _which_ constructs to combine. **Start here.** Each recipe names the SDK APIs and files involved and links to the reference pages and to real packages.
 - **Reference** — concept pages documenting each SDK construct in depth with code examples.
 
-Workflow for any task:
+Workflow for any objective:
 
 1. **Find the recipe.** Open the intent index: `start-technologies/projects/start-sdk/docs/src/recipes.md`.
 2. **Follow its reference links** for API details and code examples.
 3. **Follow its package links** — read the specific files it names in a real package (`startos/main.ts`, `startos/actions/`, …) for working production code.
-4. **Read only what the task needs.**
+4. **Read only what the objective needs.**
 
 Read pages from your local checkout (`start-technologies/projects/start-sdk/docs/src/<page>.md`). Only if `start-technologies/` is missing, fall back to the web (`https://docs.start9.com/packaging/<page>.html`).
 
@@ -55,8 +55,8 @@ Read pages from your local checkout (`start-technologies/projects/start-sdk/docs
 
 | Need                                                  | Read                                                                      |
 | ----------------------------------------------------- | ------------------------------------------------------------------------- |
-| Find the right recipe for a task                      | `start-technologies/projects/start-sdk/docs/src/recipes.md`               |
-| How to behave on every task (the disciplines below)   | `start-technologies/projects/start-sdk/docs/src/workflow.md`              |
+| Find the right recipe for an objective                | `start-technologies/projects/start-sdk/docs/src/recipes.md`               |
+| How to behave on every change (the disciplines below) | `start-technologies/projects/start-sdk/docs/src/workflow.md`              |
 | Branches, release lines, upstream bumps, sibling deps | `start-technologies/projects/start-sdk/docs/src/maintaining-a-package.md` |
 | File/directory layout of a package                    | `start-technologies/projects/start-sdk/docs/src/project-structure.md`     |
 | Service metadata, descriptions                        | `start-technologies/projects/start-sdk/docs/src/manifest.md`              |
@@ -100,7 +100,7 @@ Understand these before writing any code (full detail on the pages above):
 - **Code lives in reference pages and packages, not recipes.** Recipes describe the pattern; reference pages have the API; real packages have production implementations.
 - **Match existing patterns — but a neighbouring package is not the authority.** Read a package's code before introducing a new pattern. Then check it against the recipe: the fleet is mid-migration, so the package you happened to grep may itself be non-conformant. "It matches the package next door" is not a quality bar. A recipe and its named reference implementation outrank a package you found by searching.
 
-## Working discipline (every task)
+## Working discipline (every change)
 
 The full rules are in `start-technologies/projects/start-sdk/docs/src/workflow.md`; this is the digest.
 

--- a/projects/start-sdk/docs/src/agent-context.md
+++ b/projects/start-sdk/docs/src/agent-context.md
@@ -53,25 +53,26 @@ Read pages from your local checkout (`start-technologies/projects/start-sdk/docs
 
 ## Where to read for X
 
-| Need                                                | Read                                                                     |
-| --------------------------------------------------- | ------------------------------------------------------------------------ |
-| Find the right recipe for a task                    | `start-technologies/projects/start-sdk/docs/src/recipes.md`              |
-| How to behave on every task (the disciplines below) | `start-technologies/projects/start-sdk/docs/src/workflow.md`             |
-| File/directory layout of a package                  | `start-technologies/projects/start-sdk/docs/src/project-structure.md`    |
-| Service metadata, descriptions                      | `start-technologies/projects/start-sdk/docs/src/manifest.md`             |
-| Versions, migrations, release notes                 | `start-technologies/projects/start-sdk/docs/src/versions.md`             |
-| Daemons, health checks, oneshots, lifecycle         | `start-technologies/projects/start-sdk/docs/src/main.md`                 |
-| Install / update / restore init logic               | `start-technologies/projects/start-sdk/docs/src/init.md`                 |
-| Network interfaces and ports                        | `start-technologies/projects/start-sdk/docs/src/interfaces.md`           |
-| User-facing actions                                 | `start-technologies/projects/start-sdk/docs/src/actions.md`              |
-| Prompting the user to run actions                   | `start-technologies/projects/start-sdk/docs/src/tasks.md`                |
-| Config files as typed models                        | `start-technologies/projects/start-sdk/docs/src/file-models.md`          |
-| Service dependencies                                | `start-technologies/projects/start-sdk/docs/src/dependencies.md`         |
-| Build / install commands                            | `start-technologies/projects/start-sdk/docs/src/makefile.md`             |
-| Writing the README                                  | `start-technologies/projects/start-sdk/docs/src/writing-readmes.md`      |
-| Writing user instructions                           | `start-technologies/projects/start-sdk/docs/src/writing-instructions.md` |
-| Publishing / registries                             | `start-technologies/projects/start-sdk/docs/src/publishing.md`           |
-| `start-cli` reference                               | `start-technologies/projects/start-sdk/docs/src/cli.md`                  |
+| Need                                                  | Read                                                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------- |
+| Find the right recipe for a task                      | `start-technologies/projects/start-sdk/docs/src/recipes.md`               |
+| How to behave on every task (the disciplines below)   | `start-technologies/projects/start-sdk/docs/src/workflow.md`              |
+| Branches, release lines, upstream bumps, sibling deps | `start-technologies/projects/start-sdk/docs/src/maintaining-a-package.md` |
+| File/directory layout of a package                    | `start-technologies/projects/start-sdk/docs/src/project-structure.md`     |
+| Service metadata, descriptions                        | `start-technologies/projects/start-sdk/docs/src/manifest.md`              |
+| Versions, migrations, release notes                   | `start-technologies/projects/start-sdk/docs/src/versions.md`              |
+| Daemons, health checks, oneshots, lifecycle           | `start-technologies/projects/start-sdk/docs/src/main.md`                  |
+| Install / update / restore init logic                 | `start-technologies/projects/start-sdk/docs/src/init.md`                  |
+| Network interfaces and ports                          | `start-technologies/projects/start-sdk/docs/src/interfaces.md`            |
+| User-facing actions                                   | `start-technologies/projects/start-sdk/docs/src/actions.md`               |
+| Prompting the user to run actions                     | `start-technologies/projects/start-sdk/docs/src/tasks.md`                 |
+| Config files as typed models                          | `start-technologies/projects/start-sdk/docs/src/file-models.md`           |
+| Service dependencies                                  | `start-technologies/projects/start-sdk/docs/src/dependencies.md`          |
+| Build / install commands                              | `start-technologies/projects/start-sdk/docs/src/makefile.md`              |
+| Writing the README                                    | `start-technologies/projects/start-sdk/docs/src/writing-readmes.md`       |
+| Writing user instructions                             | `start-technologies/projects/start-sdk/docs/src/writing-instructions.md`  |
+| Publishing / registries                               | `start-technologies/projects/start-sdk/docs/src/publishing.md`            |
+| `start-cli` reference                                 | `start-technologies/projects/start-sdk/docs/src/cli.md`                   |
 
 ## Reading the SDK and OS source (last resort)
 

--- a/projects/start-sdk/docs/src/init.md
+++ b/projects/start-sdk/docs/src/init.md
@@ -173,11 +173,11 @@ export const uninit = sdk.setupUninit(versionGraph)
 
 ## runUntilSuccess Pattern
 
-Use `runUntilSuccess(timeout)` to run daemons and oneshots during init, waiting for completion before continuing. This is essential for setup tasks that need a running server.
+Use `runUntilSuccess(timeout)` to run daemons and oneshots during init, waiting for completion before continuing. This is essential for setup steps that need a running server.
 
 ### Oneshots Only
 
-For simple sequential tasks (like database migrations):
+For simple sequential steps (like the app's own database migrations):
 
 ```typescript
 await sdk.Daemons.of(effects)
@@ -305,7 +305,7 @@ urllib.request.urlopen(req)`,
 
 Init progress is surfaced in the **Installing** / **Updating** phase of the install, so a long first-run setup (migrations, bootstrapping a server, downloading assets) shows a moving bar instead of an apparent stall. This mirrors backup progress reporting.
 
-You never call the progress effect directly. The init harness builds one `FullProgressTracker` and passes it to **every** init handler as a third argument. Each handler adds its own phases (with its own names) to the shared tracker, unaware of the others. Add phases and update them — **every update auto-reports to the host in the background**, so there's nothing to flush by hand.
+You never call the progress effect directly. The init harness builds one `FullProgressTracker` and passes it to **every** init handler as a third argument. Each handler adds its own phases (with its own names) to the shared tracker, unaware of the others. Add phases and update them — **every update auto-reports to StartOS in the background**, so there's nothing to flush by hand.
 
 `progress.addPhase(name, contribution)` returns a `PhaseHandle` with `start()`, `setTotal(n)`, `setDone(n)`, `setUnits('steps' | 'bytes')`, and `complete()`. Just update the handle; the report follows automatically.
 
@@ -364,7 +364,7 @@ export const v2_0_0 = VersionInfo.of({
 
 ### Multi-phase Handlers
 
-For a handler with several distinct sub-tasks, add one phase per task. The tracker weights them by their `contribution` and reports a combined percentage:
+For a handler with several distinct steps, add one phase per step. The tracker weights them by their `contribution` and reports a combined percentage:
 
 ```typescript
 export const bootstrap = sdk.setupOnInit(async (effects, kind, progress) => {

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -158,7 +158,7 @@ const ui = await sdk.host.getOwn(effects, 'ui', host => host?.bindings[80]?.inte
 
 ## Oneshots (Runtime)
 
-Oneshots are tasks that run on every startup before daemons. Use them for work whose answer can differ on the next start — file ownership, filesystem attributes, an app-level schema upgrade driven by the app's own state:
+Oneshots are commands that run to completion on every startup, before daemons. Use them for work whose answer can differ on the next start — file ownership, filesystem attributes, an app-level schema upgrade driven by the app's own state:
 
 ```typescript
 // change ownership of a directory
@@ -178,7 +178,7 @@ Oneshots are tasks that run on every startup before daemons. Use them for work w
 ```
 
 > [!WARNING]
-> Do NOT put one-time setup tasks (like `createsuperuser`) in `main.ts` oneshots -- they run on every startup and will fail on subsequent runs. Use a custom init file (e.g. `init/seedFiles.ts`) instead. See [Initialization Patterns](./init.md) for details.
+> Do NOT put one-time setup work (like `createsuperuser`) in `main.ts` oneshots -- they run on every startup and will fail on subsequent runs. Use a custom init file (e.g. `init/seedFiles.ts`) instead. See [Initialization Patterns](./init.md) for details.
 
 ### Choosing Between a Oneshot, an Init, and a Migration
 

--- a/projects/start-sdk/docs/src/maintaining-a-package.md
+++ b/projects/start-sdk/docs/src/maintaining-a-package.md
@@ -1,0 +1,120 @@
+# Maintaining a Package
+
+The rest of this guide is about making _a_ change: which construct to reach for, how to write it, how to verify it. This page is about the package as something that keeps existing — the branches it accumulates, the upstream it chases, and the sibling packages it depends on. None of it matters much on the day you scaffold a package, and all of it matters by the fiftieth release.
+
+## Branches
+
+A package has one **base branch** — the integration branch its CI is wired to. `master` and `main` are both fine; what matters is that the branch the repo actually uses is the branch its workflows name. `build.yml`'s PR target and `tagAndRelease.yml`'s push trigger both have to point at it, and a package sitting on `main` whose workflows still say `master` silently never builds a PR and never releases. See [Project Structure — .github/workflows/](./project-structure.md#githubworkflows).
+
+Ordinary work targets the base branch: cut a feature branch, open a pull request, merge, and let the branch be deleted.
+
+### `next`, the long-lived iteration branch
+
+Alongside the base sits **`next`** — a branch that is never deleted and keeps accumulating work after each pull request lands. It exists so a package can be iterated on continuously without every increment having to be release-ready, and so a chain of dependent changes can build on each other before any of them ship.
+
+[`syncNext.yml`](./project-structure.md#githubworkflows) keeps it honest: every push to the base is carried onto `next`, so it never falls behind what has already shipped. You do not have to create `next` yourself — the first run makes one at the base tip.
+
+### Merge a long-lived branch with a merge commit, never a squash
+
+This is the one branch rule that is easy to get wrong, because the habit runs the other way.
+
+When you merge `next` into its base, use **`gh pr merge --merge`** — "Create a merge commit" in the web UI. The merge commit's second parent is `next`'s tip, which leaves `next` a true ancestor of the base, and the next sync fast-forwards it.
+
+**Squashing re-lands the same content under a brand-new commit.** The base ends up with the changes but not the commits, so `next` is left carrying history the base will never contain — permanently diverged, with every later sync having to merge around it. Rebase-merging diverges for the same reason.
+
+Feature branches are the opposite case: they are deleted on merge, so squash them as usual. The rule is about the head branch's **lifetime**, not about the repository. Anything long-lived — `next`, a release line, the scratch branch `syncNext` opens when a sync conflicts — takes a merge commit.
+
+## Parallel release lines
+
+Some packages ship more than one line at once: two upstream major versions that both still receive updates, or two build flavors of the same software. Each line gets its own base branch, and each base branch gets its own paired iteration branch named **`next/<base>`**.
+
+The slash order is forced by git, not chosen. Refs are paths, so while a branch named `29.x` exists, no branch `29.x/next` can exist beside it — a ref cannot be both a file and a directory. `next/29.x` is the form that works.
+
+> [!IMPORTANT]
+> Every operation applies to **every** line, not just the one you have checked out. A version bump, a dependency refresh, a README correction, a security fix — if it belongs on one line it almost certainly belongs on the others. `git branch -r` tells you what the package maintains; `git worktree list` is the ergonomic way to keep several checked out at once.
+
+For example, a package wrapping a widely-deployed daemon might carry `28.x` through `31.x` as base branches, with `next/28.x` … `next/31.x` paired to them, plus a separate line for a variant build of the same software. Users on the older line keep receiving fixes without being forced onto a major upgrade, and the packaging work happens once per line rather than once per release.
+
+If your package only ever tracks one upstream line — most do — ignore all of this. A plain `next` is the whole story.
+
+## Chasing upstream
+
+`UPDATING.md` at the package root is the package-specific recipe: where its version string lives, which registry and tag format to look for, and exactly which field to edit. Follow it. It is also **not automatically correct** — if its command contradicts what you can actually observe, trust the observation, fix the file in the same change, and say so in the pull request.
+
+Four disciplines apply on top of it.
+
+### A release existing does not mean the artifact exists
+
+**Verify that the thing you are about to pin actually resolves, before you pin it.** Upstreams tag a release and fail to publish the image often enough that this is a routine failure, not an edge case — and the symptom lands on users of the package, not on you, because the manifest type-checks and only the build fails.
+
+- For a `dockerTag`, confirm the exact tag resolves. `docker manifest inspect <image>:<tag>` works, but anonymous Docker Hub requests are rate-limited and a throttled response is indistinguishable from a missing tag — prefer the registry's tag API (`https://hub.docker.com/v2/repositories/<namespace>/<repo>/tags/<tag>` for Docker Hub).
+- For a source build, confirm the git tag exists.
+- If the package pins **several** images that move together, check every one.
+- If the newest release has no usable artifact, target the newest one that does, and say so in the pull request.
+
+### Skip prereleases, and don't trust "Latest"
+
+GitHub's "Latest" badge is unreliable in both directions: it can sit on a prerelease, and it can lag behind the newest stable. Read the tag list rather than the release page, and pin a stable release unless the package deliberately tracks a prerelease line.
+
+### Scale scrutiny to the size of the jump
+
+| Jump                      | What it needs                                                                                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------------- |
+| **Patch** (1.2.3 → 1.2.4) | Low risk. Bump, verify the build, move on.                                                               |
+| **Minor** (1.2.x → 1.3.0) | Read the full changelog. Look for deprecations and behavior changes; note new features worth surfacing.  |
+| **Major** (1.x → 2.0)     | Read the changelog, release notes, and any migration guide. Inspect code diffs where the notes are thin. |
+
+A major bump is also where you ask whether the package needs a [data migration](./recipe-version-migrations.md) — and whether the version currently in `current.ts` carries one that has to be spun off first. See [Versions — When to Create a New Version File](./versions.md#when-to-create-a-new-version-file).
+
+### When the packaging repo is itself a fork
+
+To sync a fork, you need its **fork parent**, which the GitHub API knows:
+
+```sh
+gh api repos/<owner>/<repo> --jq '.parent.full_name'
+```
+
+Do **not** use the manifest's `upstreamRepo` for this. That field points at the upstream _software_ project, which is a different repository from the packaging repo you forked — using it for a fork sync merges an unrelated history.
+
+## Depending on another package's repo
+
+A package can depend on another package's repo through npm, to reuse its exported constants and types:
+
+```json
+"dependencies": {
+  "some-service-startos": "github:<org>/some-service-startos#next"
+}
+```
+
+### Track the iteration branch, and let the lockfile do the pinning
+
+Pin the git dependency at **`#next`** (or `#next/<base>` for a package with parallel lines) rather than at the base branch, so your package compiles against the sibling's newest types instead of the last integrated ones.
+
+What makes a moving branch safe is the **lockfile**, not the specifier. `package-lock.json` records an exact commit, and CI installs with `npm ci`, so every build is reproducible. The branch only decides what a future `npm update` resolves _to_ — and that arrives as a reviewable lockfile diff rather than as a silent change.
+
+> [!WARNING]
+> `npm update` is a **no-op on a git-ref dependency**. npm considers `github:org/repo#next` already satisfied and will not re-fetch it, so the pin stays stale however many times you run it. To actually refresh: delete the git-resolved entries and their subtrees from `package-lock.json`, then `npm install` to re-resolve from `package.json`. That refreshes direct and transitive git dependencies together, which naming one package on the command line does not.
+
+### Read the lockfile diff as code review, not as a version bump
+
+Whether a sibling's code ends up in your `.s9pk` depends on how you import it, because the bundler tree-shakes what it can:
+
+- A **type-only** use (`typeof manifest`) sits in a type position and is erased entirely.
+- A **scalar constant** (a port number, a path) is inlined as its value; nothing else comes with it.
+- A **value object** pulls its whole reachable graph in. Importing one exported config object can drag an entire configuration spec into your package — and then a sibling's changes become your package's changes.
+
+So a lockfile diff that moves a sibling commit can change what ships. Check what actually landed:
+
+```sh
+start-cli s9pk inspect <package>.s9pk cat javascript.squashfs | unsquashfs -d out /dev/stdin
+```
+
+### Keep one copy of the SDK
+
+When a sibling pins an older `@start9labs/start-sdk` than yours, npm hoists two copies, and generic helpers start failing to type-check in ways that read as bugs in your own code — a payload "not assignable to type `never`" is the usual shape, because the imported value no longer structurally matches the generic it is being matched against.
+
+Force a single copy with an override, and remove it once the sibling catches up:
+
+```json
+"overrides": { "@start9labs/start-sdk": "<version>" }
+```

--- a/projects/start-sdk/docs/src/maintaining-a-package.md
+++ b/projects/start-sdk/docs/src/maintaining-a-package.md
@@ -14,6 +14,11 @@ Alongside the base sits **`next`** — a branch that is never deleted and keeps 
 
 [`syncNext.yml`](./project-structure.md#githubworkflows) keeps it honest: every push to the base is carried onto `next`, so it never falls behind what has already shipped. You do not have to create `next` yourself — the first run makes one at the base tip.
 
+**After `next` picks up the base, re-check the version it claims.** The base moves on its own, and it can land — and release — the very work `next` is carrying. Two things go wrong, and neither announces itself:
+
+- **The version is already published.** If `next` claimed `1.36.0:2` while the base was on `:1`, and the base has since released `1.36.0:2`, publishing `next` ships _different bytes under a live version_. Query the registry for the package's existing versions and take the next free revision.
+- **The release notes describe work that already shipped.** When the base landed the same submodule bump or upstream refresh independently, `next`'s own commit is a no-op after the sync, but its notes still announce the fix. Drop the redundant commit and rewrite the notes to describe only what this version adds on top.
+
 ### Merge a long-lived branch with a merge commit, never a squash
 
 This is the one branch rule that is easy to get wrong, because the habit runs the other way.

--- a/projects/start-sdk/docs/src/notifications.md
+++ b/projects/start-sdk/docs/src/notifications.md
@@ -2,7 +2,7 @@
 
 Notifications are messages your service can post to the StartOS notifications panel — the same panel where StartOS shows backup-completion notices, install failures, and similar OS-generated events. Use them **sparingly**, only for information the user genuinely needs to know about — most commonly that a long-running action has finished: a sync health check that finally passes, a lengthy reindex or migration completing. They are not a changelog feed or an activity log; the vast majority of what your service does should not produce one. If you need the user to _do_ something, use a [Task](./tasks.md) instead.
 
-The host attributes every notification to the calling service automatically — a package cannot post notifications on behalf of another package.
+StartOS attributes every notification to the calling service automatically — a package cannot post notifications on behalf of another package.
 
 ## Plain Notification
 

--- a/projects/start-sdk/docs/src/recipes.md
+++ b/projects/start-sdk/docs/src/recipes.md
@@ -2,7 +2,7 @@
 
 This is the primary entry point for StartOS service packaging — for both you and your AI coding agent. Each recipe describes a common packaging pattern, names the SDK constructs involved, links to reference pages for API details, and points to real packages for working code. Your agent reads these to understand what to build; you read them to understand what to ask for.
 
-If you're using [Claude Code](https://claude.com/claude-code) (recommended), point your agent at the recipe for your task and let it follow the reference and package links from there.
+If you're using [Claude Code](https://claude.com/claude-code) (recommended), point your agent at the recipe for your objective and let it follow the reference and package links from there.
 
 > **Starting a brand-new package?** Scaffold it first with `start-cli s9pk init-package "My Service"`, then work the generated `TODO.md` from top to bottom — don't hand-assemble files by copying another package. If you're wrapping an existing upstream Docker image (the common case), read [Package a Prebuilt Docker Image](recipe-prebuilt-image.md) before you start.
 

--- a/projects/start-sdk/docs/src/workflow.md
+++ b/projects/start-sdk/docs/src/workflow.md
@@ -1,12 +1,12 @@
 # Development Workflow
 
-This page covers how to _behave_ while working on a package — the disciplines that apply to every change, no matter which SDK constructs you touch. The rest of the guide describes _what_ to build; this page describes _how_ to work while building it. These rules are the canonical home for the working discipline an AI coding agent should follow on every task.
+This page covers how to _behave_ while working on a package — the disciplines that apply to every change, no matter which SDK constructs you touch. The rest of the guide describes _what_ to build; this page describes _how_ to work while building it. These rules are the canonical home for the working discipline an AI coding agent should follow on every change.
 
 ## Keep README and instructions in sync
 
 `README.md` and `instructions.md` are part of the package, not afterthoughts, and they track different things. `README.md` is the package's technical reference, and the only one an AI support or administering agent reads — update it for any change to how the package is built, structured, or behaves (a new or renamed action, an added or removed volume/port/interface/dependency, a changed default, a new feature or limitation). `instructions.md` is the end-user guide — update it whenever a change affects what the user sees or does. When a change touches both, update both in the same change.
 
-Apply this loop on every task:
+Apply this loop on every change:
 
 1. Make the code change.
 2. Open `README.md` and `instructions.md`. Read what each says about the area you touched.

--- a/projects/start-sdk/docs/src/workflow.md
+++ b/projects/start-sdk/docs/src/workflow.md
@@ -29,6 +29,16 @@ See [Writing READMEs](./writing-readmes.md) and [Writing Instructions](./writing
 
 If `tsc`, a test, or the pack step fails — even on something unrelated to your change — the package does not pass. "Pre-existing" is not a pass condition; it is a signal that nobody has fixed the problem yet. Either fix it, or stop and flag it explicitly. Never report a run as green when any check was red.
 
+### Reinstall before believing a type error
+
+A `node_modules` that has drifted from `package-lock.json` produces errors that read exactly like real bugs in your code — a nullability complaint, a mismatch deep inside a dependency's own typings. Run `npm ci` and check whether the error survives before you spend time on it, and certainly before you change code to satisfy it.
+
+The same drift ruins `git bisect`. If `node_modules` is shared across the checkouts you're bisecting — symlinked in, or left in place while the tree moves under it — every commit is judged against the same broken typings, and the bisect lands on an innocent commit with total confidence.
+
+## Work one package at a time
+
+Finish a change in one package before starting the next. When several packages need the same edit, that is a deliberate decision to make once and then apply, not a default to slip into: a mistake made in one package is a bug, and the same mistake cascaded across a fleet is an afternoon of reverts. Land the first one, confirm it builds and behaves, and only then propagate.
+
 ## Verify against reality, not against `tsc`
 
 A clean `tsc` and a successful `start-cli s9pk pack` prove the code type-checks and the package builds. They prove **nothing** about whether the service runs, the web UI loads, logins work, or data persists. Type-checking a credential flow that has never accepted a login, or a daemon that mounts the wrong path, passes just as green as one that works.

--- a/projects/start-sdk/docs/src/workflow.md
+++ b/projects/start-sdk/docs/src/workflow.md
@@ -79,6 +79,10 @@ A comment asserting what an SDK call does — in a package you're reading, in a 
 
 `merge(effects, {})` is the standing example. It has variously been described as rewriting the file, as cleaning or stripping it, and as a no-op against an existing one. Every reading was plausible; none was correct — see [What an Empty merge() Does](./file-models.md#what-an-empty-merge-does).
 
+### Fetch a package before reading it as a reference
+
+The same applies to a package you open to derive behavior from — a dependency's volume path, a credential scheme, a shared pattern, a version pin. Fetch it first. A checkout you cloned weeks ago shows code the package has since changed, and it will mislead you with total confidence: reading a dependency's API key after upstream dropped it produces an integration that type-checks, builds, and cannot work.
+
 ## Read the monorepo source only when the guide can't answer
 
 Your workspace's `start-technologies/` is a checkout of the whole Start9 monorepo, so the **SDK source** (`projects/start-sdk/lib`) and the **StartOS source** (`projects/start-os`, and the shared core in `shared-libs/`) are already on disk — behind the recipes, the reference pages, real packages, and the installed `@start9labs/start-sdk` types.


### PR DESCRIPTION
The guide covers making *a* change well and says nothing about keeping a package alive. Every packager using the shipped template meets these conventions whether or not anyone explains them — `syncNext.yml` creates a `next` branch on its first run — but they lived only in maintainers' private notes, where each reader rediscovered them by getting one wrong.

Adds **`maintaining-a-package.md`** (Getting Started, after Development Workflow):

- **Branches.** Base vs. `next`, and why a long-lived head branch takes a merge commit where a feature branch takes a squash. The rule turns on the head branch's *lifetime*, which is exactly what makes it easy to get backwards.
- **Parallel release lines.** `next/<base>`, why git's ref tree forces that slash order (a ref can't be both a file and a directory), and that every operation applies to every line.
- **Chasing upstream.** Verify the artifact resolves before pinning it; prereleases and the unreliable "Latest" badge; scrutiny scaled to the size of the jump; fork parents via `gh api … .parent.full_name` rather than the manifest's `upstreamRepo`, which names the upstream *software* and not the fork parent.
- **Sibling package dependencies.** Pin `#next` and let the lockfile do the pinning; `npm update` is a no-op on a git ref; which import shapes actually reach the shipped s9pk; the two-hoisted-SDK-copies type error and its `overrides` fix.

**`workflow.md`** gains two disciplines that belong with the per-change rules rather than the per-package ones: reinstall before believing a type error (and never bisect against a shared `node_modules`), and finish one package before starting the next.

### Scope

Deliberately generic. The multi-line section is illustrated with an anonymous package carrying `28.x`–`31.x` rather than naming ours, and nothing here encodes a specific package's version arithmetic or a registry's tier names — those aren't packaging doctrine and don't belong on a public site.

### Why live-docs

All of it is true of the shipped SDK and the template's current workflows, so it corrects the published site rather than describing something unreleased.

`git apply --check` of this commit against `origin/master` passes, so `docs-backport.yml` will apply cleanly — the existing live-docs↔master drift in `workflow.md` and `agent-context.md` is elsewhere in both files.

### Checks

`mdbook build` clean; the page renders, appears in the sidebar, and both cross-page anchors it links to (`project-structure.md#githubworkflows`, `versions.md#when-to-create-a-new-version-file`) exist in the rendered HTML. Prettier clean across the book.

The `agent-context.md` diff is one new table row — the rest is prettier reflowing the table to the new column width.