### PR TITLE
fix(ci): run pull-request checks when a draft is marked ready

### DIFF
--- a/.github/workflows/start-cli.yaml
+++ b/.github/workflows/start-cli.yaml
@@ -47,6 +47,9 @@ on:
       # today, but this guards a README or future docs added under the allowlist.)
       - '!**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*

--- a/.github/workflows/start-registry.yaml
+++ b/.github/workflows/start-registry.yaml
@@ -45,6 +45,9 @@ on:
       # subtree today, but this guards a README or future docs under the allowlist.)
       - '!**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*

--- a/.github/workflows/start-tunnel.yaml
+++ b/.github/workflows/start-tunnel.yaml
@@ -52,6 +52,9 @@ on:
       # projects/start-tunnel/docs/**) shouldn't trigger a build.
       - '!**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*

--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -49,6 +49,9 @@ on:
       # projects/start-wrt/docs/**) shouldn't trigger a build.
       - '!**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*

--- a/.github/workflows/startos-iso.yaml
+++ b/.github/workflows/startos-iso.yaml
@@ -76,6 +76,9 @@ on:
       # projects/start-os/docs/**) shouldn't trigger a build.
       - '!**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,9 @@ on:
     paths-ignore:
       - '**/*.md'
   pull_request:
+    # The jobs below skip drafts, and `ready_for_review` is not a default
+    # activity type, so without it a draft marked ready is never checked.
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - master
       - integration/*


### PR DESCRIPTION
Every `pull_request` workflow here guards its jobs with `if: github.event.pull_request.draft != true`, and `pull_request` with no `types:` listens for `opened`, `synchronize` and `reopened` only. Marking a draft ready for review is the `ready_for_review` activity type, which none of them listen for.

So a draft PR gets one run with every job skipped, and marking it ready produces no run at all. The PR then sits with a skipped-and-therefore-green check that never executed, until somebody happens to push another commit.

Measured on a scratch repo carrying the same trigger shape as `test.yaml`:

| | run on the draft | run when marked ready |
| --- | --- | --- |
| before | 1 run, job `skipped` | none |
| after | 1 run, job `skipped` | 1 run, job `success` |

The six workflows changed are the ones that both trigger on `pull_request` and carry the draft guard: `test.yaml`, `start-cli.yaml`, `start-registry.yaml`, `start-tunnel.yaml`, `start-wrt.yaml`, `startos-iso.yaml`. Listing `types:` explicitly means naming the three defaults alongside the new one; the `branches:` and `paths:` filters are untouched, so a draft marked ready is filtered exactly as a push to it would be.

Nobody has used a draft PR in this repo recently, which is why the hole has gone unnoticed. It is about to matter: helix is being taught to open the PRs it writes for an issue as drafts and mark them ready only once their code review comes back clean (Start9Labs/helix), and without this those PRs would reach a reviewer having never been built or tested.
