### PR TITLE
docs(start-sdk): virtualNetworking grants a device, not a capability

### DIFF
--- a/projects/start-sdk/docs/src/manifest.md
+++ b/projects/start-sdk/docs/src/manifest.md
@@ -239,7 +239,7 @@ For services that bring up their own kernel tunnel interface — VPNs, WireGuard
 virtualNetworking: true,
 ```
 
-When set, StartOS exposes `/dev/net/tun` inside the service's container **and grants `CAP_NET_ADMIN`** (scoped to the container's user namespace) so the service can create and configure tunnel interfaces. This is a meaningful privilege escalation — enable it only when the service genuinely needs a kernel tunnel interface.
+When set, StartOS exposes `/dev/net/tun` inside the service's container, so the service can create and configure tunnel interfaces. The flag grants that device and nothing else; it does not change the container's capabilities. Enable it only when the service genuinely needs a kernel tunnel interface.
 
 ### Nested OCI Runtimes (Docker / Podman inside a service)
 
@@ -250,7 +250,7 @@ userspaceFilesystems: true,  // /dev/fuse for fuse-overlayfs storage
 virtualNetworking: true,     // /dev/net/tun for slirp4netns / pasta networking
 ```
 
-`userspaceFilesystems` exposes `/dev/fuse` so a rootless engine (Podman or Docker) can use `fuse-overlayfs` for layered storage. `virtualNetworking` exposes `/dev/net/tun` so it can use `slirp4netns` (or `pasta`) for networking (and also grants `CAP_NET_ADMIN`). Both are opt-in. Service authors are still responsible for installing the OCI engine in the image and configuring it for rootless mode — see [Run a Nested OCI Runtime](./recipe-nested-oci-runtime.md) for the full recipe (subuid setup, daemon configuration, and the runc wrapper required when using Docker).
+`userspaceFilesystems` exposes `/dev/fuse` so a rootless engine (Podman or Docker) can use `fuse-overlayfs` for layered storage. `virtualNetworking` exposes `/dev/net/tun` so it can use `slirp4netns` (or `pasta`) for networking. Both are opt-in. Service authors are still responsible for installing the OCI engine in the image and configuring it for rootless mode — see [Run a Nested OCI Runtime](./recipe-nested-oci-runtime.md) for the full recipe (subuid setup, daemon configuration, and the runc wrapper required when using Docker).
 
 ### Multiple Images
 

--- a/projects/start-sdk/docs/src/recipe-nested-oci-runtime.md
+++ b/projects/start-sdk/docs/src/recipe-nested-oci-runtime.md
@@ -45,7 +45,7 @@ With `userspaceFilesystems` and `virtualNetworking` set, the per-service LXC get
 - `/dev/fuse` — char device 10:229, world-RW (via `userspaceFilesystems`). Required by `fuse-overlayfs` for rootless layered storage. Kernel overlayfs-on-overlayfs is denied for unprivileged users, so fuse-overlayfs is the only viable rootless storage driver inside a userns LXC.
 - `/dev/net/tun` — char device 10:200, world-RW (via `virtualNetworking`). Required by `slirp4netns` and `pasta` for rootless container networking.
 
