### PR TITLE
docs: label PRs with the project(s) they modify

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,11 @@ What `### Environment` carries, by project:
 - `brochure` — page URL, browser and OS, and the registry being browsed
 - `start-docs` — page URL, which book, and the source file under `projects/<product>/docs/`
 
+## Opening PRs
+
+- **Label every PR with the project(s) it modifies.** Nothing labels it for you: [`issue-triage.yml`](.github/workflows/issue-triage.yml) is bound to `issues:` alone, and no workflow reads a PR's diff. Pass them when you open it — `gh pr create --label StartOS --label StartSDK` — or add them after with `gh pr edit <n> --add-label repo`. Take them from the same set as an issue, listed under [Filing issues](#filing-issues); `gh` fails on a label the repo doesn't have, and the casing is matched literally.
+- **The diff decides, so a PR takes as many labels as it needs.** An issue carries the one product a defect surfaces in; a PR carries every project whose files it changes, because that is what tells a reviewer and a release what a merge can break. Build, CI, and release tooling — `.github/`, `build/`, `scripts/`, `Makefile`, `debian/`, `apt/`, and the repo-root docs — is `repo`. A `shared-libs/` change has no label of its own: label the products whose behavior it changes.
+
 ## Code style
 
 - **Comment only what the code can't say for itself.** Add a comment for a non-obvious mechanism, a deviation from convention, or a load-bearing subtlety — not to restate what the code plainly does. Try the rename or the restructure that would make the comment unnecessary first; it is almost always available, and it is always better.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -234,6 +234,8 @@ docs: update CONTRIBUTING.md with style guidelines
 refactor(sdk): simplify package validation logic
 ```
 
+**Label a PR with the project(s) it modifies**, so a reviewer can see what a merge can break. Nothing applies them for you; the label set and the rule are in [AGENTS.md § Opening PRs](AGENTS.md#opening-prs).
+
 ## Licensing
 
 This repository is MIT. By contributing you agree your work is licensed under


### PR DESCRIPTION
No PR in this repo carries a label today, and nothing applies one: `issue-triage.yml` is bound to `issues:` alone and no workflow reads a PR's diff. This writes the convention down.

New `## Opening PRs` section in the root `AGENTS.md`, next to `## Filing issues` so the two share one label vocabulary:

- label every PR with the project(s) it modifies, passed on `gh pr create --label` or added with `gh pr edit --add-label`
- the diff decides, so a PR takes as many labels as it needs — unlike an issue, which carries the one product a defect surfaces in
- tooling and root docs are `repo`; a `shared-libs/` change has no label of its own, so it takes the label of the products whose behavior it changes

`CONTRIBUTING.md` § Commits / PRs gets a one-line human-facing pointer, mirroring how § Code Style Guidelines points at `AGENTS.md § Code style`.

This PR is labeled `repo` under its own rule.