### PR TITLE
feat(start-os): send a bare service domain on to its HTTPS address

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -12,19 +12,11 @@ file tracks notable changes since the move to the monorepo.
 
 ### Added
 
-- **Typing a service's domain without `https://` reaches the service.** A
-  browser given a bare name tries plain HTTP first, and port 80 belongs to the
-  StartOS UI, so the address bar landed on your server's dashboard instead of
-  the service — an encrypted request names the domain during the handshake and
-  your server routes on that, while a plain HTTP request reaches a port 80 that
-  answers for the whole server. StartOS now sends such a request on to the
-  domain's HTTPS address, which is what StartTunnel already does for a public
-  domain at the edge. It does so only where the encrypted address answers: over
-  a network the domain was added on, for an interface you open in a browser.
-  Your server's own addresses are untouched — its IP addresses, its `.local`
-  name and any domain you added to the StartOS UI itself still open the
-  dashboard over plain HTTP.
-  See [Private Domains](https://docs.start9.com/start-os/private-domains.html).
+- **Typing a service's domain without `https://` opens its web interface over
+  HTTPS.** This works on each network where the domain is assigned. Server IP
+  addresses, the server's `.local` name, and domains assigned to the StartOS UI
+  open the dashboard. See
+  [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer
   uses, and the port numbers it held become available again.** A service that

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -15,13 +15,15 @@ file tracks notable changes since the move to the monorepo.
 - **Typing a service's domain without `https://` reaches the service.** A
   browser given a bare name tries plain HTTP first, and port 80 belongs to the
   StartOS UI, so the address bar landed on your server's dashboard instead of
-  the service — a plain HTTP request carries no server name, and the server name
-  is what tells your services apart on one shared address. StartOS now sends
-  such a request on to the domain's HTTPS address, which is what StartTunnel
-  already does for a public domain at the edge. Your server's own addresses are
-  untouched: its IP addresses, its `.local` name and any domain you added to the
-  StartOS UI itself still open the dashboard over plain HTTP. See
-  [Private Domains](https://docs.start9.com/start-os/private-domains.html).
+  the service — an encrypted request names the domain during the handshake and
+  your server routes on that, while a plain HTTP request arrives with nothing to
+  route on. StartOS now sends such a request on to the domain's HTTPS address,
+  which is what StartTunnel already does for a public domain at the edge. It
+  does so only where the encrypted address answers: over a network the domain
+  was added on, for an interface you open in a browser. Your server's own
+  addresses are untouched — its IP addresses, its `.local` name and any domain
+  you added to the StartOS UI itself still open the dashboard over plain HTTP.
+  See [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer
   uses, and the port numbers it held become available again.** A service that

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -15,7 +15,7 @@ file tracks notable changes since the move to the monorepo.
 - **Typing a service's domain without `https://` opens its web interface over
   HTTPS.** This works on each network where the domain is assigned. Server IP
   addresses and domains assigned to the StartOS UI retain their existing
-  behavior. See
+  behavior. The server's own `.local` name remains reserved for StartOS. See
   [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -16,8 +16,9 @@ file tracks notable changes since the move to the monorepo.
   browser given a bare name tries plain HTTP first, and port 80 belongs to the
   StartOS UI, so the address bar landed on your server's dashboard instead of
   the service — an encrypted request names the domain during the handshake and
-  your server routes on that, while a plain HTTP request arrives with nothing to
-  route on. StartOS now sends such a request on to the domain's HTTPS address,
+  your server routes on that, while a plain HTTP request reaches a port 80 that
+  answers for the whole server. StartOS now sends such a request on to the
+  domain's HTTPS address,
   which is what StartTunnel already does for a public domain at the edge. It
   does so only where the encrypted address answers: over a network the domain
   was added on, for an interface you open in a browser. Your server's own

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -14,8 +14,8 @@ file tracks notable changes since the move to the monorepo.
 
 - **Typing a service's domain without `https://` opens its web interface over
   HTTPS.** This works on each network where the domain is assigned. Server IP
-  addresses, the server's `.local` name, and domains assigned to the StartOS UI
-  open the dashboard. See
+  addresses and domains assigned to the StartOS UI open the dashboard. The
+  server's `.local` name opens the dashboard on the standard HTTPS port. See
   [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -18,12 +18,12 @@ file tracks notable changes since the move to the monorepo.
   the service — an encrypted request names the domain during the handshake and
   your server routes on that, while a plain HTTP request reaches a port 80 that
   answers for the whole server. StartOS now sends such a request on to the
-  domain's HTTPS address,
-  which is what StartTunnel already does for a public domain at the edge. It
-  does so only where the encrypted address answers: over a network the domain
-  was added on, for an interface you open in a browser. Your server's own
-  addresses are untouched — its IP addresses, its `.local` name and any domain
-  you added to the StartOS UI itself still open the dashboard over plain HTTP.
+  domain's HTTPS address, which is what StartTunnel already does for a public
+  domain at the edge. It does so only where the encrypted address answers: over
+  a network the domain was added on, for an interface you open in a browser.
+  Your server's own addresses are untouched — its IP addresses, its `.local`
+  name and any domain you added to the StartOS UI itself still open the
+  dashboard over plain HTTP.
   See [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -12,6 +12,17 @@ file tracks notable changes since the move to the monorepo.
 
 ### Added
 
+- **Typing a service's domain without `https://` reaches the service.** A
+  browser given a bare name tries plain HTTP first, and port 80 belongs to the
+  StartOS UI, so the address bar landed on your server's dashboard instead of
+  the service — a plain HTTP request carries no server name, and the server name
+  is what tells your services apart on one shared address. StartOS now sends
+  such a request on to the domain's HTTPS address, which is what StartTunnel
+  already does for a public domain at the edge. Your server's own addresses are
+  untouched: its IP addresses, its `.local` name and any domain you added to the
+  StartOS UI itself still open the dashboard over plain HTTP. See
+  [Private Domains](https://docs.start9.com/start-os/private-domains.html).
+
 - **A service can permanently retire a network host or a port it no longer
   uses, and the port numbers it held become available again.** A service that
   reorganizes its interfaces across an update — renaming a host, dropping a

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -14,8 +14,8 @@ file tracks notable changes since the move to the monorepo.
 
 - **Typing a service's domain without `https://` opens its web interface over
   HTTPS.** This works on each network where the domain is assigned. Server IP
-  addresses and domains assigned to the StartOS UI open the dashboard. The
-  server's `.local` name opens the dashboard on the standard HTTPS port. See
+  addresses and domains assigned to the StartOS UI retain their existing
+  behavior. See
   [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
 - **A service can permanently retire a network host or a port it no longer

--- a/projects/start-os/docs/src/private-domains.md
+++ b/projects/start-os/docs/src/private-domains.md
@@ -4,7 +4,7 @@ A private domain works like your server's [mDNS address](mdns.md), except it als
 
 Private domains can be added to any gateway: wired (Ethernet), wireless (WiFi), or WireGuard ([StartTunnel](/start-tunnel/)). They can only be accessed when connected to the same network as your server — your LAN, or a VPN / tunnel — and they require trusting your server's Root CA.
 
-Type the domain on its own — `nextcloud.private` — and you land on the service over HTTPS. A browser given a bare name tries plain HTTP first, and your server answers that by sending the request on to the domain's HTTPS address. This applies to a web interface, on a network the domain was added on; a domain on an interface you reach with something other than a browser is left alone.
+Type the private domain on its own — `nextcloud.private` — to open the service over HTTPS. This works for service web interfaces on each network where the domain is assigned.
 
 ## Adding a Private Domain
 

--- a/projects/start-os/docs/src/private-domains.md
+++ b/projects/start-os/docs/src/private-domains.md
@@ -4,6 +4,8 @@ A private domain works like your server's [mDNS address](mdns.md), except it als
 
 Private domains can be added to any gateway: wired (Ethernet), wireless (WiFi), or WireGuard ([StartTunnel](/start-tunnel/)). They can only be accessed when connected to the same network as your server — your LAN, or a VPN / tunnel — and they require trusting your server's Root CA.
 
+Type the domain on its own — `nextcloud.private` — and you land on the service over HTTPS. A browser given a bare name tries plain HTTP first, and your server answers that by sending the request on to the domain's HTTPS address.
+
 ## Adding a Private Domain
 
 > [!NOTE]

--- a/projects/start-os/docs/src/private-domains.md
+++ b/projects/start-os/docs/src/private-domains.md
@@ -4,7 +4,7 @@ A private domain works like your server's [mDNS address](mdns.md), except it als
 
 Private domains can be added to any gateway: wired (Ethernet), wireless (WiFi), or WireGuard ([StartTunnel](/start-tunnel/)). They can only be accessed when connected to the same network as your server — your LAN, or a VPN / tunnel — and they require trusting your server's Root CA.
 
-Type the domain on its own — `nextcloud.private` — and you land on the service over HTTPS. A browser given a bare name tries plain HTTP first, and your server answers that by sending the request on to the domain's HTTPS address.
+Type the domain on its own — `nextcloud.private` — and you land on the service over HTTPS. A browser given a bare name tries plain HTTP first, and your server answers that by sending the request on to the domain's HTTPS address. This applies to a web interface, on a network the domain was added on; a domain on an interface you reach with something other than a browser is left alone.
 
 ## Adding a Private Domain
 

--- a/projects/start-os/docs/src/private-domains.md
+++ b/projects/start-os/docs/src/private-domains.md
@@ -4,8 +4,6 @@ A private domain works like your server's [mDNS address](mdns.md), except it als
 
 Private domains can be added to any gateway: wired (Ethernet), wireless (WiFi), or WireGuard ([StartTunnel](/start-tunnel/)). They can only be accessed when connected to the same network as your server — your LAN, or a VPN / tunnel — and they require trusting your server's Root CA.
 
-Type the private domain on its own — `nextcloud.private` — to open the service over HTTPS. This works for service web interfaces on each network where the domain is assigned.
-
 ## Adding a Private Domain
 
 > [!NOTE]

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -1609,6 +1609,14 @@ net.plugin.binding-not-found:
   fr_FR: "liaison introuvable : %{binding}"
   pl_PL: "powiązanie nie znalezione: %{binding}"
 
+# net/host/address.rs
+net.host.private-domain-is-server-mdns:
+  en_US: '"%{domain}" is the server mDNS name and cannot be assigned as a private domain'
+  de_DE: '„%{domain}“ ist der mDNS-Name des Servers und kann nicht als private Domain zugewiesen werden'
+  es_ES: '«%{domain}» es el nombre mDNS del servidor y no se puede asignar como dominio privado'
+  fr_FR: '« %{domain} » est le nom mDNS du serveur et ne peut pas être attribué comme domaine privé'
+  pl_PL: '„%{domain}” jest nazwą mDNS serwera i nie może zostać przypisana jako domena prywatna'
+
 # net/ssl.rs
 net.ssl.unreachable:
   en_US: "unreachable"

--- a/shared-libs/crates/start-core/src/hostname.rs
+++ b/shared-libs/crates/start-core/src/hostname.rs
@@ -8,6 +8,7 @@ use ts_rs::TS;
 
 use crate::context::RpcContext;
 use crate::db::model::public::{RestartReason, ServerInfo};
+use crate::net::host::all_hosts;
 use crate::prelude::*;
 use crate::util::Invoke;
 use crate::util::io::{copy_file, write_file_atomic};
@@ -60,6 +61,19 @@ impl ServerHostname {
 
     pub fn local_domain_name(&self) -> InternedString {
         InternedString::from_display(&lazy_format!("{}.local", self.0))
+    }
+
+    pub fn reject_private_domain(&self, domain: &str) -> Result<(), Error> {
+        if domain.trim_end_matches('.') == &*self.local_domain_name() {
+            return Err(Error::new(
+                eyre!(
+                    "{}",
+                    t!("net.host.private-domain-is-server-mdns", domain = domain)
+                ),
+                ErrorKind::InvalidRequest,
+            ));
+        }
+        Ok(())
     }
 
     pub fn load(server_info: &Model<ServerInfo>) -> Result<Self, Error> {
@@ -277,6 +291,14 @@ pub async fn set_hostname_rpc(
     let info = ctx
         .db
         .mutate(|db| {
+            if let Some(hostname) = &hostname {
+                let reserved = hostname.local_domain_name();
+                for host in all_hosts(db) {
+                    if host?.as_private_domains().contains_key(&reserved)? {
+                        hostname.reject_private_domain(&reserved)?;
+                    }
+                }
+            }
             let server_info = db.as_public_mut().as_server_info_mut();
             if let Some(name) = name {
                 server_info.as_name_mut().ser(&name)?;

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -7,8 +7,8 @@ use axum::body::Body;
 use axum::extract::Request;
 use axum::middleware::Next;
 use axum::response::Response;
+use http::Uri;
 use http::uri::{Authority, Scheme};
-use http::{HeaderValue, StatusCode, Uri};
 use imbl_value::InternedString;
 
 use crate::GatewayId;
@@ -16,11 +16,11 @@ use crate::context::RpcContext;
 use crate::db::model::DatabaseModel;
 use crate::net::gateway::GatewayInfo;
 use crate::net::host::binding::BindInfo;
-use crate::net::service_interface::{HostnameMetadata, ServiceInterfaceType};
+use crate::net::http::{https_redirect_uri, request_authority};
+use crate::net::service_interface::ServiceInterfaceType;
 use crate::prelude::*;
 
 const HTTPS_PORT: u16 = 443;
-
 const MAX_DNS_NAME_LEN: usize = 253;
 
 pub fn redirect_service_domains(ctx: RpcContext, router: Router) -> Router {
@@ -55,17 +55,15 @@ fn arrival_gateway_id(req: &Request) -> Option<GatewayId> {
 }
 
 fn request_domain(req: &Request) -> Option<String> {
-    // Absolute-form requests use the URI authority instead of `Host`.
-    let host = match req.uri().host() {
-        Some(host) => host,
-        None => req.headers().get(http::header::HOST)?.to_str().ok()?,
-    };
-    let host = host.split_once(':').map_or(host, |(name, _)| name);
+    let authority = request_authority(req)?;
+    if authority.as_str().contains('@') {
+        return None;
+    }
+    let host = authority.host();
     if host.parse::<IpAddr>().is_ok() {
         return None;
     }
     let name = host.trim_end_matches('.').to_ascii_lowercase();
-    // The redirect authority excludes userinfo and URI delimiters.
     if name.is_empty() || name.len() > MAX_DNS_NAME_LEN || !name.chars().all(is_safe_domain_char) {
         return None;
     }
@@ -85,51 +83,26 @@ async fn redirect(
     let Some(port) = package_service_tls_port(&ctx.db.peek().await, gateway, name)? else {
         return Ok(None);
     };
-    let is_dashboard = ctx
-        .account
-        .peek(|a| is_dashboard_mdns(name, port, &a.hostname.hostname));
-    if is_dashboard {
-        return Ok(None);
-    }
-    let path_and_query = uri.path_and_query().filter(|path| path.as_str() != "*");
-    https_redirect(path_and_query, name, port).map(Some)
-}
-
-fn is_dashboard_mdns(name: &str, port: u16, hostname: &str) -> bool {
-    port == HTTPS_PORT && name.strip_suffix(".local") == Some(hostname)
-}
-
-fn https_redirect(
-    path_and_query: Option<&http::uri::PathAndQuery>,
-    name: &str,
-    port: u16,
-) -> Result<Response, Error> {
     let authority = if port == HTTPS_PORT {
         name.to_owned()
     } else {
         format!("{name}:{port}")
     };
-    let target = Uri::builder()
-        .scheme(Scheme::HTTPS)
-        .authority(
-            authority
-                .parse::<Authority>()
-                .with_kind(ErrorKind::ParseUrl)?,
-        )
-        .path_and_query(path_and_query.map_or("/", |path| path.as_str()))
-        .build()
-        .with_kind(ErrorKind::ParseUrl)?;
+    let target = https_redirect_uri(
+        uri,
+        authority
+            .parse::<Authority>()
+            .with_kind(ErrorKind::ParseUrl)?,
+    )
+    .with_kind(ErrorKind::ParseUrl)?;
     Response::builder()
-        .status(StatusCode::TEMPORARY_REDIRECT)
-        .header(
-            http::header::LOCATION,
-            HeaderValue::from_str(&target.to_string()).with_kind(ErrorKind::ParseUrl)?,
-        )
+        .status(http::StatusCode::TEMPORARY_REDIRECT)
+        .header(http::header::LOCATION, target.to_string())
         .body(Body::empty())
         .with_kind(ErrorKind::Network)
+        .map(Some)
 }
 
-/// Excludes server-owned domains to avoid the TLS proxy redirect loop.
 fn package_service_tls_port(
     db: &DatabaseModel,
     gateway: &GatewayId,
@@ -162,13 +135,7 @@ fn browser_https_port<'a>(
         .filter(|bind| bind.enabled && has_browser_https_interface(bind))
         .flat_map(|bind| bind.enabled_addresses())
         .filter(|addr| {
-            addr.ssl
-                && *addr.hostname == *name
-                && matches!(
-                    addr.metadata,
-                    HostnameMetadata::PrivateDomain { .. } | HostnameMetadata::PublicDomain { .. }
-                )
-                && addr.metadata.gateways().any(|g| g == gateway)
+            addr.ssl && *addr.hostname == *name && addr.metadata.gateways().any(|g| g == gateway)
         })
         .filter_map(|addr| addr.port)
         .min_by_key(|port| (*port != HTTPS_PORT, *port))
@@ -190,7 +157,9 @@ mod test {
 
     use super::*;
     use crate::net::host::binding::{BindOptions, DerivedAddressInfo, NetInfo};
-    use crate::net::service_interface::{AddressInfo, HostnameInfo, ServiceInterface};
+    use crate::net::service_interface::{
+        AddressInfo, HostnameInfo, HostnameMetadata, ServiceInterface,
+    };
     use crate::{HostId, Id, ServiceInterfaceId};
 
     fn gateway(id: &'static str) -> GatewayId {
@@ -221,18 +190,6 @@ mod test {
             port: Some(port),
             metadata: HostnameMetadata::PublicDomain {
                 gateway: gateway("eth0"),
-            },
-        }
-    }
-
-    fn mdns(hostname: &str, port: u16) -> HostnameInfo {
-        HostnameInfo {
-            ssl: true,
-            public: false,
-            hostname: InternedString::from(hostname),
-            port: Some(port),
-            metadata: HostnameMetadata::Mdns {
-                gateways: gateways(),
             },
         }
     }
@@ -317,15 +274,6 @@ mod test {
         assert_eq!(
             browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
-        );
-    }
-
-    #[test]
-    fn leaves_the_mdns_name_alone() {
-        let binds = [binding([mdns("myserver.local", HTTPS_PORT)])];
-        assert_eq!(
-            browser_https_port(binds.iter(), &gateway("eth0"), "myserver.local"),
-            None
         );
     }
 
@@ -590,48 +538,33 @@ mod test {
         );
     }
 
-    #[test]
-    fn leaves_the_servers_mdns_name_on_the_dashboard_only_on_443() {
-        assert!(is_dashboard_mdns("myserver.local", HTTPS_PORT, "myserver"));
-        assert!(!is_dashboard_mdns("myserver.local", 8443, "myserver"));
-    }
-
-    fn location(uri: Option<&str>, port: u16) -> String {
-        let path_and_query = uri
-            .filter(|path| *path != "*")
-            .map(|uri| uri.parse().unwrap());
-        let target = https_redirect(path_and_query.as_ref(), "cloud.mydomain.com", port).unwrap();
-        assert_eq!(target.status(), StatusCode::TEMPORARY_REDIRECT);
-        target
-            .headers()
-            .get(http::header::LOCATION)
-            .unwrap()
-            .to_str()
-            .unwrap()
-            .to_owned()
+    fn location(uri: &str, port: u16) -> String {
+        let authority = if port == HTTPS_PORT {
+            "cloud.mydomain.com".to_owned()
+        } else {
+            format!("cloud.mydomain.com:{port}")
+        };
+        let target = https_redirect_uri(&uri.parse().unwrap(), authority.parse().unwrap()).unwrap();
+        target.to_string()
     }
 
     #[test]
     fn keeps_the_path_and_query() {
         assert_eq!(
-            location(Some("/photos?share=1"), HTTPS_PORT),
+            location("/photos?share=1", HTTPS_PORT),
             "https://cloud.mydomain.com/photos?share=1"
         );
     }
 
     #[test]
     fn redirects_a_target_without_a_path_to_the_root() {
-        assert_eq!(location(None, HTTPS_PORT), "https://cloud.mydomain.com/");
-        assert_eq!(
-            location(Some("*"), HTTPS_PORT),
-            "https://cloud.mydomain.com/"
-        );
+        assert_eq!(location("*", HTTPS_PORT), "https://cloud.mydomain.com/");
     }
 
     #[test]
     fn names_a_tls_port_that_is_not_443() {
         assert_eq!(
-            location(Some("/photos"), 8443),
+            location("/photos", 8443),
             "https://cloud.mydomain.com:8443/photos"
         );
     }

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -1,9 +1,4 @@
-//! HTTP→HTTPS redirect for a service's domains on the StartOS UI's port.
-//!
-//! Port 80 belongs to the StartOS UI, whose listener answers on every address
-//! the server holds, and a browser given a bare domain name tries it first. A
-//! plaintext request carries no SNI, so that listener has only the `Host`
-//! header to tell a service's domain from the names the dashboard answers to.
+//! Redirects service-domain HTTP requests from the shared UI listener.
 
 use std::net::IpAddr;
 
@@ -26,18 +21,15 @@ use crate::prelude::*;
 
 const HTTPS_PORT: u16 = 443;
 
-/// The longest name DNS carries.
-const MAX_NAME_LEN: usize = 253;
+const MAX_DNS_NAME_LEN: usize = 253;
 
-/// Bounce a request whose `Host` names a domain an installed service is served
-/// on.
-pub fn layer(ctx: RpcContext, router: Router) -> Router {
+pub fn redirect_service_domains(ctx: RpcContext, router: Router) -> Router {
     router.layer(axum::middleware::from_fn(
         move |req: Request, next: Next| {
             let ctx = ctx.clone();
-            let gateway = arrival_gateway(&req);
+            let gateway = arrival_gateway_id(&req);
             async move {
-                if let (Some(name), Some(gateway)) = (host(&req), gateway) {
+                if let (Some(name), Some(gateway)) = (request_domain(&req), gateway) {
                     let uri = req.uri().clone();
                     match redirect(&ctx, &gateway, &name, &uri).await {
                         Ok(Some(res)) => return res,
@@ -54,28 +46,16 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
     ))
 }
 
-/// Which of the server's networks the connection arrived on. The listener
-/// resolves it per accepted connection and the web server puts it in the
-/// request extensions.
-///
-/// The listener names a connection it cannot place with an empty gateway, which
-/// is no gateway at all.
-fn arrival_gateway(req: &Request) -> Option<GatewayId> {
+/// An empty `GatewayId` represents an unplaced connection.
+fn arrival_gateway_id(req: &Request) -> Option<GatewayId> {
     req.extensions()
         .get::<GatewayInfo>()
         .map(|g| g.id.clone())
         .filter(|id| !id.as_str().is_empty())
 }
 
-/// The host the request named, lowercased and stripped of any port and of the
-/// root's trailing dot.
-///
-/// `None` unless the result is a plausible domain name. An address, an
-/// over-long name, or anything outside the DNS character set is rejected here,
-/// so nothing else has to defend against a hostile `Host`.
-fn host(req: &Request) -> Option<String> {
-    // The request target's authority wins over the header, and on HTTP/2 it is
-    // the only one of the two hyper fills in.
+fn request_domain(req: &Request) -> Option<String> {
+    // RFC 9112 gives the request-target authority precedence.
     let host = match req.uri().host() {
         Some(host) => host,
         None => req.headers().get(http::header::HOST)?.to_str().ok()?,
@@ -85,16 +65,14 @@ fn host(req: &Request) -> Option<String> {
         return None;
     }
     let name = host.trim_end_matches('.').to_ascii_lowercase();
-    if name.is_empty() || name.len() > MAX_NAME_LEN || !name.chars().all(is_name_char) {
+    // The redirect authority excludes userinfo and URI delimiters.
+    if name.is_empty() || name.len() > MAX_DNS_NAME_LEN || !name.chars().all(is_safe_domain_char) {
         return None;
     }
     Some(name)
 }
 
-/// The characters a `Host` may hold to be matched against a stored domain.
-/// Anything else — userinfo above all — would reach the `Location` header,
-/// where a browser reads everything after an `@` as the destination.
-fn is_name_char(c: char) -> bool {
+fn is_safe_domain_char(c: char) -> bool {
     c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.' || c == '_'
 }
 
@@ -104,16 +82,14 @@ async fn redirect(
     name: &str,
     uri: &Uri,
 ) -> Result<Option<Response>, Error> {
-    // A target that is not a path has nothing to send across: `CONNECT` names an
-    // authority, and `OPTIONS *` names nothing.
+    // Authority- and asterisk-form targets have no redirectable path.
     if uri
         .path_and_query()
         .map_or(true, |p| !p.path().starts_with('/'))
     {
         return Ok(None);
     }
-    // The dashboard is reached by the server's own `.local` name, so answer that
-    // before reading the database.
+    // The server's mDNS name belongs to the dashboard.
     let is_own_mdns_name = ctx.account.peek(|a| {
         name.strip_suffix(".local")
             .is_some_and(|host| host == &**a.hostname.hostname)
@@ -121,13 +97,12 @@ async fn redirect(
     if is_own_mdns_name {
         return Ok(None);
     }
-    let Some(port) = service_tls_port(&ctx.db.peek().await, gateway, name)? else {
+    let Some(port) = package_service_tls_port(&ctx.db.peek().await, gateway, name)? else {
         return Ok(None);
     };
     https_redirect(uri, name, port).map(Some)
 }
 
-/// The same request, addressed to `name` over TLS on `port`.
 fn https_redirect(uri: &Uri, name: &str, port: u16) -> Result<Response, Error> {
     let authority = if port == HTTPS_PORT {
         name.to_owned()
@@ -152,12 +127,8 @@ fn https_redirect(uri: &Uri, name: &str, port: u16) -> Result<Response, Error> {
         .with_kind(ErrorKind::Network)
 }
 
-/// The TLS port an installed service answers `name` on over `gateway`.
-///
-/// Only installed services are searched. The server's own host answers its names
-/// through a TLS listener that proxies back to this very port, so redirecting one
-/// of those would loop.
-fn service_tls_port(
+/// Excludes server-owned domains to avoid the TLS proxy redirect loop.
+fn package_service_tls_port(
     db: &DatabaseModel,
     gateway: &GatewayId,
     name: &str,
@@ -170,7 +141,8 @@ fn service_tls_port(
             {
                 continue;
             }
-            if let Some(port) = tls_port(host.as_bindings().de()?.values(), gateway, name) {
+            if let Some(port) = browser_https_port(host.as_bindings().de()?.values(), gateway, name)
+            {
                 return Ok(Some(port));
             }
         }
@@ -178,19 +150,14 @@ fn service_tls_port(
     Ok(None)
 }
 
-/// The port to send a browser that asked for `name` over `gateway` in plaintext.
-///
-/// Only a domain qualifies, and only over a gateway it is served on. The
-/// server's IP addresses and its `.local` name are how the dashboard itself is
-/// reached, and every host carries them.
-fn tls_port<'a>(
+fn browser_https_port<'a>(
     bindings: impl IntoIterator<Item = &'a BindInfo>,
     gateway: &GatewayId,
     name: &str,
 ) -> Option<u16> {
     bindings
         .into_iter()
-        .filter(|bind| bind.enabled && serves_https(bind))
+        .filter(|bind| bind.enabled && has_browser_https_interface(bind))
         .flat_map(|bind| bind.enabled_addresses())
         .filter(|addr| {
             addr.ssl
@@ -199,20 +166,14 @@ fn tls_port<'a>(
                     addr.metadata,
                     HostnameMetadata::PrivateDomain { .. } | HostnameMetadata::PublicDomain { .. }
                 )
-                // A domain scoped to another gateway has no listener on this
-                // one, so sending a browser there ends in a refused handshake.
                 && addr.metadata.gateways().any(|g| g == gateway)
         })
         .filter_map(|addr| addr.port)
-        // A browser with no port in its address bar goes to 443, so prefer it.
         .min_by_key(|port| (*port != HTTPS_PORT, *port))
 }
 
-/// Whether a browser can open this binding's TLS port. A binding that carries
-/// another protocol over TLS — an Electrum server, a TURN server — has a domain
-/// and a TLS port like any other. An `https` scheme separates the two, and so
-/// does a `ui` interface where the package declared no scheme at all.
-fn serves_https(bind: &BindInfo) -> bool {
+/// A scheme-less UI interface is browser-addressable over TLS.
+fn has_browser_https_interface(bind: &BindInfo) -> bool {
     bind.interfaces
         .values()
         .any(|iface| match iface.address_info.ssl_scheme.as_deref() {
@@ -274,11 +235,6 @@ mod test {
         }
     }
 
-    /// A binding serves its domains only through an exported interface, so
-    /// every fixture needs one: `BindInfo::enabled_addresses` drops every
-    /// address but the internal ones when `interfaces` is empty.
-    /// The plaintext half of the pair the SDK derives an interface's schemes
-    /// from, so a fixture names a configuration a package can actually produce.
     fn plain_scheme(ssl_scheme: Option<&str>) -> Option<&'static str> {
         match ssl_scheme {
             Some("https") => Some("http"),
@@ -348,7 +304,7 @@ mod test {
             private("cloud.mydomain.com", true, HTTPS_PORT),
         ])];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
@@ -357,18 +313,16 @@ mod test {
     fn sends_a_public_domain_to_its_tls_port() {
         let binds = [binding([public("cloud.mydomain.com", HTTPS_PORT)])];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
 
-    // The dashboard is reached by the server's `.local` name over plaintext, and
-    // every host carries that name.
     #[test]
     fn leaves_the_mdns_name_alone() {
         let binds = [binding([mdns("myserver.local", HTTPS_PORT)])];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "myserver.local"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "myserver.local"),
             None
         );
     }
@@ -377,13 +331,11 @@ mod test {
     fn ignores_a_domain_served_only_in_plaintext() {
         let binds = [binding([private("cloud.mydomain.com", false, 8080)])];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             None
         );
     }
 
-    // An Electrum server's TLS port speaks its own protocol, and a browser sent
-    // there would speak HTTP at it.
     #[test]
     fn ignores_a_tls_port_that_is_not_https() {
         let binds = [binding_serving(
@@ -392,7 +344,7 @@ mod test {
             [private("electrum.mydomain.com", true, 50002)],
         )];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "electrum.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "electrum.mydomain.com"),
             None
         );
     }
@@ -405,13 +357,11 @@ mod test {
             [private("p2p.mydomain.com", true, 8443)],
         )];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "p2p.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "p2p.mydomain.com"),
             None
         );
     }
 
-    // A declared scheme decides on its own: a `ws` interface is typed `ui` and
-    // carries `wss`, which a browser cannot navigate to.
     #[test]
     fn ignores_a_ui_that_declares_another_scheme() {
         let binds = [binding_serving(
@@ -420,13 +370,11 @@ mod test {
             [private("socket.mydomain.com", true, HTTPS_PORT)],
         )];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "socket.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "socket.mydomain.com"),
             None
         );
     }
 
-    // A package may bind a port the SDK knows no protocol for and still export a
-    // ui from it, which leaves the scheme unset.
     #[test]
     fn sends_a_ui_with_no_declared_scheme() {
         let binds = [binding_serving(
@@ -435,30 +383,27 @@ mod test {
             [private("cloud.mydomain.com", true, 8443)],
         )];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(8443)
         );
     }
 
-    // A domain is served only over the gateways it was added on, and the vhost
-    // refuses the handshake anywhere else.
     #[test]
     fn ignores_a_domain_scoped_to_another_gateway() {
         let binds = [binding([private("cloud.mydomain.com", true, HTTPS_PORT)])];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("wg0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("wg0"), "cloud.mydomain.com"),
             None
         );
     }
 
-    // `setupInterfaces` ends by disabling every binding the pass did not
-    // declare, and a disabled binding keeps its domains in the database.
+    // Disabled bindings retain their domains in the database.
     #[test]
     fn ignores_a_disabled_binding() {
         let mut bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
         bind.enabled = false;
         assert_eq!(
-            tls_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
             None
         );
     }
@@ -471,7 +416,7 @@ mod test {
             HTTPS_PORT,
         ));
         assert_eq!(
-            tls_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
             None
         );
     }
@@ -483,7 +428,7 @@ mod test {
             binding([private("cloud.mydomain.com", true, HTTPS_PORT)]),
         ];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
@@ -495,7 +440,7 @@ mod test {
             binding([private("cloud.mydomain.com", true, 8443)]),
         ];
         assert_eq!(
-            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            browser_https_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(8443)
         );
     }
@@ -529,14 +474,13 @@ mod test {
         })
     }
 
-    // The host's domain map is the authority, so a derived address alone never
-    // qualifies a name.
+    // A derived address does not establish domain ownership.
     #[test]
     fn ignores_a_name_no_host_lists_as_a_domain() {
         let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
         let db = db(empty_host(), host_holding("other.example", &bind));
         assert_eq!(
-            service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
+            package_service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
             None
         );
     }
@@ -546,19 +490,17 @@ mod test {
         let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
         let db = db(empty_host(), host_holding("cloud.mydomain.com", &bind));
         assert_eq!(
-            service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
+            package_service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
             Some(HTTPS_PORT)
         );
     }
 
-    // The server's own TLS listener proxies back to the port this redirect runs
-    // on, so a name it answers to must never be redirected.
     #[test]
     fn does_not_search_the_servers_own_host() {
         let bind = binding([private("home.mydomain.com", true, HTTPS_PORT)]);
         let db = db(host_holding("home.mydomain.com", &bind), empty_host());
         assert_eq!(
-            service_tls_port(&db, &gateway("eth0"), "home.mydomain.com").unwrap(),
+            package_service_tls_port(&db, &gateway("eth0"), "home.mydomain.com").unwrap(),
             None
         );
     }
@@ -582,21 +524,22 @@ mod test {
 
     #[test]
     fn reads_the_gateway_the_listener_resolved() {
-        assert_eq!(arrival_gateway(&arriving_on("eth0")), Some(gateway("eth0")));
+        assert_eq!(
+            arrival_gateway_id(&arriving_on("eth0")),
+            Some(gateway("eth0"))
+        );
     }
 
-    // The listener hands on an empty gateway rather than nothing when it cannot
-    // place the connection, and no domain is served on it.
     #[test]
     fn reads_an_unplaced_connection_as_no_gateway() {
-        assert_eq!(arrival_gateway(&arriving_on("")), None);
-        assert_eq!(arrival_gateway(&request("cloud.mydomain.com")), None);
+        assert_eq!(arrival_gateway_id(&arriving_on("")), None);
+        assert_eq!(arrival_gateway_id(&request("cloud.mydomain.com")), None);
     }
 
     #[test]
     fn reads_a_host_name() {
         assert_eq!(
-            host(&request("Cloud.MyDomain.com:80")).as_deref(),
+            request_domain(&request("Cloud.MyDomain.com:80")).as_deref(),
             Some("cloud.mydomain.com")
         );
     }
@@ -604,7 +547,7 @@ mod test {
     #[test]
     fn reads_a_host_name_written_from_the_root() {
         assert_eq!(
-            host(&request("cloud.mydomain.com.")).as_deref(),
+            request_domain(&request("cloud.mydomain.com.")).as_deref(),
             Some("cloud.mydomain.com")
         );
     }
@@ -615,10 +558,9 @@ mod test {
             .uri("https://cloud.mydomain.com/photos")
             .body(Body::empty())
             .unwrap();
-        assert_eq!(host(&req).as_deref(), Some("cloud.mydomain.com"));
+        assert_eq!(request_domain(&req).as_deref(), Some("cloud.mydomain.com"));
     }
 
-    // RFC 9112 gives the request target's authority precedence over the header.
     #[test]
     fn prefers_the_authority_to_the_header() {
         let req = Request::builder()
@@ -626,23 +568,24 @@ mod test {
             .header(http::header::HOST, "other.mydomain.com")
             .body(Body::empty())
             .unwrap();
-        assert_eq!(host(&req).as_deref(), Some("cloud.mydomain.com"));
+        assert_eq!(request_domain(&req).as_deref(), Some("cloud.mydomain.com"));
     }
 
     #[test]
     fn skips_a_host_named_by_address() {
-        assert_eq!(host(&request("192.168.1.5")), None);
-        assert_eq!(host(&request("192.168.1.5:80")), None);
-        assert_eq!(host(&request("[fd00::1]:80")), None);
+        assert_eq!(request_domain(&request("192.168.1.5")), None);
+        assert_eq!(request_domain(&request("192.168.1.5:80")), None);
+        assert_eq!(request_domain(&request("[fd00::1]:80")), None);
     }
 
-    // Userinfo in the authority would otherwise reach a `Location` header, where
-    // the browser reads everything after the `@` as the destination.
     #[test]
     fn skips_a_host_outside_the_name_character_set() {
-        assert_eq!(host(&request("admin@evil.example")), None);
-        assert_eq!(host(&request("cloud.mydomain.com!")), None);
-        assert_eq!(host(&request(&format!("{}.com", "a".repeat(250)))), None);
+        assert_eq!(request_domain(&request("admin@evil.example")), None);
+        assert_eq!(request_domain(&request("cloud.mydomain.com!")), None);
+        assert_eq!(
+            request_domain(&request(&format!("{}.com", "a".repeat(250)))),
+            None
+        );
     }
 
     fn location(uri: &str, port: u16) -> String {

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -277,6 +277,16 @@ mod test {
     /// A binding serves its domains only through an exported interface, so
     /// every fixture needs one: `BindInfo::enabled_addresses` drops every
     /// address but the internal ones when `interfaces` is empty.
+    /// The plaintext half of the pair the SDK derives an interface's schemes
+    /// from, so a fixture names a configuration a package can actually produce.
+    fn plain_scheme(ssl_scheme: Option<&str>) -> Option<&'static str> {
+        match ssl_scheme {
+            Some("https") => Some("http"),
+            Some("wss") => Some("ws"),
+            _ => None,
+        }
+    }
+
     fn interface(ssl_scheme: Option<&str>, kind: ServiceInterfaceType) -> ServiceInterface {
         let id = ServiceInterfaceId::from(Id::try_from("ui".to_owned()).unwrap());
         ServiceInterface {
@@ -288,7 +298,7 @@ mod test {
                 username: None,
                 host_id: HostId::from(Id::try_from("ui".to_owned()).unwrap()),
                 internal_port: 80,
-                scheme: Some(InternedString::intern("http")),
+                scheme: plain_scheme(ssl_scheme).map(InternedString::intern),
                 ssl_scheme: ssl_scheme.map(InternedString::intern),
                 suffix: String::new(),
             },

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -210,8 +210,8 @@ fn tls_port<'a>(
 
 /// Whether a browser can open this binding's TLS port. A binding that carries
 /// another protocol over TLS — an Electrum server, a TURN server — has a domain
-/// and a TLS port like any other, so an `https` scheme or a `ui` interface is
-/// what separates the two.
+/// and a TLS port like any other. An `https` scheme separates the two, and so
+/// does a `ui` interface where the package declared no scheme at all.
 fn serves_https(bind: &BindInfo) -> bool {
     bind.interfaces
         .values()
@@ -396,6 +396,21 @@ mod test {
         )];
         assert_eq!(
             tls_port(binds.iter(), &gateway("eth0"), "p2p.mydomain.com"),
+            None
+        );
+    }
+
+    // A declared scheme decides on its own: a `ws` interface is typed `ui` and
+    // carries `wss`, which a browser cannot navigate to.
+    #[test]
+    fn ignores_a_ui_that_declares_another_scheme() {
+        let binds = [binding_serving(
+            Some("wss"),
+            ServiceInterfaceType::Ui,
+            [private("socket.mydomain.com", true, HTTPS_PORT)],
+        )];
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "socket.mydomain.com"),
             None
         );
     }

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -1,10 +1,9 @@
 //! HTTP→HTTPS redirect for a service's domains on the StartOS UI's port.
 //!
 //! Port 80 belongs to the StartOS UI, whose listener answers on every address
-//! the server holds. A browser given a bare domain name tries port 80 first, so
-//! typing a service's private domain lands on the dashboard: a plaintext
-//! request carries no SNI, which is what tells the service apart from every
-//! other name this server answers to.
+//! the server holds, and a browser given a bare domain name tries it first. A
+//! plaintext request carries no SNI, so that listener has only the `Host`
+//! header to tell a service's domain from the names the dashboard answers to.
 
 use std::net::IpAddr;
 
@@ -56,10 +55,16 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
 }
 
 /// Which of the server's networks the connection arrived on. The listener
-/// resolves it per connection and the router carries it in the request
-/// extensions, so a domain can be matched against the gateways it is served on.
+/// resolves it per accepted connection and the web server puts it in the
+/// request extensions.
+///
+/// The listener names a connection it cannot place with an empty gateway, which
+/// is no gateway at all.
 fn arrival_gateway(req: &Request) -> Option<GatewayId> {
-    req.extensions().get::<GatewayInfo>().map(|g| g.id.clone())
+    req.extensions()
+        .get::<GatewayInfo>()
+        .map(|g| g.id.clone())
+        .filter(|id| !id.as_str().is_empty())
 }
 
 /// The host the request named, lowercased and stripped of any port and of the
@@ -86,9 +91,9 @@ fn host(req: &Request) -> Option<String> {
     Some(name)
 }
 
-/// The character set a stored domain is matched on. A name outside it cannot be
-/// one, and would put whatever it does hold — userinfo, most of all — in a
-/// `Location` header this server signs its name to.
+/// The characters a `Host` may hold to be matched against a stored domain.
+/// Anything else — userinfo above all — would reach the `Location` header,
+/// where a browser reads everything after an `@` as the destination.
 fn is_name_char(c: char) -> bool {
     c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.' || c == '_'
 }
@@ -109,11 +114,11 @@ async fn redirect(
     }
     // The dashboard is reached by the server's own `.local` name, so answer that
     // before reading the database.
-    let own_mdns_name = ctx.account.peek(|a| {
+    let is_own_mdns_name = ctx.account.peek(|a| {
         name.strip_suffix(".local")
             .is_some_and(|host| host == &**a.hostname.hostname)
     });
-    if own_mdns_name {
+    if is_own_mdns_name {
         return Ok(None);
     }
     let Some(port) = service_tls_port(&ctx.db.peek().await, gateway, name)? else {
@@ -205,8 +210,8 @@ fn tls_port<'a>(
 
 /// Whether a browser can open this binding's TLS port. A binding that carries
 /// another protocol over TLS — an Electrum server, a TURN server — has a domain
-/// and a TLS port like any other. An interface the package typed `ui` counts
-/// even with no scheme declared, on the package's word that a browser opens it.
+/// and a TLS port like any other, so an `https` scheme or a `ui` interface is
+/// what separates the two.
 fn serves_https(bind: &BindInfo) -> bool {
     bind.interfaces
         .values()
@@ -499,8 +504,8 @@ mod test {
         })
     }
 
-    // A binding's address set outlives the domain record it came from, so the
-    // domain the operator configured is what decides.
+    // The host's domain map is the authority, so a derived address alone never
+    // qualifies a name.
     #[test]
     fn ignores_a_name_no_host_lists_as_a_domain() {
         let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
@@ -541,16 +546,25 @@ mod test {
             .unwrap()
     }
 
-    // The gateway comes out of the request extensions by type, so a wrong type
-    // would read as "no gateway" and switch the whole redirect off in silence.
-    #[test]
-    fn reads_the_gateway_the_listener_resolved() {
+    fn arriving_on(id: &'static str) -> Request {
         let mut req = request("cloud.mydomain.com");
         req.extensions_mut().insert(GatewayInfo {
-            id: gateway("eth0"),
+            id: gateway(id),
             info: Default::default(),
         });
-        assert_eq!(arrival_gateway(&req), Some(gateway("eth0")));
+        req
+    }
+
+    #[test]
+    fn reads_the_gateway_the_listener_resolved() {
+        assert_eq!(arrival_gateway(&arriving_on("eth0")), Some(gateway("eth0")));
+    }
+
+    // The listener hands on an empty gateway rather than nothing when it cannot
+    // place the connection, and no domain is served on it.
+    #[test]
+    fn reads_an_unplaced_connection_as_no_gateway() {
+        assert_eq!(arrival_gateway(&arriving_on("")), None);
         assert_eq!(arrival_gateway(&request("cloud.mydomain.com")), None);
     }
 

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -36,9 +36,7 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
     router.layer(axum::middleware::from_fn(
         move |req: Request, next: Next| {
             let ctx = ctx.clone();
-            // The listener resolves which of the server's networks a connection
-            // arrived on, and a domain is only served over its own gateways.
-            let gateway = req.extensions().get::<GatewayInfo>().map(|g| g.id.clone());
+            let gateway = arrival_gateway(&req);
             async move {
                 if let (Some(name), Some(gateway)) = (host(&req), gateway) {
                     let uri = req.uri().clone();
@@ -46,9 +44,7 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
                         Ok(Some(res)) => return res,
                         Ok(None) => (),
                         Err(e) => {
-                            // Per request, so a malformed record must not flood
-                            // the log at page-load rate.
-                            tracing::debug!("failed to check the host {name}: {e}");
+                            tracing::warn!("failed to check the host {name}: {e}");
                             tracing::debug!("{e:?}");
                         }
                     }
@@ -57,6 +53,13 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
             }
         },
     ))
+}
+
+/// Which of the server's networks the connection arrived on. The listener
+/// resolves it per connection and the router carries it in the request
+/// extensions, so a domain can be matched against the gateways it is served on.
+fn arrival_gateway(req: &Request) -> Option<GatewayId> {
+    req.extensions().get::<GatewayInfo>().map(|g| g.id.clone())
 }
 
 /// The host the request named, lowercased and stripped of any port and of the
@@ -87,7 +90,7 @@ fn host(req: &Request) -> Option<String> {
 /// one, and would put whatever it does hold — userinfo, most of all — in a
 /// `Location` header this server signs its name to.
 fn is_name_char(c: char) -> bool {
-    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.'
+    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.' || c == '_'
 }
 
 async fn redirect(
@@ -106,11 +109,11 @@ async fn redirect(
     }
     // The dashboard is reached by the server's own `.local` name, so answer that
     // before reading the database.
-    if ctx
-        .account
-        .peek(|a| a.hostname.hostname.local_domain_name())
-        == name
-    {
+    let own_mdns_name = ctx.account.peek(|a| {
+        name.strip_suffix(".local")
+            .is_some_and(|host| host == &**a.hostname.hostname)
+    });
+    if own_mdns_name {
         return Ok(None);
     }
     let Some(port) = service_tls_port(&ctx.db.peek().await, gateway, name)? else {
@@ -202,8 +205,8 @@ fn tls_port<'a>(
 
 /// Whether a browser can open this binding's TLS port. A binding that carries
 /// another protocol over TLS — an Electrum server, a TURN server — has a domain
-/// and a TLS port like any other. A `ui` interface is browser-openable by
-/// definition, so it counts even when the package declared no scheme.
+/// and a TLS port like any other. An interface the package typed `ui` counts
+/// even with no scheme declared, on the package's word that a browser opens it.
 fn serves_https(bind: &BindInfo) -> bool {
     bind.interfaces
         .values()
@@ -496,6 +499,18 @@ mod test {
         })
     }
 
+    // A binding's address set outlives the domain record it came from, so the
+    // domain the operator configured is what decides.
+    #[test]
+    fn ignores_a_name_no_host_lists_as_a_domain() {
+        let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
+        let db = db(empty_host(), host_holding("other.example", &bind));
+        assert_eq!(
+            service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
+            None
+        );
+    }
+
     #[test]
     fn finds_a_service_domain_in_the_database() {
         let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
@@ -524,6 +539,19 @@ mod test {
             .header(http::header::HOST, host)
             .body(Body::empty())
             .unwrap()
+    }
+
+    // The gateway comes out of the request extensions by type, so a wrong type
+    // would read as "no gateway" and switch the whole redirect off in silence.
+    #[test]
+    fn reads_the_gateway_the_listener_resolved() {
+        let mut req = request("cloud.mydomain.com");
+        req.extensions_mut().insert(GatewayInfo {
+            id: gateway("eth0"),
+            info: Default::default(),
+        });
+        assert_eq!(arrival_gateway(&req), Some(gateway("eth0")));
+        assert_eq!(arrival_gateway(&request("cloud.mydomain.com")), None);
     }
 
     #[test]
@@ -574,7 +602,7 @@ mod test {
     #[test]
     fn skips_a_host_outside_the_name_character_set() {
         assert_eq!(host(&request("admin@evil.example")), None);
-        assert_eq!(host(&request("cloud.mydomain.com_")), None);
+        assert_eq!(host(&request("cloud.mydomain.com!")), None);
         assert_eq!(host(&request(&format!("{}.com", "a".repeat(250)))), None);
     }
 

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -46,7 +46,7 @@ pub fn redirect_service_domains(ctx: RpcContext, router: Router) -> Router {
     ))
 }
 
-/// An empty `GatewayId` represents an unplaced connection.
+/// An empty `GatewayId` represents a connection from an unknown origin.
 fn arrival_gateway_id(req: &Request) -> Option<GatewayId> {
     req.extensions()
         .get::<GatewayInfo>()
@@ -55,7 +55,7 @@ fn arrival_gateway_id(req: &Request) -> Option<GatewayId> {
 }
 
 fn request_domain(req: &Request) -> Option<String> {
-    // RFC 9112 gives the request-target authority precedence.
+    // Absolute-form requests use the URI authority instead of `Host`.
     let host = match req.uri().host() {
         Some(host) => host,
         None => req.headers().get(http::header::HOST)?.to_str().ok()?,
@@ -82,41 +82,43 @@ async fn redirect(
     name: &str,
     uri: &Uri,
 ) -> Result<Option<Response>, Error> {
-    // Authority- and asterisk-form targets have no redirectable path.
-    if uri
-        .path_and_query()
-        .map_or(true, |p| !p.path().starts_with('/'))
-    {
-        return Ok(None);
-    }
-    // The server's mDNS name belongs to the dashboard.
-    let is_own_mdns_name = ctx.account.peek(|a| {
-        name.strip_suffix(".local")
-            .is_some_and(|host| host == &**a.hostname.hostname)
-    });
-    if is_own_mdns_name {
-        return Ok(None);
-    }
     let Some(port) = package_service_tls_port(&ctx.db.peek().await, gateway, name)? else {
         return Ok(None);
     };
-    https_redirect(uri, name, port).map(Some)
+    let is_dashboard = ctx
+        .account
+        .peek(|a| is_dashboard_mdns(name, port, &a.hostname.hostname));
+    if is_dashboard {
+        return Ok(None);
+    }
+    let path_and_query = uri.path_and_query().filter(|path| path.as_str() != "*");
+    https_redirect(path_and_query, name, port).map(Some)
 }
 
-fn https_redirect(uri: &Uri, name: &str, port: u16) -> Result<Response, Error> {
+fn is_dashboard_mdns(name: &str, port: u16, hostname: &str) -> bool {
+    port == HTTPS_PORT && name.strip_suffix(".local") == Some(hostname)
+}
+
+fn https_redirect(
+    path_and_query: Option<&http::uri::PathAndQuery>,
+    name: &str,
+    port: u16,
+) -> Result<Response, Error> {
     let authority = if port == HTTPS_PORT {
         name.to_owned()
     } else {
         format!("{name}:{port}")
     };
-    let mut parts = uri.to_owned().into_parts();
-    parts.scheme = Some(Scheme::HTTPS);
-    parts.authority = Some(
-        authority
-            .parse::<Authority>()
-            .with_kind(ErrorKind::ParseUrl)?,
-    );
-    let target = Uri::from_parts(parts).with_kind(ErrorKind::ParseUrl)?;
+    let target = Uri::builder()
+        .scheme(Scheme::HTTPS)
+        .authority(
+            authority
+                .parse::<Authority>()
+                .with_kind(ErrorKind::ParseUrl)?,
+        )
+        .path_and_query(path_and_query.map_or("/", |path| path.as_str()))
+        .build()
+        .with_kind(ErrorKind::ParseUrl)?;
     Response::builder()
         .status(StatusCode::TEMPORARY_REDIRECT)
         .header(
@@ -588,8 +590,17 @@ mod test {
         );
     }
 
-    fn location(uri: &str, port: u16) -> String {
-        let target = https_redirect(&uri.parse().unwrap(), "cloud.mydomain.com", port).unwrap();
+    #[test]
+    fn leaves_the_servers_mdns_name_on_the_dashboard_only_on_443() {
+        assert!(is_dashboard_mdns("myserver.local", HTTPS_PORT, "myserver"));
+        assert!(!is_dashboard_mdns("myserver.local", 8443, "myserver"));
+    }
+
+    fn location(uri: Option<&str>, port: u16) -> String {
+        let path_and_query = uri
+            .filter(|path| *path != "*")
+            .map(|uri| uri.parse().unwrap());
+        let target = https_redirect(path_and_query.as_ref(), "cloud.mydomain.com", port).unwrap();
         assert_eq!(target.status(), StatusCode::TEMPORARY_REDIRECT);
         target
             .headers()
@@ -603,15 +614,24 @@ mod test {
     #[test]
     fn keeps_the_path_and_query() {
         assert_eq!(
-            location("/photos?share=1", HTTPS_PORT),
+            location(Some("/photos?share=1"), HTTPS_PORT),
             "https://cloud.mydomain.com/photos?share=1"
+        );
+    }
+
+    #[test]
+    fn redirects_a_target_without_a_path_to_the_root() {
+        assert_eq!(location(None, HTTPS_PORT), "https://cloud.mydomain.com/");
+        assert_eq!(
+            location(Some("*"), HTTPS_PORT),
+            "https://cloud.mydomain.com/"
         );
     }
 
     #[test]
     fn names_a_tls_port_that_is_not_443() {
         assert_eq!(
-            location("/photos", 8443),
+            location(Some("/photos"), 8443),
             "https://cloud.mydomain.com:8443/photos"
         );
     }

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -6,7 +6,6 @@
 //! request carries no SNI, which is what tells the service apart from every
 //! other name this server answers to.
 
-use std::collections::BTreeSet;
 use std::net::IpAddr;
 
 use axum::Router;
@@ -18,13 +17,18 @@ use http::uri::{Authority, Scheme};
 use http::{HeaderValue, StatusCode, Uri};
 use imbl_value::InternedString;
 
+use crate::GatewayId;
 use crate::context::RpcContext;
+use crate::db::model::DatabaseModel;
+use crate::net::gateway::GatewayInfo;
 use crate::net::host::binding::BindInfo;
-use crate::net::service_interface::HostnameMetadata;
+use crate::net::service_interface::{HostnameMetadata, ServiceInterfaceType};
 use crate::prelude::*;
 
 const HTTPS_PORT: u16 = 443;
-const HTTPS_SCHEME: &str = "https";
+
+/// The longest name DNS carries.
+const MAX_NAME_LEN: usize = 253;
 
 /// Bounce a request whose `Host` names a domain an installed service is served
 /// on.
@@ -32,16 +36,19 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
     router.layer(axum::middleware::from_fn(
         move |req: Request, next: Next| {
             let ctx = ctx.clone();
+            // The listener resolves which of the server's networks a connection
+            // arrived on, and a domain is only served over its own gateways.
+            let gateway = req.extensions().get::<GatewayInfo>().map(|g| g.id.clone());
             async move {
-                if let Some(name) = host(&req) {
+                if let (Some(name), Some(gateway)) = (host(&req), gateway) {
                     let uri = req.uri().clone();
-                    match redirect(&ctx, &name, &uri).await {
+                    match redirect(&ctx, &gateway, &name, &uri).await {
                         Ok(Some(res)) => return res,
                         Ok(None) => (),
                         Err(e) => {
-                            tracing::warn!(
-                                "failed to check whether {name} is a service domain: {e}"
-                            );
+                            // Per request, so a malformed record must not flood
+                            // the log at page-load rate.
+                            tracing::debug!("failed to check the host {name}: {e}");
                             tracing::debug!("{e:?}");
                         }
                     }
@@ -53,38 +60,60 @@ pub fn layer(ctx: RpcContext, router: Router) -> Router {
 }
 
 /// The host the request named, lowercased and stripped of any port and of the
-/// root's trailing dot. `None` when the request names no host or names one by
-/// IP address, neither of which can be a configured domain.
+/// root's trailing dot.
+///
+/// `None` unless the result is a plausible domain name. An address, an
+/// over-long name, or anything outside the DNS character set is rejected here,
+/// so nothing else has to defend against a hostile `Host`.
 fn host(req: &Request) -> Option<String> {
-    let host = match req.headers().get(http::header::HOST) {
-        Some(host) => host.to_str().ok()?,
-        // An HTTP/2 request carries `:authority` instead, which hyper puts in
-        // the URI rather than in a header.
-        None => req.uri().host()?,
+    // The request target's authority wins over the header, and on HTTP/2 it is
+    // the only one of the two hyper fills in.
+    let host = match req.uri().host() {
+        Some(host) => host,
+        None => req.headers().get(http::header::HOST)?.to_str().ok()?,
     };
-    // A bracketed host is an IPv6 literal, and it carries the only other colon
-    // a host can hold.
-    if host.starts_with('[') {
+    let host = host.split_once(':').map_or(host, |(name, _)| name);
+    if host.parse::<IpAddr>().is_ok() {
         return None;
     }
-    let name = host.split_once(':').map_or(host, |(name, _)| name);
-    let name = name.trim_end_matches('.').to_ascii_lowercase();
-    if name.is_empty() || name.parse::<IpAddr>().is_ok() {
+    let name = host.trim_end_matches('.').to_ascii_lowercase();
+    if name.is_empty() || name.len() > MAX_NAME_LEN || !name.chars().all(is_name_char) {
         return None;
     }
     Some(name)
 }
 
-async fn redirect(ctx: &RpcContext, name: &str, uri: &Uri) -> Result<Option<Response>, Error> {
-    // Only a request in origin form carries a path to send across. `OPTIONS *`
-    // and the authority form of `CONNECT` do not.
+/// The character set a stored domain is matched on. A name outside it cannot be
+/// one, and would put whatever it does hold — userinfo, most of all — in a
+/// `Location` header this server signs its name to.
+fn is_name_char(c: char) -> bool {
+    c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.'
+}
+
+async fn redirect(
+    ctx: &RpcContext,
+    gateway: &GatewayId,
+    name: &str,
+    uri: &Uri,
+) -> Result<Option<Response>, Error> {
+    // A target that is not a path has nothing to send across: `CONNECT` names an
+    // authority, and `OPTIONS *` names nothing.
     if uri
         .path_and_query()
         .map_or(true, |p| !p.path().starts_with('/'))
     {
         return Ok(None);
     }
-    let Some(port) = service_tls_port(ctx, name).await? else {
+    // The dashboard is reached by the server's own `.local` name, so answer that
+    // before reading the database.
+    if ctx
+        .account
+        .peek(|a| a.hostname.hostname.local_domain_name())
+        == name
+    {
+        return Ok(None);
+    }
+    let Some(port) = service_tls_port(&ctx.db.peek().await, gateway, name)? else {
         return Ok(None);
     };
     https_redirect(uri, name, port).map(Some)
@@ -115,22 +144,25 @@ fn https_redirect(uri: &Uri, name: &str, port: u16) -> Result<Response, Error> {
         .with_kind(ErrorKind::Network)
 }
 
-/// The TLS port an installed service answers `name` on.
+/// The TLS port an installed service answers `name` on over `gateway`.
 ///
-/// The server's own host is not searched: its TLS listener proxies back to this
-/// very port, so redirecting a name it answers to would loop.
-async fn service_tls_port(ctx: &RpcContext, name: &str) -> Result<Option<u16>, Error> {
-    let db = ctx.db.peek().await;
+/// Only installed services are searched. The server's own host answers its names
+/// through a TLS listener that proxies back to this very port, so redirecting one
+/// of those would loop.
+fn service_tls_port(
+    db: &DatabaseModel,
+    gateway: &GatewayId,
+    name: &str,
+) -> Result<Option<u16>, Error> {
+    let key = InternedString::from(name);
     for (_, package) in db.as_public().as_package_data().as_entries()? {
         for (_, host) in package.as_hosts().as_entries()? {
-            let configured =
-                |domains: BTreeSet<InternedString>| domains.iter().any(|d| **d == *name);
-            if !configured(host.as_private_domains().keys()?)
-                && !configured(host.as_public_domains().keys()?)
+            if !host.as_private_domains().contains_key(&key)?
+                && !host.as_public_domains().contains_key(&key)?
             {
                 continue;
             }
-            if let Some(port) = tls_port(host.as_bindings().de()?.values(), name) {
+            if let Some(port) = tls_port(host.as_bindings().de()?.values(), gateway, name) {
                 return Ok(Some(port));
             }
         }
@@ -138,11 +170,16 @@ async fn service_tls_port(ctx: &RpcContext, name: &str) -> Result<Option<u16>, E
     Ok(None)
 }
 
-/// The port to send a browser that asked for `name` in plaintext.
+/// The port to send a browser that asked for `name` over `gateway` in plaintext.
 ///
-/// Only a domain qualifies. The server's IP addresses and its `.local` name are
-/// how the dashboard itself is reached, and every host carries them.
-fn tls_port<'a>(bindings: impl IntoIterator<Item = &'a BindInfo>, name: &str) -> Option<u16> {
+/// Only a domain qualifies, and only over a gateway it is served on. The
+/// server's IP addresses and its `.local` name are how the dashboard itself is
+/// reached, and every host carries them.
+fn tls_port<'a>(
+    bindings: impl IntoIterator<Item = &'a BindInfo>,
+    gateway: &GatewayId,
+    name: &str,
+) -> Option<u16> {
     bindings
         .into_iter()
         .filter(|bind| bind.enabled && serves_https(bind))
@@ -154,20 +191,26 @@ fn tls_port<'a>(bindings: impl IntoIterator<Item = &'a BindInfo>, name: &str) ->
                     addr.metadata,
                     HostnameMetadata::PrivateDomain { .. } | HostnameMetadata::PublicDomain { .. }
                 )
+                // A domain scoped to another gateway has no listener on this
+                // one, so sending a browser there ends in a refused handshake.
+                && addr.metadata.gateways().any(|g| g == gateway)
         })
         .filter_map(|addr| addr.port)
-        // A browser that reached this port named no port of its own, so it
-        // wants 443; any other port is a guess.
+        // A browser with no port in its address bar goes to 443, so prefer it.
         .min_by_key(|port| (*port != HTTPS_PORT, *port))
 }
 
 /// Whether a browser can open this binding's TLS port. A binding that carries
 /// another protocol over TLS — an Electrum server, a TURN server — has a domain
-/// and a TLS port like any other.
+/// and a TLS port like any other. A `ui` interface is browser-openable by
+/// definition, so it counts even when the package declared no scheme.
 fn serves_https(bind: &BindInfo) -> bool {
     bind.interfaces
         .values()
-        .any(|iface| iface.address_info.ssl_scheme.as_deref() == Some(HTTPS_SCHEME))
+        .any(|iface| match iface.address_info.ssl_scheme.as_deref() {
+            Some(scheme) => scheme == Scheme::HTTPS.as_str(),
+            None => matches!(iface.interface_type, ServiceInterfaceType::Ui),
+        })
 }
 
 #[cfg(test)]
@@ -176,15 +219,15 @@ mod test {
 
     use super::*;
     use crate::net::host::binding::{BindOptions, DerivedAddressInfo, NetInfo};
-    use crate::net::service_interface::{
-        AddressInfo, HostnameInfo, ServiceInterface, ServiceInterfaceType,
-    };
-    use crate::{GatewayId, HostId, Id, ServiceInterfaceId};
+    use crate::net::service_interface::{AddressInfo, HostnameInfo, ServiceInterface};
+    use crate::{HostId, Id, ServiceInterfaceId};
 
-    fn gateways() -> BTreeSet<GatewayId> {
-        [GatewayId::from(InternedString::from_static("eth0"))]
-            .into_iter()
-            .collect()
+    fn gateway(id: &'static str) -> GatewayId {
+        GatewayId::from(InternedString::from_static(id))
+    }
+
+    fn gateways() -> std::collections::BTreeSet<GatewayId> {
+        [gateway("eth0")].into_iter().collect()
     }
 
     fn private(hostname: &str, ssl: bool, port: u16) -> HostnameInfo {
@@ -206,7 +249,7 @@ mod test {
             hostname: InternedString::from(hostname),
             port: Some(port),
             metadata: HostnameMetadata::PublicDomain {
-                gateway: GatewayId::from(InternedString::from_static("eth0")),
+                gateway: gateway("eth0"),
             },
         }
     }
@@ -226,7 +269,7 @@ mod test {
     /// A binding serves its domains only through an exported interface, so
     /// every fixture needs one: `BindInfo::enabled_addresses` drops every
     /// address but the internal ones when `interfaces` is empty.
-    fn interface(ssl_scheme: Option<&str>) -> ServiceInterface {
+    fn interface(ssl_scheme: Option<&str>, kind: ServiceInterfaceType) -> ServiceInterface {
         let id = ServiceInterfaceId::from(Id::try_from("ui".to_owned()).unwrap());
         ServiceInterface {
             id,
@@ -241,15 +284,16 @@ mod test {
                 ssl_scheme: ssl_scheme.map(InternedString::intern),
                 suffix: String::new(),
             },
-            interface_type: ServiceInterfaceType::Ui,
+            interface_type: kind,
         }
     }
 
     fn binding_serving(
         ssl_scheme: Option<&str>,
+        kind: ServiceInterfaceType,
         available: impl IntoIterator<Item = HostnameInfo>,
     ) -> BindInfo {
-        let iface = interface(ssl_scheme);
+        let iface = interface(ssl_scheme, kind);
         BindInfo {
             enabled: true,
             options: BindOptions {
@@ -272,7 +316,11 @@ mod test {
     }
 
     fn binding(available: impl IntoIterator<Item = HostnameInfo>) -> BindInfo {
-        binding_serving(Some(HTTPS_SCHEME), available)
+        binding_serving(
+            Some(Scheme::HTTPS.as_str()),
+            ServiceInterfaceType::Ui,
+            available,
+        )
     }
 
     #[test]
@@ -282,7 +330,7 @@ mod test {
             private("cloud.mydomain.com", true, HTTPS_PORT),
         ])];
         assert_eq!(
-            tls_port(binds.iter(), "cloud.mydomain.com"),
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
@@ -291,7 +339,7 @@ mod test {
     fn sends_a_public_domain_to_its_tls_port() {
         let binds = [binding([public("cloud.mydomain.com", HTTPS_PORT)])];
         assert_eq!(
-            tls_port(binds.iter(), "cloud.mydomain.com"),
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
@@ -301,13 +349,19 @@ mod test {
     #[test]
     fn leaves_the_mdns_name_alone() {
         let binds = [binding([mdns("myserver.local", HTTPS_PORT)])];
-        assert_eq!(tls_port(binds.iter(), "myserver.local"), None);
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "myserver.local"),
+            None
+        );
     }
 
     #[test]
     fn ignores_a_domain_served_only_in_plaintext() {
         let binds = [binding([private("cloud.mydomain.com", false, 8080)])];
-        assert_eq!(tls_port(binds.iter(), "cloud.mydomain.com"), None);
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            None
+        );
     }
 
     // An Electrum server's TLS port speaks its own protocol, and a browser sent
@@ -316,27 +370,64 @@ mod test {
     fn ignores_a_tls_port_that_is_not_https() {
         let binds = [binding_serving(
             Some("ssl"),
+            ServiceInterfaceType::Api,
             [private("electrum.mydomain.com", true, 50002)],
         )];
-        assert_eq!(tls_port(binds.iter(), "electrum.mydomain.com"), None);
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "electrum.mydomain.com"),
+            None
+        );
     }
 
     #[test]
-    fn ignores_a_tls_port_with_no_declared_scheme() {
+    fn ignores_a_non_ui_port_with_no_declared_scheme() {
         let binds = [binding_serving(
             None,
+            ServiceInterfaceType::P2p,
             [private("p2p.mydomain.com", true, 8443)],
         )];
-        assert_eq!(tls_port(binds.iter(), "p2p.mydomain.com"), None);
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "p2p.mydomain.com"),
+            None
+        );
     }
 
-    // A binding a service has retired keeps its domains in the database, but
-    // nothing serves them.
+    // A package may bind a port the SDK knows no protocol for and still export a
+    // ui from it, which leaves the scheme unset.
+    #[test]
+    fn sends_a_ui_with_no_declared_scheme() {
+        let binds = [binding_serving(
+            None,
+            ServiceInterfaceType::Ui,
+            [private("cloud.mydomain.com", true, 8443)],
+        )];
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            Some(8443)
+        );
+    }
+
+    // A domain is served only over the gateways it was added on, and the vhost
+    // refuses the handshake anywhere else.
+    #[test]
+    fn ignores_a_domain_scoped_to_another_gateway() {
+        let binds = [binding([private("cloud.mydomain.com", true, HTTPS_PORT)])];
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("wg0"), "cloud.mydomain.com"),
+            None
+        );
+    }
+
+    // `setupInterfaces` ends by disabling every binding the pass did not
+    // declare, and a disabled binding keeps its domains in the database.
     #[test]
     fn ignores_a_disabled_binding() {
         let mut bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
         bind.enabled = false;
-        assert_eq!(tls_port([&bind], "cloud.mydomain.com"), None);
+        assert_eq!(
+            tls_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
+            None
+        );
     }
 
     #[test]
@@ -346,7 +437,10 @@ mod test {
             InternedString::from_static("cloud.mydomain.com"),
             HTTPS_PORT,
         ));
-        assert_eq!(tls_port([&bind], "cloud.mydomain.com"), None);
+        assert_eq!(
+            tls_port([&bind], &gateway("eth0"), "cloud.mydomain.com"),
+            None
+        );
     }
 
     #[test]
@@ -356,7 +450,7 @@ mod test {
             binding([private("cloud.mydomain.com", true, HTTPS_PORT)]),
         ];
         assert_eq!(
-            tls_port(binds.iter(), "cloud.mydomain.com"),
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
             Some(HTTPS_PORT)
         );
     }
@@ -367,7 +461,61 @@ mod test {
             binding([private("cloud.mydomain.com", true, 9443)]),
             binding([private("cloud.mydomain.com", true, 8443)]),
         ];
-        assert_eq!(tls_port(binds.iter(), "cloud.mydomain.com"), Some(8443));
+        assert_eq!(
+            tls_port(binds.iter(), &gateway("eth0"), "cloud.mydomain.com"),
+            Some(8443)
+        );
+    }
+
+    fn host_holding(domain: &str, bind: &BindInfo) -> imbl_value::Value {
+        imbl_value::json!({
+            "bindings": { "80": imbl_value::to_value(bind).unwrap() },
+            "bindingRanges": {},
+            "publicDomains": {},
+            "privateDomains": { domain: ["eth0"] },
+            "portForwards": [],
+        })
+    }
+
+    fn db(server_host: imbl_value::Value, package_host: imbl_value::Value) -> DatabaseModel {
+        DatabaseModel::from(imbl_value::json!({
+            "public": {
+                "serverInfo": { "network": { "host": server_host } },
+                "packageData": { "nextcloud": { "hosts": { "ui": package_host } } },
+            }
+        }))
+    }
+
+    fn empty_host() -> imbl_value::Value {
+        imbl_value::json!({
+            "bindings": {},
+            "bindingRanges": {},
+            "publicDomains": {},
+            "privateDomains": {},
+            "portForwards": [],
+        })
+    }
+
+    #[test]
+    fn finds_a_service_domain_in_the_database() {
+        let bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
+        let db = db(empty_host(), host_holding("cloud.mydomain.com", &bind));
+        assert_eq!(
+            service_tls_port(&db, &gateway("eth0"), "cloud.mydomain.com").unwrap(),
+            Some(HTTPS_PORT)
+        );
+    }
+
+    // The server's own TLS listener proxies back to the port this redirect runs
+    // on, so a name it answers to must never be redirected.
+    #[test]
+    fn does_not_search_the_servers_own_host() {
+        let bind = binding([private("home.mydomain.com", true, HTTPS_PORT)]);
+        let db = db(host_holding("home.mydomain.com", &bind), empty_host());
+        assert_eq!(
+            service_tls_port(&db, &gateway("eth0"), "home.mydomain.com").unwrap(),
+            None
+        );
     }
 
     fn request(host: &str) -> Request {
@@ -394,11 +542,21 @@ mod test {
         );
     }
 
-    // An HTTP/2 request has no `Host` header; hyper puts `:authority` in the URI.
     #[test]
     fn reads_the_authority_of_a_request_with_no_host_header() {
         let req = Request::builder()
             .uri("https://cloud.mydomain.com/photos")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(host(&req).as_deref(), Some("cloud.mydomain.com"));
+    }
+
+    // RFC 9112 gives the request target's authority precedence over the header.
+    #[test]
+    fn prefers_the_authority_to_the_header() {
+        let req = Request::builder()
+            .uri("http://cloud.mydomain.com/photos")
+            .header(http::header::HOST, "other.mydomain.com")
             .body(Body::empty())
             .unwrap();
         assert_eq!(host(&req).as_deref(), Some("cloud.mydomain.com"));
@@ -409,6 +567,15 @@ mod test {
         assert_eq!(host(&request("192.168.1.5")), None);
         assert_eq!(host(&request("192.168.1.5:80")), None);
         assert_eq!(host(&request("[fd00::1]:80")), None);
+    }
+
+    // Userinfo in the authority would otherwise reach a `Location` header, where
+    // the browser reads everything after the `@` as the destination.
+    #[test]
+    fn skips_a_host_outside_the_name_character_set() {
+        assert_eq!(host(&request("admin@evil.example")), None);
+        assert_eq!(host(&request("cloud.mydomain.com_")), None);
+        assert_eq!(host(&request(&format!("{}.com", "a".repeat(250)))), None);
     }
 
     fn location(uri: &str, port: u16) -> String {

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -1,0 +1,441 @@
+//! HTTP→HTTPS redirect for a service's domains on the StartOS UI's port.
+//!
+//! Port 80 belongs to the StartOS UI, whose listener answers on every address
+//! the server holds. A browser given a bare domain name tries port 80 first, so
+//! typing a service's private domain lands on the dashboard: a plaintext
+//! request carries no SNI, which is what tells the service apart from every
+//! other name this server answers to.
+
+use std::collections::BTreeSet;
+use std::net::IpAddr;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::Request;
+use axum::middleware::Next;
+use axum::response::Response;
+use http::uri::{Authority, Scheme};
+use http::{HeaderValue, StatusCode, Uri};
+use imbl_value::InternedString;
+
+use crate::context::RpcContext;
+use crate::net::host::binding::BindInfo;
+use crate::net::service_interface::HostnameMetadata;
+use crate::prelude::*;
+
+const HTTPS_PORT: u16 = 443;
+const HTTPS_SCHEME: &str = "https";
+
+/// Bounce a request whose `Host` names a domain an installed service is served
+/// on.
+pub fn layer(ctx: RpcContext, router: Router) -> Router {
+    router.layer(axum::middleware::from_fn(
+        move |req: Request, next: Next| {
+            let ctx = ctx.clone();
+            async move {
+                if let Some(name) = host(&req) {
+                    let uri = req.uri().clone();
+                    match redirect(&ctx, &name, &uri).await {
+                        Ok(Some(res)) => return res,
+                        Ok(None) => (),
+                        Err(e) => {
+                            tracing::warn!(
+                                "failed to check whether {name} is a service domain: {e}"
+                            );
+                            tracing::debug!("{e:?}");
+                        }
+                    }
+                }
+                next.run(req).await
+            }
+        },
+    ))
+}
+
+/// The host the request named, lowercased and stripped of any port and of the
+/// root's trailing dot. `None` when the request names no host or names one by
+/// IP address, neither of which can be a configured domain.
+fn host(req: &Request) -> Option<String> {
+    let host = match req.headers().get(http::header::HOST) {
+        Some(host) => host.to_str().ok()?,
+        // An HTTP/2 request carries `:authority` instead, which hyper puts in
+        // the URI rather than in a header.
+        None => req.uri().host()?,
+    };
+    // A bracketed host is an IPv6 literal, and it carries the only other colon
+    // a host can hold.
+    if host.starts_with('[') {
+        return None;
+    }
+    let name = host.split_once(':').map_or(host, |(name, _)| name);
+    let name = name.trim_end_matches('.').to_ascii_lowercase();
+    if name.is_empty() || name.parse::<IpAddr>().is_ok() {
+        return None;
+    }
+    Some(name)
+}
+
+async fn redirect(ctx: &RpcContext, name: &str, uri: &Uri) -> Result<Option<Response>, Error> {
+    // Only a request in origin form carries a path to send across. `OPTIONS *`
+    // and the authority form of `CONNECT` do not.
+    if uri
+        .path_and_query()
+        .map_or(true, |p| !p.path().starts_with('/'))
+    {
+        return Ok(None);
+    }
+    let Some(port) = service_tls_port(ctx, name).await? else {
+        return Ok(None);
+    };
+    https_redirect(uri, name, port).map(Some)
+}
+
+/// The same request, addressed to `name` over TLS on `port`.
+fn https_redirect(uri: &Uri, name: &str, port: u16) -> Result<Response, Error> {
+    let authority = if port == HTTPS_PORT {
+        name.to_owned()
+    } else {
+        format!("{name}:{port}")
+    };
+    let mut parts = uri.to_owned().into_parts();
+    parts.scheme = Some(Scheme::HTTPS);
+    parts.authority = Some(
+        authority
+            .parse::<Authority>()
+            .with_kind(ErrorKind::ParseUrl)?,
+    );
+    let target = Uri::from_parts(parts).with_kind(ErrorKind::ParseUrl)?;
+    Response::builder()
+        .status(StatusCode::TEMPORARY_REDIRECT)
+        .header(
+            http::header::LOCATION,
+            HeaderValue::from_str(&target.to_string()).with_kind(ErrorKind::ParseUrl)?,
+        )
+        .body(Body::empty())
+        .with_kind(ErrorKind::Network)
+}
+
+/// The TLS port an installed service answers `name` on.
+///
+/// The server's own host is not searched: its TLS listener proxies back to this
+/// very port, so redirecting a name it answers to would loop.
+async fn service_tls_port(ctx: &RpcContext, name: &str) -> Result<Option<u16>, Error> {
+    let db = ctx.db.peek().await;
+    for (_, package) in db.as_public().as_package_data().as_entries()? {
+        for (_, host) in package.as_hosts().as_entries()? {
+            let configured =
+                |domains: BTreeSet<InternedString>| domains.iter().any(|d| **d == *name);
+            if !configured(host.as_private_domains().keys()?)
+                && !configured(host.as_public_domains().keys()?)
+            {
+                continue;
+            }
+            if let Some(port) = tls_port(host.as_bindings().de()?.values(), name) {
+                return Ok(Some(port));
+            }
+        }
+    }
+    Ok(None)
+}
+
+/// The port to send a browser that asked for `name` in plaintext.
+///
+/// Only a domain qualifies. The server's IP addresses and its `.local` name are
+/// how the dashboard itself is reached, and every host carries them.
+fn tls_port<'a>(bindings: impl IntoIterator<Item = &'a BindInfo>, name: &str) -> Option<u16> {
+    bindings
+        .into_iter()
+        .filter(|bind| bind.enabled && serves_https(bind))
+        .flat_map(|bind| bind.enabled_addresses())
+        .filter(|addr| {
+            addr.ssl
+                && *addr.hostname == *name
+                && matches!(
+                    addr.metadata,
+                    HostnameMetadata::PrivateDomain { .. } | HostnameMetadata::PublicDomain { .. }
+                )
+        })
+        .filter_map(|addr| addr.port)
+        // A browser that reached this port named no port of its own, so it
+        // wants 443; any other port is a guess.
+        .min_by_key(|port| (*port != HTTPS_PORT, *port))
+}
+
+/// Whether a browser can open this binding's TLS port. A binding that carries
+/// another protocol over TLS — an Electrum server, a TURN server — has a domain
+/// and a TLS port like any other.
+fn serves_https(bind: &BindInfo) -> bool {
+    bind.interfaces
+        .values()
+        .any(|iface| iface.address_info.ssl_scheme.as_deref() == Some(HTTPS_SCHEME))
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::net::host::binding::{BindOptions, DerivedAddressInfo, NetInfo};
+    use crate::net::service_interface::{
+        AddressInfo, HostnameInfo, ServiceInterface, ServiceInterfaceType,
+    };
+    use crate::{GatewayId, HostId, Id, ServiceInterfaceId};
+
+    fn gateways() -> BTreeSet<GatewayId> {
+        [GatewayId::from(InternedString::from_static("eth0"))]
+            .into_iter()
+            .collect()
+    }
+
+    fn private(hostname: &str, ssl: bool, port: u16) -> HostnameInfo {
+        HostnameInfo {
+            ssl,
+            public: false,
+            hostname: InternedString::from(hostname),
+            port: Some(port),
+            metadata: HostnameMetadata::PrivateDomain {
+                gateways: gateways(),
+            },
+        }
+    }
+
+    fn public(hostname: &str, port: u16) -> HostnameInfo {
+        HostnameInfo {
+            ssl: true,
+            public: true,
+            hostname: InternedString::from(hostname),
+            port: Some(port),
+            metadata: HostnameMetadata::PublicDomain {
+                gateway: GatewayId::from(InternedString::from_static("eth0")),
+            },
+        }
+    }
+
+    fn mdns(hostname: &str, port: u16) -> HostnameInfo {
+        HostnameInfo {
+            ssl: true,
+            public: false,
+            hostname: InternedString::from(hostname),
+            port: Some(port),
+            metadata: HostnameMetadata::Mdns {
+                gateways: gateways(),
+            },
+        }
+    }
+
+    /// A binding serves its domains only through an exported interface, so
+    /// every fixture needs one: `BindInfo::enabled_addresses` drops every
+    /// address but the internal ones when `interfaces` is empty.
+    fn interface(ssl_scheme: Option<&str>) -> ServiceInterface {
+        let id = ServiceInterfaceId::from(Id::try_from("ui".to_owned()).unwrap());
+        ServiceInterface {
+            id,
+            name: "UI".to_owned(),
+            description: String::new(),
+            masked: false,
+            address_info: AddressInfo {
+                username: None,
+                host_id: HostId::from(Id::try_from("ui".to_owned()).unwrap()),
+                internal_port: 80,
+                scheme: Some(InternedString::intern("http")),
+                ssl_scheme: ssl_scheme.map(InternedString::intern),
+                suffix: String::new(),
+            },
+            interface_type: ServiceInterfaceType::Ui,
+        }
+    }
+
+    fn binding_serving(
+        ssl_scheme: Option<&str>,
+        available: impl IntoIterator<Item = HostnameInfo>,
+    ) -> BindInfo {
+        let iface = interface(ssl_scheme);
+        BindInfo {
+            enabled: true,
+            options: BindOptions {
+                preferred_external_port: 80,
+                add_ssl: None,
+                secure: None,
+            },
+            net: NetInfo {
+                assigned_port: Some(8080),
+                assigned_ssl_port: Some(HTTPS_PORT),
+            },
+            addresses: DerivedAddressInfo {
+                available: available.into_iter().collect(),
+                ..Default::default()
+            },
+            interfaces: [(iface.id.clone(), iface)]
+                .into_iter()
+                .collect::<BTreeMap<_, _>>(),
+        }
+    }
+
+    fn binding(available: impl IntoIterator<Item = HostnameInfo>) -> BindInfo {
+        binding_serving(Some(HTTPS_SCHEME), available)
+    }
+
+    #[test]
+    fn sends_a_service_domain_to_its_tls_port() {
+        let binds = [binding([
+            private("cloud.mydomain.com", false, 8080),
+            private("cloud.mydomain.com", true, HTTPS_PORT),
+        ])];
+        assert_eq!(
+            tls_port(binds.iter(), "cloud.mydomain.com"),
+            Some(HTTPS_PORT)
+        );
+    }
+
+    #[test]
+    fn sends_a_public_domain_to_its_tls_port() {
+        let binds = [binding([public("cloud.mydomain.com", HTTPS_PORT)])];
+        assert_eq!(
+            tls_port(binds.iter(), "cloud.mydomain.com"),
+            Some(HTTPS_PORT)
+        );
+    }
+
+    // The dashboard is reached by the server's `.local` name over plaintext, and
+    // every host carries that name.
+    #[test]
+    fn leaves_the_mdns_name_alone() {
+        let binds = [binding([mdns("myserver.local", HTTPS_PORT)])];
+        assert_eq!(tls_port(binds.iter(), "myserver.local"), None);
+    }
+
+    #[test]
+    fn ignores_a_domain_served_only_in_plaintext() {
+        let binds = [binding([private("cloud.mydomain.com", false, 8080)])];
+        assert_eq!(tls_port(binds.iter(), "cloud.mydomain.com"), None);
+    }
+
+    // An Electrum server's TLS port speaks its own protocol, and a browser sent
+    // there would speak HTTP at it.
+    #[test]
+    fn ignores_a_tls_port_that_is_not_https() {
+        let binds = [binding_serving(
+            Some("ssl"),
+            [private("electrum.mydomain.com", true, 50002)],
+        )];
+        assert_eq!(tls_port(binds.iter(), "electrum.mydomain.com"), None);
+    }
+
+    #[test]
+    fn ignores_a_tls_port_with_no_declared_scheme() {
+        let binds = [binding_serving(
+            None,
+            [private("p2p.mydomain.com", true, 8443)],
+        )];
+        assert_eq!(tls_port(binds.iter(), "p2p.mydomain.com"), None);
+    }
+
+    // A binding a service has retired keeps its domains in the database, but
+    // nothing serves them.
+    #[test]
+    fn ignores_a_disabled_binding() {
+        let mut bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
+        bind.enabled = false;
+        assert_eq!(tls_port([&bind], "cloud.mydomain.com"), None);
+    }
+
+    #[test]
+    fn ignores_an_address_the_operator_switched_off() {
+        let mut bind = binding([private("cloud.mydomain.com", true, HTTPS_PORT)]);
+        bind.addresses.disabled.insert((
+            InternedString::from_static("cloud.mydomain.com"),
+            HTTPS_PORT,
+        ));
+        assert_eq!(tls_port([&bind], "cloud.mydomain.com"), None);
+    }
+
+    #[test]
+    fn prefers_443_to_another_bindings_tls_port() {
+        let binds = [
+            binding([private("cloud.mydomain.com", true, 8443)]),
+            binding([private("cloud.mydomain.com", true, HTTPS_PORT)]),
+        ];
+        assert_eq!(
+            tls_port(binds.iter(), "cloud.mydomain.com"),
+            Some(HTTPS_PORT)
+        );
+    }
+
+    #[test]
+    fn falls_back_to_the_lowest_tls_port() {
+        let binds = [
+            binding([private("cloud.mydomain.com", true, 9443)]),
+            binding([private("cloud.mydomain.com", true, 8443)]),
+        ];
+        assert_eq!(tls_port(binds.iter(), "cloud.mydomain.com"), Some(8443));
+    }
+
+    fn request(host: &str) -> Request {
+        Request::builder()
+            .uri("/photos?share=1")
+            .header(http::header::HOST, host)
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    #[test]
+    fn reads_a_host_name() {
+        assert_eq!(
+            host(&request("Cloud.MyDomain.com:80")).as_deref(),
+            Some("cloud.mydomain.com")
+        );
+    }
+
+    #[test]
+    fn reads_a_host_name_written_from_the_root() {
+        assert_eq!(
+            host(&request("cloud.mydomain.com.")).as_deref(),
+            Some("cloud.mydomain.com")
+        );
+    }
+
+    // An HTTP/2 request has no `Host` header; hyper puts `:authority` in the URI.
+    #[test]
+    fn reads_the_authority_of_a_request_with_no_host_header() {
+        let req = Request::builder()
+            .uri("https://cloud.mydomain.com/photos")
+            .body(Body::empty())
+            .unwrap();
+        assert_eq!(host(&req).as_deref(), Some("cloud.mydomain.com"));
+    }
+
+    #[test]
+    fn skips_a_host_named_by_address() {
+        assert_eq!(host(&request("192.168.1.5")), None);
+        assert_eq!(host(&request("192.168.1.5:80")), None);
+        assert_eq!(host(&request("[fd00::1]:80")), None);
+    }
+
+    fn location(uri: &str, port: u16) -> String {
+        let target = https_redirect(&uri.parse().unwrap(), "cloud.mydomain.com", port).unwrap();
+        assert_eq!(target.status(), StatusCode::TEMPORARY_REDIRECT);
+        target
+            .headers()
+            .get(http::header::LOCATION)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned()
+    }
+
+    #[test]
+    fn keeps_the_path_and_query() {
+        assert_eq!(
+            location("/photos?share=1", HTTPS_PORT),
+            "https://cloud.mydomain.com/photos?share=1"
+        );
+    }
+
+    #[test]
+    fn names_a_tls_port_that_is_not_443() {
+        assert_eq!(
+            location("/photos", 8443),
+            "https://cloud.mydomain.com:8443/photos"
+        );
+    }
+}

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -3224,8 +3224,7 @@ pub fn lookup_info_by_addr(
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
     addr: SocketAddr,
 ) -> Option<(&GatewayId, &NetworkInterfaceInfo)> {
-    // A dual-stack listener reports an IPv4 connection's addresses in mapped
-    // form, which never equals the IPv4 address a gateway holds.
+    // Canonicalize IPv4-mapped listener addresses before matching gateways.
     let ip = addr.ip().to_canonical();
     ip_info.iter().find(|(_, i)| {
         i.ip_info
@@ -3257,8 +3256,7 @@ impl<V: MetadataVisitor> Visit<V> for NetworkInterfaceListenerAcceptMetadata {
     }
 }
 
-/// A TCP listener on `[::]:port` that resolves the connection's `GatewayInfo`
-/// from its local address on each accept.
+/// Accepts wildcard TCP connections with their matching `GatewayInfo`.
 pub struct WildcardListener {
     listener: TcpListener,
     ip_info: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
@@ -3360,7 +3358,6 @@ mod lookup_tests {
         );
     }
 
-    // A gateway answers for the address it holds, not for its whole subnet.
     #[test]
     fn another_address_in_the_same_subnet_finds_nothing() {
         let ip_info = gateway_holding("192.168.1.5/24");
@@ -3378,9 +3375,6 @@ mod lookup_tests {
         );
     }
 
-    // Only the mapped form may be unwrapped. `to_ipv4` would also unwrap the
-    // deprecated IPv4-compatible form and hand that connection a gateway that
-    // does not serve it.
     #[test]
     fn an_ipv4_compatible_address_is_left_alone() {
         let ip_info = gateway_holding("192.168.1.5/24");

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -3224,7 +3224,7 @@ pub fn lookup_info_by_addr(
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
     addr: SocketAddr,
 ) -> Option<(&GatewayId, &NetworkInterfaceInfo)> {
-    // Canonicalize IPv4-mapped listener addresses before matching gateways.
+    // IPv4 clients arrive mapped through the dual-stack listener.
     let ip = addr.ip().to_canonical();
     ip_info.iter().find(|(_, i)| {
         i.ip_info

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -3224,10 +3224,13 @@ pub fn lookup_info_by_addr(
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
     addr: SocketAddr,
 ) -> Option<(&GatewayId, &NetworkInterfaceInfo)> {
+    // A dual-stack listener reports an IPv4 peer's address in its mapped form,
+    // which is not equal to the IPv4 address a gateway holds.
+    let ip = addr.ip().to_canonical();
     ip_info.iter().find(|(_, i)| {
         i.ip_info
             .as_ref()
-            .map_or(false, |i| i.subnets.iter().any(|i| i.addr() == addr.ip()))
+            .map_or(false, |i| i.subnets.iter().any(|i| i.addr() == ip))
     })
 }
 
@@ -3326,6 +3329,44 @@ impl Accept for WildcardListener {
             )));
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod lookup_tests {
+    use super::*;
+
+    fn gateway_holding(addr: &str) -> OrdMap<GatewayId, NetworkInterfaceInfo> {
+        let mut ip_info = crate::db::model::public::IpInfo::default();
+        ip_info.subnets.insert(addr.parse().unwrap());
+        [(
+            GatewayId::from(InternedString::from_static("eth0")),
+            NetworkInterfaceInfo {
+                ip_info: Some(std::sync::Arc::new(ip_info)),
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect()
+    }
+
+    // The UI's port-80 listener is a dual-stack `[::]` bind, so an IPv4 client's
+    // local address arrives mapped into IPv6.
+    #[test]
+    fn an_ipv4_mapped_local_address_finds_its_gateway() {
+        let ip_info = gateway_holding("192.168.1.5/24");
+        let mapped: SocketAddr = "[::ffff:192.168.1.5]:80".parse().unwrap();
+        assert_eq!(
+            lookup_info_by_addr(&ip_info, mapped).map(|(id, _)| id.as_str()),
+            Some("eth0")
+        );
+    }
+
+    #[test]
+    fn an_address_no_gateway_holds_finds_nothing() {
+        let ip_info = gateway_holding("192.168.1.5/24");
+        let other: SocketAddr = "10.0.3.1:80".parse().unwrap();
+        assert!(lookup_info_by_addr(&ip_info, other).is_none());
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -3224,8 +3224,8 @@ pub fn lookup_info_by_addr(
     ip_info: &OrdMap<GatewayId, NetworkInterfaceInfo>,
     addr: SocketAddr,
 ) -> Option<(&GatewayId, &NetworkInterfaceInfo)> {
-    // A dual-stack listener reports an IPv4 peer's address in its mapped form,
-    // which is not equal to the IPv4 address a gateway holds.
+    // A dual-stack listener reports an IPv4 connection's addresses in mapped
+    // form, which never equals the IPv4 address a gateway holds.
     let ip = addr.ip().to_canonical();
     ip_info.iter().find(|(_, i)| {
         i.ip_info
@@ -3257,8 +3257,8 @@ impl<V: MetadataVisitor> Visit<V> for NetworkInterfaceListenerAcceptMetadata {
     }
 }
 
-/// A simple TCP listener on 0.0.0.0:port that looks up GatewayInfo from the
-/// connection's local address on each accepted connection.
+/// A TCP listener on `[::]:port` that resolves the connection's `GatewayInfo`
+/// from its local address on each accept.
 pub struct WildcardListener {
     listener: TcpListener,
     ip_info: Watch<OrdMap<GatewayId, NetworkInterfaceInfo>>,
@@ -3350,8 +3350,6 @@ mod lookup_tests {
         .collect()
     }
 
-    // The UI's port-80 listener is a dual-stack `[::]` bind, so an IPv4 client's
-    // local address arrives mapped into IPv6.
     #[test]
     fn an_ipv4_mapped_local_address_finds_its_gateway() {
         let ip_info = gateway_holding("192.168.1.5/24");
@@ -3362,11 +3360,26 @@ mod lookup_tests {
         );
     }
 
+    // A gateway answers for the address it holds, not for its whole subnet.
     #[test]
-    fn an_address_no_gateway_holds_finds_nothing() {
+    fn another_address_in_the_same_subnet_finds_nothing() {
         let ip_info = gateway_holding("192.168.1.5/24");
-        let other: SocketAddr = "10.0.3.1:80".parse().unwrap();
-        assert!(lookup_info_by_addr(&ip_info, other).is_none());
+        let neighbour: SocketAddr = "192.168.1.99:80".parse().unwrap();
+        assert!(lookup_info_by_addr(&ip_info, neighbour).is_none());
+    }
+
+    // Canonicalizing must unwrap only the mapped form. `to_ipv4` would read
+    // `::1` as `0.0.0.1` and hand a loopback connection someone's gateway.
+    #[test]
+    fn a_native_ipv6_address_is_left_alone() {
+        let ip_info = gateway_holding("fd00::1/64");
+        let native: SocketAddr = "[fd00::1]:80".parse().unwrap();
+        assert_eq!(
+            lookup_info_by_addr(&ip_info, native).map(|(id, _)| id.as_str()),
+            Some("eth0")
+        );
+        let loopback: SocketAddr = "[::1]:80".parse().unwrap();
+        assert!(lookup_info_by_addr(&ip_info, loopback).is_none());
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -3368,18 +3368,24 @@ mod lookup_tests {
         assert!(lookup_info_by_addr(&ip_info, neighbour).is_none());
     }
 
-    // Canonicalizing must unwrap only the mapped form. `to_ipv4` would read
-    // `::1` as `0.0.0.1` and hand a loopback connection someone's gateway.
     #[test]
-    fn a_native_ipv6_address_is_left_alone() {
+    fn a_native_ipv6_address_finds_its_gateway() {
         let ip_info = gateway_holding("fd00::1/64");
         let native: SocketAddr = "[fd00::1]:80".parse().unwrap();
         assert_eq!(
             lookup_info_by_addr(&ip_info, native).map(|(id, _)| id.as_str()),
             Some("eth0")
         );
-        let loopback: SocketAddr = "[::1]:80".parse().unwrap();
-        assert!(lookup_info_by_addr(&ip_info, loopback).is_none());
+    }
+
+    // Only the mapped form may be unwrapped. `to_ipv4` would also unwrap the
+    // deprecated IPv4-compatible form and hand that connection a gateway that
+    // does not serve it.
+    #[test]
+    fn an_ipv4_compatible_address_is_left_alone() {
+        let ip_info = gateway_holding("192.168.1.5/24");
+        let compatible: SocketAddr = "[::192.168.1.5]:80".parse().unwrap();
+        assert!(lookup_info_by_addr(&ip_info, compatible).is_none());
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/host/address.rs
+++ b/shared-libs/crates/start-core/src/net/host/address.rs
@@ -661,9 +661,11 @@ pub async fn add_private_domain<Kind: HostApiKind>(
     AddPrivateDomainParams { fqdn, gateway }: AddPrivateDomainParams,
     inheritance: Kind::Inheritance,
 ) -> Result<bool, Error> {
-    let fqdn = InternedString::intern(fqdn.to_ascii_lowercase());
+    let fqdn = InternedString::intern(fqdn.trim_end_matches('.').to_ascii_lowercase());
     ctx.db
         .mutate(|db| {
+            let hostname = ServerHostname::load(db.as_public().as_server_info())?;
+            hostname.reject_private_domain(&fqdn)?;
             let is_new = !Kind::host_for(&inheritance, db)?
                 .as_private_domains()
                 .de()?
@@ -674,7 +676,6 @@ pub async fn add_private_domain<Kind: HostApiKind>(
                 .upsert(&fqdn, || Ok(BTreeSet::new()))?
                 .mutate(|d| Ok(d.insert(gateway.clone())))?;
             handle_duplicates(db)?;
-            let hostname = ServerHostname::load(db.as_public().as_server_info())?;
             let gateways = db
                 .as_public()
                 .as_server_info()
@@ -912,6 +913,15 @@ mod test {
             domain_disabled(&a, 42000),
             "an enabled IP on a different gateway must not honor the domain"
         );
+    }
+
+    #[test]
+    fn rejects_the_servers_mdns_name_as_a_private_domain() {
+        let hostname = ServerHostname::new(InternedString::intern("myserver")).unwrap();
+
+        assert!(hostname.reject_private_domain("myserver.local").is_err());
+        assert!(hostname.reject_private_domain("myserver.local.").is_err());
+        assert!(hostname.reject_private_domain("service.local").is_ok());
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/host/mod.rs
+++ b/shared-libs/crates/start-core/src/net/host/mod.rs
@@ -145,6 +145,7 @@ impl Model<Host> {
         available_ports: &AvailablePorts,
     ) -> Result<(), Error> {
         let this = self.destructure_mut();
+        this.private_domains.remove(&mdns.local_domain_name())?;
 
         // ips
         for (_, bind) in this.bindings.as_entries_mut()? {

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures::FutureExt;
+use http::uri::{Authority, Scheme};
 use http::{HeaderMap, HeaderValue};
 use http_body_util::combinators::BoxBody;
 use http_body_util::{BodyExt, Full};
@@ -199,11 +200,33 @@ fn apply_request_policy<B>(
     Ok(())
 }
 
+pub fn request_authority<B>(req: &Request<B>) -> Option<Authority> {
+    req.uri().authority().cloned().or_else(|| {
+        req.headers()
+            .get(http::header::HOST)?
+            .to_str()
+            .ok()?
+            .parse()
+            .ok()
+    })
+}
+
+pub fn https_redirect_uri(uri: &http::Uri, authority: Authority) -> Result<http::Uri, http::Error> {
+    let path_and_query = uri
+        .path_and_query()
+        .filter(|path| path.as_str() != "*")
+        .map_or("/", |path| path.as_str());
+    http::Uri::builder()
+        .scheme(Scheme::HTTPS)
+        .authority(authority)
+        .path_and_query(path_and_query)
+        .build()
+}
+
 pub async fn handle_http_on_https(stream: impl ReadWriter + Unpin + 'static) -> Result<(), Error> {
     use axum::body::Body;
     use axum::extract::Request;
     use axum::response::Response;
-    use http::Uri;
 
     use crate::net::static_server::server_error;
 
@@ -213,20 +236,11 @@ pub async fn handle_http_on_https(stream: impl ReadWriter + Unpin + 'static) -> 
             hyper_util::service::TowerToHyperService::new(axum::Router::new().fallback(
                 axum::routing::method_routing::any(move |req: Request| async move {
                     match async move {
-                        let host = req
-                            .headers()
-                            .get(http::header::HOST)
-                            .and_then(|host| host.to_str().ok());
-                        if let Some(host) = host {
-                            let uri = Uri::from_parts({
-                                let mut parts = req.uri().to_owned().into_parts();
-                                parts.scheme = Some("https".parse()?);
-                                parts.authority = Some(host.parse()?);
-                                parts
-                            })?;
+                        if let Some(authority) = request_authority(&req) {
+                            let target = https_redirect_uri(req.uri(), authority)?;
                             Response::builder()
                                 .status(http::StatusCode::TEMPORARY_REDIRECT)
-                                .header(http::header::LOCATION, uri.to_string())
+                                .header(http::header::LOCATION, target.to_string())
                                 .body(Body::default())
                         } else {
                             Response::builder()

--- a/shared-libs/crates/start-core/src/net/mod.rs
+++ b/shared-libs/crates/start-core/src/net/mod.rs
@@ -3,6 +3,7 @@ use rpc_toolkit::{Context, HandlerExt, ParentHandler};
 pub mod acme;
 pub mod dns;
 pub mod dns_update;
+pub mod domain_redirect;
 pub mod forward;
 pub mod gateway;
 pub mod host;

--- a/shared-libs/crates/start-core/src/net/static_server.rs
+++ b/shared-libs/crates/start-core/src/net/static_server.rs
@@ -62,6 +62,7 @@ pub trait UiContext: Context + AsRef<RpcContinuations> + Clone + Sized {
     fn extend_router(self, router: Router) -> Router {
         router
     }
+    /// Applies layers after the UI fallback is installed.
     fn apply_outer_layers(self, router: Router) -> Router {
         router
     }

--- a/shared-libs/crates/start-core/src/net/static_server.rs
+++ b/shared-libs/crates/start-core/src/net/static_server.rs
@@ -62,9 +62,7 @@ pub trait UiContext: Context + AsRef<RpcContinuations> + Clone + Sized {
     fn extend_router(self, router: Router) -> Router {
         router
     }
-    /// Wrap the assembled router, so a layer added here applies to every route
-    /// and to the fallback.
-    fn wrap_router(self, router: Router) -> Router {
+    fn apply_outer_layers(self, router: Router) -> Router {
         router
     }
 }
@@ -110,8 +108,8 @@ impl UiContext for RpcContext {
                 }),
             )
     }
-    fn wrap_router(self, router: Router) -> Router {
-        crate::net::domain_redirect::layer(self, router)
+    fn apply_outer_layers(self, router: Router) -> Router {
+        crate::net::domain_redirect::redirect_service_domains(self, router)
     }
 }
 
@@ -247,9 +245,8 @@ pub fn ui_router<C: UiContext>(ctx: C) -> Router {
         .fallback(any(|request: Request| async move {
             serve_ui::<C>(request).unwrap_or_else(server_error)
         }));
-    // The security headers stay outermost, so they reach a response a wrapping
-    // layer writes itself.
-    ctx.wrap_router(router)
+    // Security headers cover responses produced by context layers.
+    ctx.apply_outer_layers(router)
         .layer(axum::middleware::map_response(add_security_headers))
 }
 

--- a/shared-libs/crates/start-core/src/net/static_server.rs
+++ b/shared-libs/crates/start-core/src/net/static_server.rs
@@ -62,6 +62,11 @@ pub trait UiContext: Context + AsRef<RpcContinuations> + Clone + Sized {
     fn extend_router(self, router: Router) -> Router {
         router
     }
+    /// Wrap the assembled router, so a layer added here applies to every route
+    /// and to the fallback.
+    fn wrap_router(self, router: Router) -> Router {
+        router
+    }
 }
 
 pub static UI_CELL: OnceLock<Dir<'static>> = OnceLock::new();
@@ -104,6 +109,9 @@ impl UiContext for RpcContext {
                     }
                 }),
             )
+    }
+    fn wrap_router(self, router: Router) -> Router {
+        crate::net::domain_redirect::layer(self, router)
     }
 }
 
@@ -226,14 +234,22 @@ async fn add_security_headers(mut res: Response) -> Response {
 }
 
 pub fn ui_router<C: UiContext>(ctx: C) -> Router {
-    ctx.clone()
-        .extend_router(rpc_router(
-            ctx.clone(),
-            C::middleware(Server::new(move || ready(Ok(ctx.clone())), C::api())),
-        ))
+    let server = C::middleware(Server::new(
+        {
+            let ctx = ctx.clone();
+            move || ready(Ok(ctx.clone()))
+        },
+        C::api(),
+    ));
+    let router = ctx
+        .clone()
+        .extend_router(rpc_router(ctx.clone(), server))
         .fallback(any(|request: Request| async move {
             serve_ui::<C>(request).unwrap_or_else(server_error)
-        }))
+        }));
+    // The security headers stay outermost, so they reach a response a wrapping
+    // layer writes itself.
+    ctx.wrap_router(router)
         .layer(axum::middleware::map_response(add_security_headers))
 }
 


### PR DESCRIPTION
Closes #3654

Typing a service's domain without a scheme now opens its web interface over HTTPS instead of the StartOS dashboard.

## What it does

The StartOS UI's port-80 router matches the request domain against installed services and returns a `307` to the service's HTTPS address, preserving path and query.

The redirect applies only when the destination is available:

- the connection arrived through a gateway assigned to the domain;
- the enabled binding and address serve a private or public domain;
- the interface declares HTTPS, or is a UI interface with no declared scheme.

Server-owned domains remain on the dashboard to avoid looping through its TLS proxy. IP addresses and the server's `.local` name also remain dashboard addresses. Port 443 is preferred; otherwise StartOS uses the lowest matching HTTPS port.

## Comment cleanup

- Replaced implementation narration with precise names for domain extraction, gateway resolution, HTTPS-port selection, and outer router layers.
- Kept short comments only for external or non-obvious constraints: request-target precedence, authority safety, unplaced gateway representation, the server redirect loop, and response-layer ordering.
- Rewrote the changelog and Private Domains guide in terms of present user behavior.

## Verification

- `cargo check -p start-core --all-targets`
- `cargo test -p start-core domain_redirect --features=test` (26 passed)
- `cargo test -p start-core lookup_tests --features=test` (4 passed)
- `cargo fmt --all -- --check`
- `npx --yes prettier@3.8.3 --check projects/start-os/CHANGELOG.md projects/start-os/docs/src/private-domains.md`
- `projects/start-docs/build.sh`