-`virtualNetworking` additionally grants `CAP_NET_ADMIN` (scoped to the container's user namespace). A rootless OCI engine using `slirp4netns`/`pasta` doesn't strictly need it, but the tun device and the capability are bundled under the one flag; the grant is namespaced and harmless here.
+Setting these flags does not change the container's capabilities. Each one adds a device node and nothing else.
 
 Both devices are bind-mounted from the host (via the same machinery that handles `hardwareAcceleration` for GPU nodes). The host's `fuse` and `tun` kernel modules are auto-loaded at boot.
 
@@ -174,4 +174,4 @@ Once dockerd is running (rootful, since `dockerd-rootless.sh` requires the calli
 - **Subordinate-UID range overlap.** `/etc/subuid` / `/etc/subgid` ranges must live inside the subcontainer's userns (UIDs 0..65535) AND must not overlap with the calling user's own UID. With `useradd --uid 1000`, the subordinate range must skip 1000 — `app:1001:64535` works, `app:1:65535` does not.
 - **`fuse-overlayfs` only.** Kernel overlayfs-on-overlayfs is denied for unprivileged users, so don't try `--storage-driver=overlay2`. `fuse-overlayfs` is the only rootless option.
 - **No bridge IPv6 by default.** Rootless networking via slirp4netns is IPv4-only out of the box. If you need IPv6 inside nested containers, configure pasta (`--network=pasta`) instead.
-- **The capability flags are independent.** `userspaceFilesystems`, `virtualNetworking`, and `hardwareAcceleration` are orthogonal opt-ins. A nested OCI engine needs the first two; an LLM-driven CI runner that also wants GPU access sets all three.
+- **The device flags are independent.** `userspaceFilesystems`, `virtualNetworking`, and `hardwareAcceleration` are orthogonal opt-ins. A nested OCI engine needs the first two; an LLM-driven CI runner that also wants GPU access sets all three.


### PR DESCRIPTION
Targets `live-docs`: this corrects text that is wrong on the published site today, so per root `AGENTS.md` it does not belong in a master PR. `docs-backport.yml` carries it to master.

The packaging book tells package authors that `virtualNetworking` grants `CAP_NET_ADMIN`, and calls it "a meaningful privilege escalation". It does not grant anything of the kind:

- `shared-libs/crates/start-core/src/lxc/config.template` includes `common.conf` then `userns.conf`, which clears the cap drop/keep lists — a service LXC's capabilities are the same whatever the manifest sets. The template is `format!`ed with only `{guid}` and `{lang}`, so there is no capability placeholder, and it is byte-identical at `start-os/v0.4.0` and `v0.4.0.1`.
- `git grep -n 'lxc\.cap' -- shared-libs projects` returns exactly one hit, inside `projects/start-os/CHANGELOG.md`. `virtual_networking` reaches one behavioural call site — `lxc/mod.rs` → `handle_devices` → `mknod` — which creates a device node.
- The `lxc.cap.drop` snippet that prompted the wording was removed by `9e729060a`, which is not an ancestor of `start-os/v0.4.0-beta.9` and is one of `start-os/v0.4.0` — so `virtualNetworking` has never shipped with a capability snippet. `projects/start-os/CHANGELOG.md` records the framing as "wrongly framed as 're-granting `CAP_NET_ADMIN`'", under `## [0.4.0]`.

Three places said it; all three now say what the flag actually does. The practical harm is that a packager reads the tun grant as a privilege escalation it is not, and weighs the flag accordingly.

Verified true of the **published** software, which is the bar for `live-docs`: the evidence above is reproduced at the released tags, not just on master.

Found while adding a `hardwareVirtualization` flag in #3787, whose new section reads as a contrast against this paragraph. That PR is master-only (it describes unshipped behaviour) and deliberately carries none of this text, so the two do not conflict; master still has the old sentences, so the backport applies cleanly.

---

### Review notes

**Round 1** rewrote the replacement sentences. They had read "A service LXC already holds `CAP_NET_ADMIN` within its own user namespace, so this flag grants the device and nothing else." Two problems: the `so` derived the scope of *every* flag from the state of *one* capability, which does not follow (and on the recipe page "each flag above" also covers `userspaceFilesystems`); and naming the capability read as a reassurance that the reader's process holds it, which a daemon running as a non-root image `USER` does not. Both sentences now state what the flag does and does not do, without a claim about what the reader's process holds.

Round 1 also corrected two false citations in an earlier draft of this description: it cited `0.4.0-beta.10`, a release never cut (the changelog says so; the entry is under `## [0.4.0]`), and offered a `git grep` over `container-runtime/` and `start-sdk/lib`, two pathspecs that match nothing from the repo root — so the command "proved" the claim by searching no files.

**Round 2** found that replacing the recipe's line 48 desynchronised it from the Caveats bullet 129 lines below, which still called these "**The capability flags**" — coherent under the old text, self-contradictory once line 48 says they do not touch capabilities. That bullet now reads "**The device flags are independent.**"

**Known and deliberately not addressed here:** `manifest.md`'s surviving clause "so the service can create and configure tunnel interfaces" holds for a process running as the container's root (the default) or one that unshares its own userns — which is why `slirp4netns`/`pasta` work rootless in the recipe — but not for a daemon that has `setuid`'d to a non-root image `USER`, which gets `EPERM` from `TUNSETIFF` with the node present. That clause and its silence on the uid condition are inherited from the published text; the SDK's own JSDoc is equally unqualified. Stating the precondition in this one page while the type documentation and the rest of the book stay silent would trade one inconsistency for another, so it is left for a change that can address both surfaces together.
