### PR TITLE
feat(start-wrt): ship the 6in4 and 6rd packages in the image

### DIFF
--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   RPC response, so an open tab notices within seconds of its next request even
   when the update restarted the daemon too quickly to drop a connection; pages
   that make no requests while idle re-check every 30 seconds.
+- **6in4 tunnels can now be configured on the router.** The `6in4` protocol
+  and the SIT kernel module it needs now ship in the image, so an IPv6 tunnel
+  from a broker such as Hurricane Electric can be set up over SSH — useful for
+  reaching IPv6 on an ISP that provides none. There is no UI for this yet.
+  Previously these packages had to be built and sideloaded by hand after every
+  update, since a sysupgrade does not preserve separately installed packages.
 
 ### Changed
 
@@ -101,6 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   service goes live.
 
 ### Fixed
+
+- **The WAN IPv6 "6RD" mode now works.** Selecting it wrote a valid
+  configuration, but the image shipped without the `6rd` protocol handler or
+  the SIT kernel module it depends on, so the WAN interface simply came up
+  without IPv6 — with nothing in the UI to indicate why. Both now ship.
 
 - **Disabled outbound VPNs are no longer offered as a Security Profile's
   outbound route.** The VPN picker on the profile's WAN / Internet tab listed

--- a/projects/start-wrt/build/openwrt.diffconfig
+++ b/projects/start-wrt/build/openwrt.diffconfig
@@ -48,6 +48,10 @@ CONFIG_OPENSSL_WITH_SEED=y
 CONFIG_OPENSSL_WITH_SRP=y
 CONFIG_OPENSSL_WITH_TLS13=y
 CONFIG_OPENSSL_WITH_WHIRLPOOL=y
+# IPv6-over-IPv4 tunnels. Both pull in kmod-sit (and kmod-iptunnel{,4}); 6rd
+# also supplies the netifd proto handler the WAN IPv6 "6RD" mode writes.
+CONFIG_PACKAGE_6in4=y
+CONFIG_PACKAGE_6rd=y
 CONFIG_PACKAGE_MAC80211_DEBUGFS=y
 CONFIG_PACKAGE_MAC80211_MESH=y
 # CONFIG_PACKAGE_TAR_POSIX_ACL is not set

--- a/projects/start-wrt/docs/src/wan.md
+++ b/projects/start-wrt/docs/src/wan.md
@@ -33,6 +33,9 @@ For SLAAC and DHCPv6, an optional **IPv6 Prefix** field lets you request a speci
 > [!NOTE]
 > IPv6 cannot be set to Disabled while any enabled [Published Ports](published-ports.md) rules use IPv6 — the option is grayed out with a hint. Remove or disable those rules first.
 
+> [!TIP]
+> A **6in4** tunnel is another way to reach IPv6 on an ISP that provides none. Unlike 6RD, which your ISP has to offer, a 6in4 tunnel comes from a third-party broker such as Hurricane Electric and works on any connection with a public IPv4 address — but not behind [CGNAT](cgnat.md), which blocks the protocol the tunnel uses. There is no UI for it; the `6in4` package ships in the image and is configured over [SSH](ssh.md) by adding an interface to `/etc/config/network`.
+
 The WAN summary shows an IPv6 status badge indicating whether IPv6 is Enabled or Disabled, along with its mode (SLAAC, DHCPv6, Static, or 6RD).
 
 ## DNS


### PR DESCRIPTION
## What

Adds `CONFIG_PACKAGE_6in4=y` and `CONFIG_PACKAGE_6rd=y` to the StartWRT OpenWrt diffconfig, so both IPv6-over-IPv4 tunnel protocols ship in the image.

## Why

**6RD was already selectable and already broken.** The WAN IPv6 `6rd` mode has been in the UI and the backend since 1.0.1 (`web/src/app/routes/wan/routes/ipv6/utils.ts`, `backend/ctrl/src/wan.rs`), and it writes a valid `/etc/config/network`. But the image at `start-wrt/v1.0.1` carried neither the `6rd` netifd proto handler nor `kmod-sit`, so netifd had no handler for the proto it was given and the WAN interface simply came up without IPv6 — with nothing in the UI to indicate why.

**6in4 rides along.** It needs the same `kmod-sit` (and `kmod-iptunnel{,4}`), and it covers the case 6RD can't: 6RD requires the ISP to offer it, while a 6in4 tunnel comes from a third-party broker such as Hurricane Electric and works over any public IPv4 address. Getting it onto a router previously meant building and sideloading the packages by hand *after every update*, since a sysupgrade does not preserve separately installed packages.

There is no UI for 6in4 yet — it is configured over SSH.

## Changes

- `build/openwrt.diffconfig` — the two package selections, with a comment noting the shared `kmod-sit` dependency and which half supplies the netifd proto handler.
- `docs/src/wan.md` — a TIP under the IPv6 section covering what 6in4 is, how it differs from 6RD, that it does not work behind CGNAT, and that it is SSH-configured.
- `CHANGELOG.md` — an `### Added` entry for 6in4 and a `### Fixed` entry for 6RD, both under the unreleased `## [1.0.2]`.

## Notes for review

- **Changelog placement**: origin has tags only through `start-wrt/v1.0.1`, so `1.0.2` is unreleased and both entries go under the existing heading. No manifest bump — this is a fix plus an additive package, and `1.0.2` already covers that tier.
- **6RD is a genuine `### Fixed`**, not a fix to an unreleased feature: `git show start-wrt/v1.0.1` confirms the mode shipped to users while the diffconfig at that tag had no `6rd`/`6in4`/`sit` entries.
- **No CI `paths:` change needed** — no `build.mk` prerequisite moved.
- Image build not run locally (hours); the diffconfig lines are ordinary upstream OpenWrt package symbols, so CI's image job is the real check here.
