### PR TITLE
fix(core): raise the install/uninstall failure notification before the rollback

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -53,7 +53,7 @@ file tracks notable changes since the move to the monorepo.
   away.** The notification naming what went wrong was held back until StartOS had
   finished putting the service back the way it was, which can take several
   minutes. It now arrives as soon as the operation fails, while that recovery is
-  still running, and it arrives even when the recovery fails too.
+  still running.
 
 - **Apps that hold a connection open — desktop sync clients, API pollers — stop
   dropping in and out.** Nextcloud Desktop and clients like it showed a

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -49,6 +49,12 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **A service that fails to install, update, restore or uninstall says so right
+  away.** The notification naming what went wrong was held back until StartOS had
+  finished putting the service back the way it was, which can take several
+  minutes. It now arrives as soon as the operation fails, while that recovery is
+  still running, and it arrives even when the recovery fails too.
+
 - **Apps that hold a connection open — desktop sync clients, API pollers — stop
   dropping in and out.** Nextcloud Desktop and clients like it showed a
   recurring "Network error" that cleared itself a few seconds later. A service

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -51,9 +51,8 @@ file tracks notable changes since the move to the monorepo.
 
 - **A service that fails to install, update, restore or uninstall says so right
   away.** The notification naming what went wrong was held back until StartOS had
