### PR TITLE
docs: replace the comment rules that were producing unreadable comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,12 @@ What `### Environment` carries, by project:
 
 ## Code style
 
-- **Comment only what the code can't say for itself.** Add a comment for a non-obvious mechanism, a deviation from convention, or a load-bearing subtlety — not to restate what the code plainly does. Keep it terse: say what needs saying and no more, and prefer cutting a comment to padding it.
+- **Comment only what the code can't say for itself.** Add a comment for a non-obvious mechanism, a deviation from convention, or a load-bearing subtlety — not to restate what the code plainly does. Try the rename or the restructure that would make the comment unnecessary first; it is almost always available, and it is always better.
+- **The comment you keep is plain prose — not a paragraph, and not shorthand.** One idea in a complete sentence: present tense, active voice with the actor named, condition before instruction, identifiers in backticks. `// The caller must hold the lock while mutating entries.` beats both a four-line essay and `// lock req'd — else races`. Read it aloud; if you can't say it, rewrite it clearer rather than shorter.
+- **Shorten by removing ideas, never by removing grammar.** Drop the second and third fact — the history, the alternative you rejected, the bug that prompted the change — and keep the articles, the verbs, and the small words that let a sentence parse. What you cut goes in the commit message, where it doesn't rot.
+- **Say what is true, not when you wrote it.** No `currently`, `new`, `for now`, or `temporary until X lands`; no `// was: …` changelog; no pointer at a PR, a ticket, or a caller. Git holds the history, and a `// TODO` belongs in an issue (see [Filing issues](#filing-issues)).
+- **Doc comments on a public surface are documentation, and they stay.** A `///` on an exported item, a JSDoc on an SDK type a package author reads in their editor — write those, keep them accurate, and hold them to the same voice as everything above.
+- **Fix the bad comments you pass.** They are already spread through this repo, and cleaning them up as you go is how they go away. In a file you are already editing: delete a comment the code now says, rewrite an unreadable one as a sentence, and cut a correct-but-three-ideas-long one down to its one idea. Leave a comment that is merely plainer than you would have written it, and check the code before deleting one that looks wrong — some encode a constraint the code can't show. Don't open files to hunt, and don't let the cleanup outgrow the change it rides on.
 
 ## Gotchas
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,22 +192,16 @@ the source of truth.
 
 ### Documentation & Comments
 
-**Rust:**
+The rule agents work from is [AGENTS.md § Code style](AGENTS.md#code-style), and it applies to people too. In short:
 
-- Add doc comments (`///`) to public APIs, structs, and non-obvious functions
-- Use `//` comments sparingly for complex logic that isn't self-evident
-- Comments should be shorthand, not prose. Most comments can say what they need to in a single line.
+- **Default to no comment.** Reach for the rename or the smaller function first — a name that needs a comment is the wrong name.
+- **Comment the _why_, never the _what_:** a non-obvious mechanism, a deviation from convention, a load-bearing subtlety.
+- **Write plain prose** — one idea, a complete sentence, present tense, the actor named. Not a paragraph, and not shorthand with the articles and verbs stripped out. Shorten by dropping ideas, never grammar; a comment nobody can read is worse than the paragraph it replaced.
+- **Keep it true.** Update or delete a comment when the code moves under it. History belongs in the commit message, and a task belongs in a GitHub issue rather than a `// TODO`.
 
-**TypeScript:**
+**Rust:** a `///` on a public item is documentation — write it, and hold it to the same voice. On a `#[ts(export)]` type it also generates the TypeScript binding, so editing one is never a comment-only change (see [`shared-libs/crates/start-core/AGENTS.md`](shared-libs/crates/start-core/AGENTS.md)).
 
-- Document exported functions and complex types with JSDoc
-- Keep comments focused on "why" rather than "what"
-
-**General:**
-
-- Don't add comments that just restate the code
-- Update or remove comments when code changes
-- TODOs should include context: `// TODO(username): reason`
+**TypeScript:** the same goes for JSDoc on an exported SDK surface, which package authors read in their editor. Elsewhere, a line restating the signature is noise.
 
 ## Commits / PRs
 

--- a/projects/start-registry/CONTRIBUTING.md
+++ b/projects/start-registry/CONTRIBUTING.md
@@ -59,7 +59,6 @@ Make sure `make start-registry-format-check` is clean before opening a PR.
 ## Conventions
 
 - **Rust 2024 edition**, formatted via `make start-registry-format` (rustfmt). Keep clippy clean.
-- **Comments:** default to none; clear names over prose. A comment is for a non-obvious _why_ only — one short line.
 - **API additions:** add subcommands in `registry/mod.rs`; use `with_call_remote::<CliContext>()` to expose them to the `start-registry` CLI and `with_about(...)` for help text. Tag admin-only commands with `with_metadata("admin", true)`.
 - **Schema changes:** changing `RegistryDatabase` / index types requires a migration in `shared-libs/crates/start-core/src/registry/migrations`.
 


### PR DESCRIPTION
## Why

`CONTRIBUTING.md` has been telling everyone **"Comments should be shorthand, not prose"** since #3115, and `projects/start-registry/CONTRIBUTING.md` says **"one short line"**. Both buy brevity by deleting grammar, and that is how a comment that is merely too long becomes one nobody can read:

```
// tz-naive dt -> UTC; DST fold => dup hr, keep 1st
```

The two failure modes are the same defect at different lengths. An essay buries one fact in narration; a telegram is what that essay becomes when someone asks for shorter. Neither is readable, and a rule that only pushes toward "shorter" moves code from the first to the second.

## What changed

**`AGENTS.md` § Code style** — the agent-binding rule, rewritten around that pair. One idea, a complete sentence, present tense, active voice with the actor named, condition before instruction. **Shorten by removing ideas, never by removing grammar** — the history, the rejected alternative, and the bug that prompted the change go in the commit message, where they don't rot.

**`CONTRIBUTING.md` § Documentation & Comments** — keeps a short human-facing summary and points at `AGENTS.md` for the rule, per the split `AGENTS.md` already describes. Three substantive changes beyond wording:

- **Doc comments on a public surface stay.** A `///` on an exported item, or JSDoc on an SDK type a package author reads in their editor, is documentation. A strict reading of "default to none" put those at risk, and on a `#[ts(export)]` type a `///` is also generated output — the note now points at `shared-libs/crates/start-core/AGENTS.md`.
- **A `// TODO` becomes an issue.** The old `// TODO(username): reason` rule contradicted both § Filing issues and the SDK guide's "bugs and feature requests are GitHub issues, not files in the repo".
- **Fix the bad comments you pass**, scoped to files you are already editing, with an explicit instruction to check the code before deleting one that looks wrong — some encode a constraint the code cannot show, and one of those is load-bearing here (`projects/start-os/AGENTS.md` points at a comment in `start-container.rs`).

**`projects/start-registry/CONTRIBUTING.md`** — the duplicate comment bullet is deleted. `AGENTS.md` line 7 says a scope's docs "must not repeat anything already stated at a higher scope", and this one both repeated the root rule and carried the "one short line" cap.

## Source

Distilled from [Google's developer documentation style guide](https://developers.google.com/style) — chiefly [voice and tone](https://developers.google.com/style/tone) ("choppy or long-winded sentences" are named as one defect, and "if you come across a sentence that's awkward or confusing when spoken, consider whether you can make it more conversational"), [jargon](https://developers.google.com/style/jargon), [global audience](https://developers.google.com/style/translation), and [timeless documentation](https://developers.google.com/style/timeless-documentation).

The matching change to the guidance helix itself works from, and a comment pass in its code-review skill, is in Start9Labs/helix.

## Verification

`prettier --check` clean on all three files at the repo's pinned 3.8.3. Docs only — no code paths touched.
