### PR TITLE
fix(start-os): keep the decoded block backup-fs just read

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -62,6 +62,26 @@ file tracks notable changes since the move to the monorepo.
 
 - Trim whitespace on form inputs.
 
+- **Restoring a service from a backup is many times faster.** A restore reads
+  the service's whole package out of the backup, and the encrypted backup
+  filesystem stores file contents as sealed 1 MiB blocks that it fetches and
+  decodes whole. It kept none of them, so each 8 KiB read along the package
+  fetched and decoded the enclosing block over again — dragging roughly 72 GB
+  across a network share to deliver a 480 MB package, and turning a restore
+  that should take a couple of minutes into 42. A block is now decoded once
+  for the run of reads inside it, which for reading a file start to finish is
+  once per block.
+
+- **A service that reads back a region of a file it has only partly written
+  no longer fails its backup.** Inside a backup or restore, a service's own
+  procedure works against the encrypted backup filesystem directly, and a
+  program that writes at one offset and then reads a little further on —
+  a database extending a file, an image being assembled — asked for bytes
+  that the pending write had not reached. That read failed with an I/O
+  error, and closing the file afterwards left the whole backup filesystem
+  unresponsive, so the operation hung rather than finishing. Such a read
+  now returns the zeros it should.
+
 - **Helper processes a service starts are cleared away once they finish.** A
   service that shells out to other programs — a media downloader calling
   `yt-dlp` and `ffmpeg`, an agent running tool subprocesses — orphans a helper

--- a/projects/start-os/backup-fs/DESIGN.md
+++ b/projects/start-os/backup-fs/DESIGN.md
@@ -56,6 +56,20 @@ atomically renamed into place. This is the core of the redesign:
   a huge file is many independent blocks written/verified in parallel.
 - **Sparse files** cost nothing for holes — unwritten blocks have no file on
   disk and read back as zeros.
+- **A decoded block is kept for the reads that follow it.** A handle from
+  `open` is served `FOPEN_DIRECT_IO` and the backing store is read
+  `O_DIRECT`, so a read of that handle reaches us at no more than the
+  caller's own size, with no page cache and no readahead behind it. (The
+  transport caps one request at just under a chunk, so a 1 MiB read arrives
+  as two.) Reading 8 KiB at a time would otherwise fetch and decode the whole
+  enclosing block once per read — 154× the file's own bytes off the backing
+  store, since each fetch carries the block's parity shards too. One block is
+  held per open inode, shared by
+  every handle on it, and freed when the last one closes; a file being read
+  therefore costs one block of memory. A write moves the block into the dirty
+  map and takes it out of the cache, and a flush drops a cached block its
+  trailing-block prune is about to unlink, so no cached copy outlives the
+  version on disk.
 
 ## Cache-deadlock avoidance
 

--- a/projects/start-os/backup-fs/src/contents.rs
+++ b/projects/start-os/backup-fs/src/contents.rs
@@ -1,19 +1,21 @@
 //! Per-file content access.
 //!
-//! [`Contents`] presents a regular file's byte stream over one of two
+//! [`Contents`] presents a regular file's byte stream over one of three
 //! storage bodies:
 //!
 //! * **Inline** — a small file (≤ the inline threshold,
 //!   [`Controller::inline_threshold`]) whose bytes live directly in its inode
 //!   record in the log. No separate content file at all: a tiny file costs
 //!   zero extra backing-store objects.
+//! * **Packed** — a file up to [`Controller::pack_max`], stored as a single
+//!   extent in the shared content log rather than a block file of its own.
 //! * **Blocks** — a larger file split into [`CHUNK_SIZE`] sealed block files
 //!   (see [`crate::blockstore`]), read-modify-written a whole block at a time
 //!   so a partial write never rewrites a sub-region of an on-disk object.
 //!
-//! A file is created inline and transitions to block storage the first time
-//! it grows past the threshold (one-way; a file that was large stays
-//! block-backed even if later truncated small).
+//! A file is created inline and moves up to the smallest tier that can hold
+//! it the first time it outgrows its current one (one-way; a file that was
+//! large stays block-backed even if later truncated small).
 
 use std::collections::BTreeMap;
 use std::io;
