### PR TITLE
docs(start-os): wait for Backup Complete before unplugging a backup drive

### DIFF
--- a/projects/start-os/docs/src/backup-create.md
+++ b/projects/start-os/docs/src/backup-create.md
@@ -23,6 +23,8 @@ Back up your server's data to a physical drive or a network folder.
 
 1. Upon completion, StartOS issues a backup report, indicating which services were backed up, as well as any errors.
 
+1. Wait for the `Backup Complete` notification before unplugging a backup drive. StartOS writes out the last of the backup and unmounts the drive before raising that notification, so the drive is safe to remove once it appears. The `Backup Progress` card reads `Complete` first, while StartOS is still finishing — the notification is the one to wait for.
+
 1. Backups are differential — each new backup to the same target overwrites the previous one. To maintain multiple backup points, use multiple backup targets.
 
 1. The backup targets list shows the free space available on each drive and network folder, so you can confirm your backup will fit before you start.


### PR DESCRIPTION
## What this documents

Nothing in the published book said whether it is safe to disconnect a backup drive when a backup finishes, so this adds one item to `## Important Info` on **Creating Backups**:

> Wait for the `Backup Complete` notification before unplugging a backup drive. StartOS writes out the last of the backup and unmounts the drive before raising that notification, so the drive is safe to remove once it appears. The `Backup Progress` card reads `Complete` first, while StartOS is still finishing — the notification is the one to wait for.

## Why it is true

`perform_backup` ends at `backup_bulk.rs:480` with `backup_guard.save_and_unmount().await?`, and its return value is the *argument* to `status_guard.handle_result(...)`, which issues the notification at `:75-89` — so the unmount is driven to completion first, with no `tokio::spawn` in between. `save_and_unmount` (`disk/mount/backup.rs:240-263`) runs `sync_directory` on the encrypted mount, which routes through `FUSE_FSYNCDIR` to backup-fs's `flush_all_dirty` — a `sync_all` per file plus a `syncfs` of the target filesystem — and only then unmounts the encrypted layer and the drive.

Measured on a StartOS `0.4.0` VM with a shim on `umount` capturing the syscall, against the notification's `createdAt` in the database:

| target | drive `umount` returned | notification `createdAt` | gap |
| --- | --- | --- | --- |
| physical drive (ext4) | `20:41:03.5625` | `20:41:03.5797` | 17.2 ms |
| network folder (CIFS) | `20:37:01.9315` | `20:37:01.9454` | 13.9 ms |

At the instant the notification became visible: zero backup mounts in `/proc/mounts`, the filesystem read back `clean`, and the backup was intact on the target.

## Why `live-docs` and not `master`

Root `AGENTS.md` requires that anything merged here is already true of the *published* software. `backup_bulk.rs`, `disk/mount/backup.rs`, `disk/mount/guard.rs`, `progress.component.ts` and the `i18n.yaml` strings are **byte-identical** at `start-os/v0.4.0`, `start-os/v0.4.0.1` and `master` (verified by blob hash), so this describes the release the site serves. It is a documentation gap about shipped behaviour, not a book change accompanying code, so it does not belong on `master` — the backport will take it there.

## Review notes

A review pass caught three things in my first draft, all fixed before this commit: it called the UI element a "progress bar" (it is the `Backup Progress` card — `tuiProgressBar` appears nowhere in the backups route); it quoted the card as reading `complete` when `text-transform: capitalize` renders `Complete`; and it said the card reads complete "a moment earlier", which promises a bound the code does not give — the flush between the two is O(open files + dirty inodes) fsync barriers plus a device writeback drain, which on a slow USB target is not a moment.

Two things I deliberately left out, flagging them here rather than deciding alone:

- **The failure path is not covered.** If a backup errors, the unmount happens via `Drop` + `tokio::spawn` (`disk/mount/backup.rs:265-278`), so `Backup Failed` is written *before* the unmount is initiated. I did not measure that margin, so I did not want to put advice for it in front of users. If you want a line there, "shut the server down before unplugging" is the conservative one.
- **Where the notification appears.** The toast only says `New notifications` with a `View` link (`notifications-toast.component.ts:16-22`); the words `Backup Complete` are on the `/notifications` route. The book has no established noun for that page, so I did not invent one.

## Related

While verifying this I found and filed #3771 — `Arc<T>::unmount` (`disk/mount/guard.rs:39-44`) returns `Ok(())` without unmounting when `try_unwrap` fails, so with a concurrent mount of the same target `save_and_unmount()` can call `umount` zero times and still report `Backup Complete`. Reproduced deterministically from the CLI; the web UI's paths mount only transiently and a tight-loop race did not reproduce. That does not change what this page should say for a normal backup, and the text deliberately does not mention it.