-  finished putting the service back the way it was, which can take several
-  minutes. It now arrives as soon as the operation fails, while that recovery is
-  still running.
+  finished cleaning up after the attempt, which can take several minutes. It now
+  arrives as soon as the operation fails, while that cleanup is still running.
 
 - **Apps that hold a connection open — desktop sync clients, API pollers — stop
   dropping in and out.** Nextcloud Desktop and clients like it showed a

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -510,7 +510,7 @@ pub struct ServiceRefReloadCancelGuard(
 impl Drop for ServiceRefReloadCancelGuard {
     fn drop(&mut self) {
         if let Some(info) = self.0.take() {
-            tokio::spawn(info.reload(None));
+            tokio::spawn(async move { info.reload(None).await.log_err() });
         }
     }
 }
@@ -572,35 +572,40 @@ struct ServiceRefReloadInfo {
 }
 impl ServiceRefReloadInfo {
     async fn reload(self, error: Option<Error>) -> Result<(), Error> {
+        if let Some(error) = error {
+            // Rolling back can take minutes, so the notification goes out before it starts.
+            self.notify_failure(&error).await.log_err();
+        }
         self.ctx
             .services
             .load(&self.ctx, &self.id, LoadDisposition::Undo)
-            .await?;
-        if let Some(error) = error {
-            let error_string = error.to_string();
-            let title = match self.operation {
-                "Installing" => t!("service.service-map.installing-failed"),
-                "Updating" => t!("service.service-map.updating-failed"),
-                "Restoring" => t!("service.service-map.restoring-failed"),
-                "Uninstall" => t!("service.service-map.uninstall-failed"),
-                other => t!("service.service-map.operation-failed", operation = other),
-            }
-            .to_string();
-            self.ctx
-                .db
-                .mutate(|db| {
-                    notify(
-                        db,
-                        Some(self.id.clone()),
-                        NotificationLevel::Error,
-                        title,
-                        error_string,
-                        (),
-                    )
-                })
-                .await
-                .result?;
+            .await
+    }
+
+    async fn notify_failure(&self, error: &Error) -> Result<(), Error> {
+        let id = self.id.clone();
+        let error_string = error.to_string();
+        let title = match self.operation {
+            "Installing" => t!("service.service-map.installing-failed"),
+            "Updating" => t!("service.service-map.updating-failed"),
+            "Restoring" => t!("service.service-map.restoring-failed"),
+            "Uninstall" => t!("service.service-map.uninstall-failed"),
+            other => t!("service.service-map.operation-failed", operation = other),
         }
-        Ok(())
+        .to_string();
+        self.ctx
+            .db
+            .mutate(move |db| {
+                notify(
+                    db,
+                    Some(id),
+                    NotificationLevel::Error,
+                    title,
+                    error_string,
+                    (),
+                )
+            })
+            .await
+            .result
     }
 }


### PR DESCRIPTION
Closes #2937

## What was wrong

`ServiceRefReloadInfo::reload` (`shared-libs/crates/start-core/src/service/service_map.rs`) awaited the rollback before writing the failure notification:

```rust
self.ctx.services.load(&self.ctx, &self.id, LoadDisposition::Undo).await?;
if let Some(error) = error { /* notify */ }
```

`load(.., Undo)` shuts the service down and re-enters `Service::load`, which rebuilds the persistent container and, for a `Removing` entry, re-runs `service.uninstall(..)` from scratch (`service/mod.rs:604-660`). That is minutes of work, and the notification naming the failure was queued behind all of it — the symptom in the issue, and the one @MattDHill reported for install failures too.

## What this does

Swap the two, and take the `?` off the notification write: a failed notification must not skip the rollback, and this crate already treats a failed notification write as `log_err` material (`report_failed_rollback` in `service/mod.rs:124`, `backup/target/mod.rs:501`). The rollback's own error is returned unwrapped, so its `ErrorKind` and eyre report reach `log_err` intact.

Notifying first also closes a narrower hole. `ServiceMap::load` swallows most rollback failures into `statusInfo.error` and returns `Ok`, but not all of them — a failed `service.shutdown()` or a failed db write escapes, and the old `?` then dropped the notification entirely.

`reload` serves every operation the reload guard wraps, so this covers **install, update and restore** failures as well as uninstall — one fix for both reports on the issue.

The `Drop` path also now logs `reload`'s result, which it discarded while the `handle` path already logged its own. A rollback that fails there — a batch restore dropping un-awaited install futures, say — left the package mid-`Installing` with nothing in the journal naming why. One line, adjacent, happy to drop it if you'd rather it went separately.

## Approach

@winshaurya proposed this shape on the issue in July and you assigned it to them on 7 Aug, so this is that proposal — notify first, capture the notification's result without short-circuiting, always run the rollback. It landed here because the nightly pass over the `Approved` queue picked the issue up and there was no PR on it. **If @winshaurya still wants it, close this** — the review notes below are worth more to them than the diff.

Two things I deliberately did **not** do, both your call:

- **Cancel reports promptly too, and it reports as a failure.** `ServiceRefReloadCancelGuard::handle` synthesises `Error::new(eyre!("Operation Cancelled"), ErrorKind::Cancelled)` when the `cancellable_installs` oneshot fires and hands it to `reload` like any other error, so pressing Cancel raises a red "Installing Failed — Cancelled: Operation Cancelled". That is true on master too; this change only moves it earlier (seconds-after-the-click for a fresh install, where the `Undo` path is just cleanup plus a db remove; minutes for an update or restore, which restore the volume snapshot).

  I looked at guarding the notify on `ErrorKind::Cancelled` and **it is not safe**. That kind has non-user producers on this very path: `service/mod.rs:247` turns a `JoinError` from the container shutdown handle into `Cancelled`, and `syscall.rs:309` does the same for a `spawn_blocking` failure during an idmapped volume mount. Decisively, the uninstall guard is constructed with no cancel receiver at all — `ServiceRefReloadCancelGuard::new(.., "Uninstall", None)` (`service_map.rs:456`) — so on that path a `Cancelled` can *only* be a real failure, and the guard would suppress "Uninstall failed" exactly when the container died on the way down. Dropping the oneshot `Sender` (an OS shutdown with an install in flight) also fires the `select!` arm, since it binds `_`. If the mislabel is worth fixing, the shape that works is changing the *content* — an `Info`-level "Install cancelled" when the operation was cancellable — not suppressing on kind. Separate change either way; the mislabel is pre-existing.
- **The service tile still spins for the whole rollback.** Only the notification moved; `stateInfo` clears when `load(Undo)` finishes. The changelog entry is worded so it doesn't imply otherwise.

## Verification

`cargo check -p start-core` clean; `make start-core-test` 327 passed / 0 failed; rustfmt (pinned nightly) and prettier clean. No test added — `reload` needs a live `RpcContext` (disk, LXC, network) and the crate has no harness that builds one, so there is no seam to unit-test the ordering at. `cargo clippy` fails on pre-existing errors in `shared-libs/crates/patch-db/json-patch`, unrelated to this diff and not run in CI.

Changelog under `## [0.4.0.2]` → `### Fixed`; `start-os/v0.4.0.1` is the newest origin tag, so that heading is unreleased and takes the entry. The old ordering is present at the `v0.4.0.1` tag, so this is a real user-visible fix rather than an unreleased-only tweak. No page under `projects/start-os/docs/src/` describes notification timing, so there is nothing to update there.

The first draft of this used an `ErrorCollection` to carry both outcomes; a review pass showed `into_result` re-kinds even a single error as `MultipleErrors` and rebuilds its `debug` at the collection site, which would have degraded the only log a failed rollback produces. The shape above is what survived.

A second review round deleted a clause from the changelog entry that claimed the notification "arrives even when the recovery fails too". That over-implied: `report_failed_rollback` returns `Err`, but `ServiceMap::load` absorbs `Service::load`'s error into `status_info.error` and returns `Ok`, so master's `?` never short-circuited on an ordinary failed volume rollback — the notification was already written, alongside the rollback-failed one. The hole the reorder really closes is only where `ServiceMap::load` itself returns `Err` (a failed shutdown, a failed db write), which is too narrow and too internal to put in front of a user.

A third round ran the concurrency/lifecycle and boundary angles, which the earlier `high` passes do not include. Two things worth stating rather than changing:

- **The notification is now durable before the rollback runs.** patch-db fsyncs each revision, so a crash partway through the rollback leaves a committed "X Failed" record for an operation that the next boot's `load(.., Retry)` may then complete successfully — the user keeps a notification about an attempt that eventually worked. That is the deliberate trade: the alternative is master's behaviour, where the same crash tells them nothing at all. Naming it so it is a choice and not an accident.
- **The service tile still spins for the whole cleanup.** `stateInfo.state` only settles when the rollback finishes, so the notification is the prompt signal and the in-place indicator is not. Out of scope here, but it is the other half of what someone watching the page experiences.

Also checked this round: every other `notify(` call site in the crate either *is* the report of the slow work it follows or already fires in the same tick, so no sibling carries the same shape and the fix is complete for its family. There is still no test — `service_map.rs` has no test module and `RpcContext::init` needs a webserver, a disk GUID, an on-disk patch-db, a `NetController` and an `LxcManager`, so an ordering test would need a production refactor to extract an order-only seam rather than a test that can ride along with this diff.

A fourth round rewrote the changelog entry once more, in `498eaf8e2` — the only commit on this branch that changes what a **user** reads, so it is worth stating plainly. The entry had said the notification waited on StartOS "putting the service back the way it was". That inverts the case this issue is named for: `Service::load` handles `Removing` in the same arm as `Restoring`, rebuilds the container, re-runs `service.uninstall(..)`, and on success returns `Ok(None)` — the service ends up **gone, not restored**, and only a failing retry puts it back. So a user whose uninstall failed would have read that StartOS was restoring their service and then watched it disappear. It now reads "cleaning up after the attempt", which holds for every arm. Note the commit message had the mechanism right all along ("re-runs the uninstall from scratch") — only the user-facing sentence was backwards.