@@ -74,7 +76,19 @@ enum Body {
         dirty_bytes: usize,
         /// Blocks believed to exist on disk (for trailing-block prune).
         disk_blocks: u64,
+        /// The most recently decoded clean block (see [`CachedBlock`]).
+        cached: Option<CachedBlock>,
     },
+}
+
+/// One decoded block, kept so a run of reads inside it decodes once.
+///
+/// A block is never both dirty and cached.
+struct CachedBlock {
+    idx: u64,
+    /// The block exactly as stored, neither clipped nor padded to the file's
+    /// current size.
+    bytes: Vec<u8>,
 }
 
 pub struct Contents {
@@ -138,6 +152,7 @@ impl Contents {
                 dirty: BTreeMap::new(),
                 dirty_bytes: 0,
                 disk_blocks: blockstore::block_count(inode.attrs.size),
+                cached: None,
             },
             FileData::Directory(_) => return BkfsResult::errno(libc::EISDIR),
             _ => return BkfsResult::errno(libc::EINVAL),
@@ -199,7 +214,7 @@ impl Contents {
         Ok(())
     }
 
-    fn read_blocks_at(&self, buf: &mut [u8], offset: u64) -> BkfsResult<()> {
+    fn read_blocks_at(&mut self, buf: &mut [u8], offset: u64) -> BkfsResult<()> {
         let mut filled = 0usize;
         while filled < buf.len() {
             let pos = offset + filled as u64;
@@ -207,9 +222,12 @@ impl Contents {
             let block = self.load_block(idx)?;
             let take = (buf.len() - filled).min(CHUNK_SIZE as usize - within);
             let dst = &mut buf[filled..filled + take];
-            let avail = block.len().saturating_sub(within);
-            let copy = take.min(avail);
-            dst[..copy].copy_from_slice(&block[within..within + copy]);
+            // A hole, a file grown without a write, and a short pending write
+            // all leave a block that stops before `within`, where indexing it
+            // would panic.
+            let src = block.get(within..).unwrap_or_default();
+            let copy = take.min(src.len());
+            dst[..copy].copy_from_slice(&src[..copy]);
             for b in &mut dst[copy..] {
                 *b = 0;
             }
@@ -228,22 +246,33 @@ impl Contents {
         }
     }
 
-    fn load_block(&self, idx: u64) -> BkfsResult<Vec<u8>> {
+    /// The stored bytes of block `idx`, decoded from the backing store only
+    /// when neither the dirty map nor the cache already holds it. The slice
+    /// is neither clipped nor padded to the block's logical length, so a
+    /// caller must bound it to the file's size itself.
+    fn load_block(&mut self, idx: u64) -> BkfsResult<&[u8]> {
         let Body::Blocks {
-            content_id, dirty, ..
-        } = &self.body
+            content_id,
+            dirty,
+            cached,
+            ..
+        } = &mut self.body
         else {
-            return Ok(Vec::new());
+            return Ok(&[]);
         };
-        if let Some(buf) = dirty.get(&idx) {
-            return Ok(buf.clone());
+        if !dirty.contains_key(&idx) && cached.as_ref().is_none_or(|c| c.idx != idx) {
+            let bytes = blockstore::read_block(&self.ctrl, *content_id, idx)?.unwrap_or_default();
+            *cached = Some(CachedBlock { idx, bytes });
         }
-        let valid = self.valid_len(idx);
-        let mut buf = blockstore::read_block(&self.ctrl, *content_id, idx)?.unwrap_or_default();
-        if buf.len() < valid {
-            buf.resize(valid, 0);
-        }
-        Ok(buf)
+        Ok(match dirty.get(&idx) {
+            Some(buf) => buf,
+            // The fill above already matched the index, so this check is
+            // deliberate redundancy against a future edit.
+            None => cached
+                .as_ref()
+                .filter(|c| c.idx == idx)
+                .map_or(&[], |c| c.bytes.as_slice()),
+        })
     }
 
     // ── writes ─────────────────────────────────────────────
@@ -345,6 +374,7 @@ impl Contents {
             dirty,
             dirty_bytes,
             disk_blocks: 0,
+            cached: None,
         };
         self.inode.attrs.contents = FileData::File(content_id);
         Ok(())
@@ -362,7 +392,10 @@ impl Contents {
             let take = (buf.len() - written).min(CHUNK_SIZE as usize - within);
             let valid = self.valid_len(idx);
             let Body::Blocks {
-                dirty, dirty_bytes, ..
+                dirty,
+                dirty_bytes,
+                cached,
+                ..
             } = &mut self.body
             else {
                 unreachable!()
@@ -372,9 +405,15 @@ impl Contents {
                     *dirty_bytes -= b.len();
                     b
                 }
+                // Taking the cached copy keeps this block out of the cache
+                // while it is dirty.
                 None => {
-                    let mut b =
-                        blockstore::read_block(&self.ctrl, content_id, idx)?.unwrap_or_default();
+                    let mut b = match cached.take_if(|c| c.idx == idx) {
+                        Some(c) => c.bytes,
+                        None => {
+                            blockstore::read_block(&self.ctrl, content_id, idx)?.unwrap_or_default()
+                        }
+                    };
                     b.truncate(valid);
                     b
                 }
@@ -415,6 +454,7 @@ impl Contents {
             dirty,
             dirty_bytes,
             disk_blocks: 0,
+            cached: None,
         };
         self.inode.attrs.contents = FileData::File(content_id);
         Ok(())
@@ -574,8 +614,13 @@ impl Contents {
                 dirty,
                 dirty_bytes,
                 disk_blocks,
+                cached,
             } => {
                 *dirty_bytes = 0;
+                // The prune below unlinks every block at or past `required`.
+                // Forget a cached one so that growing the file again reads
+                // it back as the hole it has become.
+                cached.take_if(|c| c.idx >= required);
                 (*content_id, std::mem::take(dirty), *disk_blocks)
             }
             _ => return Ok(()),

--- a/projects/start-os/backup-fs/src/tests.rs
+++ b/projects/start-os/backup-fs/src/tests.rs
@@ -1,5 +1,5 @@
 use std::future::Future;
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
@@ -1629,6 +1629,186 @@ fn sparse_file_omits_hole_blocks() {
             assert_eq!(
                 &got[2 * CHUNK_OFFSET as usize + 123..][..18],
                 b"hello sparse world"
+            );
+        },
+        None,
+    );
+}
+
+/// A run of reads inside one block decodes that block once. Deleting both
+/// block files partway through is what makes the cache visible: the reads
+/// that follow keep working only if they are served from the decoded copy,
+/// while the block that was never read comes back as the hole it now is.
+#[test_log::test]
+fn repeated_reads_in_one_block_decode_it_once() {
+    let data = TempDir::new("backupfs_data").unwrap();
+    let chunk = CHUNK_OFFSET as usize;
+    let mut payload = vec![0u8; 2 * chunk];
+    pattern_fill(0, &mut payload);
+
+    let ino = capture(data.path(), "ohea", move |mnt| {
+        fs::write(mnt.join("two_blocks"), &payload).unwrap();
+        fs::metadata(mnt.join("two_blocks")).unwrap().ino()
+    });
+
+    let ctrl = Controller::new(opts(data.path(), "ohea")).unwrap();
+    let block0 = ctrl.resolve_block_path(ContentId(ino), 0);
+    let block1 = ctrl.resolve_block_path(ContentId(ino), 1);
+    drop(ctrl);
+
+    with_backupfs(
+        data.path(),
+        "ohea".to_owned(),
+        |mnt| {
+            let mut f = fs::File::open(mnt.join("two_blocks")).unwrap();
+            let mut head = vec![0u8; 4096];
+            f.read_exact(&mut head).unwrap();
+            pattern_check(0, &head);
+
+            fs::remove_file(&block0).unwrap();
+            fs::remove_file(&block1).unwrap();
+
+            let mut rest = vec![0u8; chunk - 4096];
+            f.read_exact(&mut rest).unwrap();
+            pattern_check(4096, &rest);
+
+            let mut second = vec![0u8; chunk];
+            f.read_exact(&mut second).unwrap();
+            assert!(
+                second.iter().all(|&b| b == 0),
+                "block 1 was never read, so its deleted file must read back as a hole"
+            );
+        },
+        None,
+    );
+}
+
+/// Reading the gap after a pending write reads zeros. The written block holds
+/// only the bytes written so far, so a read landing past them has no stored
+/// byte to copy — and indexing the block there panics, which poisons the
+/// file's lock and, once the file is closed, the whole session's.
+#[test_log::test]
+fn read_past_a_short_pending_write_reads_zeros() {
+    let data = TempDir::new("backupfs_data").unwrap();
+    let chunk = CHUNK_OFFSET;
+
+    with_backupfs(
+        data.path(),
+        "ohea".to_owned(),
+        move |mnt| {
+            let mut f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(mnt.join("short_dirty"))
+                .unwrap();
+            // Two 100-byte writes a block apart. Both blocks stay in the
+            // dirty map — well under the write-buffer budget — and the
+            // second carries the file's size past the first.
+            f.seek(SeekFrom::Start(5 * chunk)).unwrap();
+            f.write_all(&[0xCDu8; 100]).unwrap();
+            f.seek(SeekFrom::Start(6 * chunk)).unwrap();
+            f.write_all(&[0xCDu8; 100]).unwrap();
+
+            let mut buf = vec![0xFFu8; 4096];
+            f.seek(SeekFrom::Start(5 * chunk + 32768)).unwrap();
+            f.read_exact(&mut buf).unwrap();
+            assert!(
+                buf.iter().all(|&b| b == 0),
+                "the gap after a pending write must read as zeros"
+            );
+
+            f.seek(SeekFrom::Start(5 * chunk)).unwrap();
+            f.read_exact(&mut buf[..150]).unwrap();
+            assert_eq!(&buf[..100], &[0xCDu8; 100]);
+            assert!(buf[100..150].iter().all(|&b| b == 0));
+        },
+        None,
+    );
+}
+
+/// A write into a block that has already been read supersedes the decoded
+/// copy — both while the write is still pending and after an fsync has
+/// written it out and emptied the dirty map.
+#[test_log::test]
+fn write_supersedes_a_previously_read_block() {
+    let data = TempDir::new("backupfs_data").unwrap();
+    let mut payload = vec![0u8; 2 * CHUNK_OFFSET as usize];
+    pattern_fill(0, &mut payload);
+
+    with_backupfs(
+        data.path(),
+        "ohea".to_owned(),
+        move |mnt| {
+            let path = mnt.join("rmw");
+            fs::write(&path, &payload).unwrap();
+            let mut f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+
+            let mut buf = vec![0u8; 4096];
+            f.read_exact(&mut buf).unwrap();
+            pattern_check(0, &buf);
+
+            f.seek(SeekFrom::Start(1024)).unwrap();
+            f.write_all(&[0xABu8; 64]).unwrap();
+
+            f.seek(SeekFrom::Start(1024)).unwrap();
+            f.read_exact(&mut buf[..64]).unwrap();
+            assert_eq!(&buf[..64], &[0xABu8; 64], "read missed the pending write");
+
+            f.sync_all().unwrap();
+
+            f.seek(SeekFrom::Start(1024)).unwrap();
+            f.read_exact(&mut buf[..64]).unwrap();
+            assert_eq!(
+                &buf[..64],
+                &[0xABu8; 64],
+                "read served bytes from before the flush"
+            );
+        },
+        None,
+    );
+}
+
+/// Truncating below a block that has been read unlinks its block file at the
+/// next flush, so growing the file back reads that region as a hole.
+#[test_log::test]
+fn truncate_below_a_read_block_then_grow_reads_zeros() {
+    let data = TempDir::new("backupfs_data").unwrap();
+    let chunk = CHUNK_OFFSET;
+    let mut payload = vec![0u8; 2 * chunk as usize];
+    pattern_fill(0, &mut payload);
+
+    with_backupfs(
+        data.path(),
+        "ohea".to_owned(),
+        move |mnt| {
+            let path = mnt.join("shrink_grow");
+            fs::write(&path, &payload).unwrap();
+            let mut f = fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&path)
+                .unwrap();
+
+            let mut buf = vec![0u8; 4096];
+            f.seek(SeekFrom::Start(chunk)).unwrap();
+            f.read_exact(&mut buf).unwrap();
+            pattern_check(chunk, &buf);
+
+            f.set_len(chunk / 2).unwrap();
+            f.sync_all().unwrap();
+            f.set_len(2 * chunk).unwrap();
+
+            f.seek(SeekFrom::Start(chunk)).unwrap();
+            f.read_exact(&mut buf).unwrap();
+            assert!(
+                buf.iter().all(|&b| b == 0),
+                "block 1 was truncated away, so it must read back as a hole"
             );
         },
         None,


### PR DESCRIPTION
Closes #3708

backup-fs splits file contents into 1 MiB blocks, each independently sealed (zstd → SHA-256 tag → ChaCha20 → Reed-Solomon 10+2), and `blockstore::read_block` decodes a whole one however few bytes were asked for. Nothing kept the result, and a handle from `open` is served `FOPEN_DIRECT_IO`, so the kernel supplies neither a page cache nor readahead — one FUSE read cost one whole-block fetch and decode.

The s9pk unpack that dominates a restore reads in 8 KiB units (the `tokio::io::copy` default), which is the worst point on that curve.

## Measured

Verified end to end on the real path, with the real artifact: the CryptPad `5.1.0:0` s9pk (590,246,423 B, 563 blocks) placed in a backup-fs store and read out through `S9pk::serialize(w, true)` — the same call `ServiceMap::install` makes.

| | before | after |
| --- | --- | --- |
| block decodes | 72,768 | **563** |
| backing-store bytes | 91.69 GB | **0.709 GB** |
| amplification | 155.3× | **1.20×** |
| elapsed (local NVMe) | 107.15 s | **2.41 s** |

563 decodes for a 563-block archive is one fetch per block — the floor. The read pattern is confirmed forward-sequential over a single cursor (2,986 of the first 3,000 reads exactly contiguous), so the one-block cache is sufficient for this workload; `verify: true` adds no second read pass.

The synthetic figures below are a 64 MiB file read through the mount at each size:

64 MiB file over a local NVMe; backing-store bytes from `read_bytes` in `/proc/self/io`.

| caller read size | before | after |
| --- | --- | --- |
| 8 KiB | 5.5 MiB/s, 154.0× | **499 MiB/s, 1.2×** |
| 64 KiB | 45 MiB/s, 19.2× | 639 MiB/s, 1.2× |
| 128 KiB | 89 MiB/s, 9.6× | 651 MiB/s, 1.2× |
| 1 MiB | 344 MiB/s, 2.4× | 658 MiB/s, 1.2× |

1.2× is the floor — one sealed block (1 MiB plaintext plus tag and ECC) per block of file. Scaled to the report in #3708, a 480 MiB package pulled ~72 GiB across an SMB share; at an ordinary ~29 MiB/s that is the 42 minutes observed.

## How it stays correct

`Contents` is per inode and every op on one inode runs on a single pool shard, so the cached block sits behind a lock the reader already holds. **A block is never both dirty and cached**, which is what keeps a write-out from leaving a stale copy:

- `load_block` caches only a block the dirty map does not hold;
- `write_blocks_at` takes the cached copy as it moves a block into the dirty map (which also spares the read-modify-write a re-decode);
- `flush_content_only` drops a cached block the trailing-block prune is about to unlink.

The cached bytes are stored exactly as they came off disk, so a size change cannot invalidate them — the reader bounds the slice and zero-fills the remainder.

## A panic this also fixes

`load_block` used to pad a short block up to its logical length, but only *after* the dirty-map early return. A block still holding a short pending write therefore reached `&block[within..within + copy]` unpadded, and a read landing past those bytes panicked the worker. The pool catches that unwind, so the damage looks confined — the read gets EIO and other files still serve — until the program closes the file: `release` runs on the dispatch thread holding the `Handler` lock, hits the poisoned `Contents` mutex and poisons the `Handler` mutex too, after which the session stops answering and the mount hangs. Reachable from an ordinary sparse write-then-read; measured against `master`:

```
pwrite(100 B @ 5 MiB); pwrite(100 B @ 6 MiB); pread(4 KiB @ 5 MiB + 32 KiB)
  panicked at contents.rs:212: range start index 32768 out of range for slice of length 100
  bad read            -> EIO        (panic caught by pool.rs)
  same file again     -> EIO        (poisoned Contents)
  an unrelated file   -> Ok         (still serving)
  close the bad file  -> handle.rs:479 PoisonError, then lib.rs:173
  the unrelated file  -> never returns
```

It has its own changelog entry and its own test.

## Verification

- 78 tests pass (`cargo test -p startos-backup-fs`), `make start-os-format-check` clean, no clippy hits in the changed files.
- Four new tests, each mutation-tested — every one fails on the mutation that removes the guard it covers, and on no other:

| mutation | `read_past_a_short_pending_write` | `repeated_reads_in_one_block` | `write_supersedes_a_previously_read_block` | `truncate_past_a_read_block` |
| --- | --- | --- | --- | --- |
| `contents.rs` reverted to master | **FAIL** | **FAIL** | ok | ok |
| drop `take_if(\|c\| c.idx == idx)` (write) | ok | ok | **FAIL** | ok |
| drop `take_if(\|c\| c.idx >= required)` (flush) | ok | ok | ok | **FAIL** |

`repeated_reads_in_one_block_decode_it_once` deletes both block files from the backing store partway through the read: the reads that follow only work if they are served from the decoded copy, and the block that was never read comes back as the hole it now is — so the same deletion that proves the hit also proves the test has teeth.

## Notes for review

- **A sibling panic on the `copy_file_range` path is filed separately as #3780.** `Handler::read`'s unchecked `attrs.size - offset` (`handle.rs:1102`) is the same defect class as the one fixed here, but a different trigger on a different path — and worse, because `lib.rs:822` holds the `Handler` lock across it. Left out to keep this diff to the read cache.

- **Nothing in CI compiles backup-fs, let alone runs its tests — filed as #3781.** `startos-backup-fs` is in `STARTOS_TARGETS` but not `COMPILED_TARGETS`, and the only job that builds it is the image job, which this PR's paths don't trigger. So the four guards below are enforced only by someone running `backup-fs/run_tests.sh`, which needs `/dev/fuse` and `CAP_SYS_ADMIN`. Pre-existing and left alone here.

- I looked at the issue's other two suggestions and did not take them. Raising the unpack copy buffer helps only that one caller and is worth much less once the cache is in (1 MiB reads gain 1.9×, 8 KiB reads gain 90×); block prefetch needs the per-inode shard pinning to change, which is a bigger question than this issue.
- The cache costs one block of memory per open block-backed inode, freed at last close. That is 1/16th of the per-file `BACKUPFS_WRITE_BUFFER` budget already accepted on the write side, so it gets a note in `DESIGN.md` rather than a knob of its own.
- Two readers scanning the same inode at different offsets thrash the single entry. That is a no-benefit case, never a regression — the old code decoded on every read anyway.
- Drive-by, in a file the change already edits: `contents.rs`'s module doc described two storage bodies when there are three, omitting `Packed`.
- No page under `projects/start-os/docs/` needed an edit — `backup-restore.md` describes the flow and makes no timing claim.




