### PR TITLE
feat(start-os): open a UI at the address its service nominates

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -18,6 +18,10 @@ file tracks notable changes since the move to the monorepo.
   behavior. The server's own `.local` name remains reserved for StartOS. See
   [Private Domains](https://docs.start9.com/start-os/private-domains.html).
 
+- **Open UI can honor a service's configured address.** Services that depend on
+  one canonical origin can now direct Open UI to that address while it remains
+  enabled and compatible with the current browser session.
+
 - **A service can permanently retire a network host or a port it no longer
   uses, and the port numbers it held become available again.** A service that
   reorganizes its interfaces across an update — renaming a host, dropping a

--- a/projects/start-os/docs/src/interfaces.md
+++ b/projects/start-os/docs/src/interfaces.md
@@ -10,6 +10,16 @@ A service interface is a network endpoint exposed by a service running on your s
 
 - **P2P** — A peer-to-peer endpoint for the service to communicate with other nodes on its network. Examples: Bitcoin P2P, Lightning P2P.
 
+## Opening a UI
+
+The **Open UI** button on a running service opens its web interface, and offers a menu of them when the service has more than one. StartOS picks which address to open from the way you are reaching StartOS itself — a `.local` name for a `.local` session, an onion address for a Tor session, a domain from outside your network — so it usually lands on an address your browser can resolve. A service reachable only on your local network has nothing else to offer a browser that is away from it, and you will get a local address that does not load.
+
+A few services work at only one address, the one they were configured with, and those tell StartOS which it is. **Open UI** then opens that address and keeps opening it, because for such a service any other address rejects you. So if it opens something you cannot reach from where you are, the address to change is the service's own, through whichever action it gives you for choosing a primary URL — that action is also how you point it somewhere else. Switching that address off in the tables below has the same effect, since StartOS only opens an address you have enabled.
+
+Which browser you are in still limits what a service can ask for. An onion address is opened from a Tor session and from no other, and from a Tor session StartOS honors only an onion or a public address, never one on your local network — Tor Browser cannot reach your LAN. Where a service's choice is ruled out this way, **Open UI** goes back to choosing for you.
+
+To open one particular address instead, open it from its own row in the gateway tables below. An onion address has no such control — copy its URL and paste it into Tor Browser.
+
 ## Viewing Interface Addresses
 
 Open the **Interfaces** tab to see every interface the service exposes. Each interface expands to reveal its **addresses** — all the ways that interface can be reached, organized by [gateway](gateways.md). When a service exposes only one interface, it is expanded by default.

--- a/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/interface.service.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/components/interfaces/interface.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core'
 import { T, utils } from '@start9labs/start-core'
+import { selectLaunchableAddress } from '@start9labs/start-core/util/selectLaunchableAddress'
 import { tuiDefaultSort } from '@taiga-ui/cdk'
 import { ConfigService } from 'src/app/services/config.service'
 import { GatewayPlus } from 'src/app/services/gateway.service'
@@ -413,77 +414,10 @@ export class InterfaceService {
   }
 
   launchableAddress(ui: T.ServiceInterface, host: T.Host): string {
-    const addresses = utils.filledAddress(host, ui.addressInfo)
-
-    if (!addresses.hostnames.length) return ''
-
-    const publicDomains = addresses.filter({
-      kind: 'domain',
-      visibility: 'public',
+    return selectLaunchableAddress(ui, host, {
+      accessType: this.config.accessType,
+      hostname: this.config.hostname,
     })
-    const wanIp = addresses.filter({ kind: 'ipv4', visibility: 'public' })
-    const bestPublic = [publicDomains, wanIp].flatMap(h =>
-      h.format('urlstring'),
-    )[0]
-    const privateDomains = addresses.filter({
-      kind: 'domain',
-      visibility: 'private',
-    })
-    const mdns = addresses.filter({ kind: 'mdns' })
-    const bestPrivate = [privateDomains, mdns].flatMap(h =>
-      h.format('urlstring'),
-    )[0]
-
-    let matching
-    let onLan = false
-    switch (this.config.accessType) {
-      case 'ipv4':
-        matching = addresses.nonLocal
-          .filter({
-            kind: 'ipv4',
-            predicate: h => h.hostname === this.config.hostname,
-          })
-          .format('urlstring')[0]
-        onLan = true
-        break
-      case 'ipv6':
-        matching = addresses.nonLocal
-          .filter({
-            kind: 'ipv6',
-            predicate: h => h.hostname === this.config.hostname,
-          })
-          .format('urlstring')[0]
-        break
-      case 'localhost':
-        matching = addresses
-          .filter({ kind: 'localhost' })
-          .format('urlstring')[0]
-        onLan = true
-        break
-      case 'mdns':
-        matching = mdns.format('urlstring')[0]
-        onLan = true
-        break
-      case 'domain':
-        matching = publicDomains.format('urlstring')[0]
-        break
-      case 'tor':
-        matching = addresses
-          .filter({
-            pluginId: 'tor',
-          })
-          .format('urlstring')[0]
-        break
-      case 'wan-ipv4':
-        matching = wanIp.format('urlstring')[0]
-        break
-    }
-
-    if (matching) return matching
-    if (onLan && bestPrivate) return bestPrivate
-    if (bestPublic) return bestPublic
-    if (bestPrivate) return bestPrivate
-    return ''
   }
 }
 

--- a/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
+++ b/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
@@ -625,6 +625,7 @@ export const mockPatchData: DataModel = {
                   description:
                     'A launchable web app for you to interact with your Bitcoin node',
                   type: 'ui',
+                  preferredLauncherAddress: 'https://my-bitcoin.home:42443',
                   addressInfo: {
                     username: null,
                     hostId: 'abcdefg',

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -87,6 +87,11 @@
   so handle its absence. See
   [Hardware Virtualization (KVM)](https://docs.start9.com/packaging/manifest.html#hardware-virtualization-kvm)
 
+- **`createInterface` accepts `preferredLauncherAddress`.** A UI interface can
+  nominate the absolute URL that StartOS should open when a service depends on
+  one canonical origin. See
+  [Nominating an Address to Open](https://docs.start9.com/packaging/interfaces.html#nominating-an-address-to-open).
+
 ### Fixed
 
 - **`VersionGraph` reports a missing migration path in terms a service owner can

--- a/projects/start-sdk/docs/src/interfaces.md
+++ b/projects/start-sdk/docs/src/interfaces.md
@@ -238,23 +238,75 @@ sdk.createInterface(effects, {
   username: null, // Auth username embedded in URL
   path: '/some/path/', // URL path
   query: {}, // URL query params
+  preferredLauncherAddress: null, // Address Open UI should prefer (see below)
 })
 ```
 
-| Option           | Type                                                       | Description                                                                                                                                                                    |
-| ---------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`           | `string`                                                   | Display name shown to the user. Wrap with `i18n()`.                                                                                                                            |
-| `id`             | `string`                                                   | Unique identifier. How you find this interface at runtime, by walking the host from `sdk.host.getOwn()` (see [main.ts](./main.md)).                                            |
-| `description`    | `string`                                                   | Description shown to the user. Wrap with `i18n()`.                                                                                                                             |
-| `type`           | `'ui'`, `'api'`, or `'p2p'`                                | `'ui'` for browser interfaces, `'api'` for programmatic endpoints, `'p2p'` for peer-to-peer connections.                                                                       |
-| `masked`         | `boolean`                                                  | If `true`, the interface URL is shown as a copyable secret. Use for URLs containing credentials or tokens.                                                                     |
-| `schemeOverride` | `{ ssl: string \| null; noSsl: string \| null }` \| `null` | Override the URL scheme for custom protocols. For example, `{ ssl: 'lndconnect', noSsl: 'lndconnect' }` produces `lndconnect://` URLs. Use `null` for standard `http`/`https`. |
-| `username`       | `string` \| `null`                                         | Username embedded in the URL (e.g., for `smp://fingerprint:password@host`).                                                                                                    |
-| `path`           | `string`                                                   | URL path appended to the base address (e.g., `'/admin/'`).                                                                                                                     |
-| `query`          | `object`                                                   | URL query parameters as key-value pairs (e.g., `{ macaroon: 'abc123' }`).                                                                                                      |
+| Option                     | Type                                                       | Description                                                                                                                                                                    |
+| -------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`                     | `string`                                                   | Display name shown to the user. Wrap with `i18n()`.                                                                                                                            |
+| `id`                       | `string`                                                   | Unique identifier. How you find this interface at runtime, by walking the host from `sdk.host.getOwn()` (see [main.ts](./main.md)).                                            |
+| `description`              | `string`                                                   | Description shown to the user. Wrap with `i18n()`.                                                                                                                             |
+| `type`                     | `'ui'`, `'api'`, or `'p2p'`                                | `'ui'` for browser interfaces, `'api'` for programmatic endpoints, `'p2p'` for peer-to-peer connections.                                                                       |
+| `masked`                   | `boolean`                                                  | If `true`, the interface URL is shown as a copyable secret. Use for URLs containing credentials or tokens.                                                                     |
+| `schemeOverride`           | `{ ssl: string \| null; noSsl: string \| null }` \| `null` | Override the URL scheme for custom protocols. For example, `{ ssl: 'lndconnect', noSsl: 'lndconnect' }` produces `lndconnect://` URLs. Use `null` for standard `http`/`https`. |
+| `username`                 | `string` \| `null`                                         | Username embedded in the URL (e.g., for `smp://fingerprint:password@host`).                                                                                                    |
+| `path`                     | `string`                                                   | URL path appended to the base address (e.g., `'/admin/'`).                                                                                                                     |
+| `query`                    | `object`                                                   | URL query parameters as key-value pairs (e.g., `{ macaroon: 'abc123' }`).                                                                                                      |
+| `preferredLauncherAddress` | `string` \| `null` \| _omitted_                            | The URL of the address StartOS's **Open UI** control should prefer for this interface. See [Nominating an Address to Open](#nominating-an-address-to-open).                    |
 
 > [!TIP]
 > The `id` you assign to an interface is what you use in `main.ts` to retrieve hostnames for it. Interfaces are reached through their **host**: `sdk.host.getOwn(effects, hostId)` returns the host, and the interface lives at `host.bindings[internalPort].interfaces[id]`. See [Main](./main.md#getting-hostnames) for details.
+
+## Nominating an Address to Open
+
+StartOS's **Open UI** control picks the address that suits how the admin is reaching StartOS at that moment — a `.local` name for a `.local` session, an onion address for a Tor session — so it usually lands on a link that resolves in the browser they are already using.
+
+A few services work at exactly one origin. CryptPad derives account keys from the origin it is loaded at, so opening it at a second, perfectly reachable address rejects the right password; Ghost, Gitea and Vaultwarden each build links or callbacks from one configured URL. Such a service already asks the user which URL to treat as primary — see [Set a Primary URL](./recipe-primary-url.md) — and `preferredLauncherAddress` passes that answer on, so **Open UI** opens the address the service was configured for.
+
+Nominate on the interface the user opens, which is the one carrying the control: **Open UI** appears only for a `type: 'ui'` interface whose `scheme` is `http` or whose `sslScheme` is `https`, so a nomination on an `api` or `p2p` interface is stored and never acted on. Some services keep their canonical URL on an interface that is not the web UI — Synapse's server name belongs to its federation interface, and its admin UI is a separate one on another host. There the stored URL is not this interface's address and nominating it would match nothing, so nominate only where the URL the user picked is an address of the interface carrying the control.
+
+Read the user's choice reactively, so re-running the action re-runs `setupInterfaces` and re-nominates:
+
+```typescript
+export const setInterfaces = sdk.setupInterfaces(async ({ effects }) => {
+  const primaryUrl = await storeJson.read(s => s.primaryUrl).const(effects)
+
+  const uiMulti = sdk.MultiHost.of(effects, 'ui-multi')
+  const uiOrigin = await uiMulti.bindPort(uiPort, { protocol: 'http' })
+
+  const ui = sdk.createInterface(effects, {
+    name: i18n('Web UI'),
+    id: 'ui',
+    description: i18n('The web interface'),
+    type: 'ui',
+    masked: false,
+    schemeOverride: null,
+    username: null,
+    path: '',
+    query: {},
+    preferredLauncherAddress: primaryUrl,
+  })
+
+  return [await uiOrigin.export([ui])]
+})
+```
+
+Pass an absolute URL carrying a scheme and a host. Omitting `preferredLauncherAddress`, setting it to `null`, or passing a blank, whitespace-only, or malformed value leaves **Open UI** on its usual address-selection behavior.
+
+StartOS compares the scheme, hostname and port of what you pass against the addresses this interface has right now, and opens the match. The nomination outranks the connection-based choice, because a service that works at one origin is better served by the address its user picked than by one derived from the admin's connection — so **Open UI** stays on it until the user disables that address, at which point the choice reverts.
+
+Some addresses are left out of the comparison, in the cases where StartOS can tell the session asking could not resolve them. Everywhere else it takes your word for it:
+
+- **An address a plugin publishes is honored only from a session on that plugin.** `accessType` recognizes Tor by the `.onion` the browser is on, and no other plugin's session, so an onion nomination is honored from a Tor session and every other plugin address reverts to the usual choice.
+- **A Tor session honors only an onion address or a public one.** Tor Browser reaches neither a `.local` name nor a LAN IP.
+- **Loopback, IPv6 link-local and the container bridge are never nominated.** The primary-URL select a user picks from can list them, and none is reachable from another machine.
+
+> [!WARNING]
+> Nominate an address the people who use the service can actually reach, because StartOS opens it rather than second-guessing them. A public domain nominated on a home network needs the router to loop LAN traffic back to it, and a `.local` name nominated for a service reached from outside resolves for nobody who is away.
+
+> [!NOTE]
+> Only the origin has to match. The path and query of the opened URL come from this interface's own `path` and `query`, so changing either leaves the nomination standing — what pins it is the scheme, hostname and port, which is the part an origin-sensitive app checks. That also means reassigning the interface's external port unseats the nomination, which is correct: the origin the app was configured for changed too. Give the user a way back to a working choice — the reactive variant of [Set a Primary URL](./recipe-primary-url.md) raises a task when the stored URL goes missing, and a service whose URL is permanent has no watcher to do that.
 
 ## Port Ranges
 

--- a/projects/start-sdk/docs/src/recipe-primary-url.md
+++ b/projects/start-sdk/docs/src/recipe-primary-url.md
@@ -6,6 +6,8 @@ Some services need to know which URL they're hosted at — for generating links,
 
 Create a "Set Primary URL" action using `sdk.Action.withInput()` with `Value.dynamicSelect()` that queries the service's own interfaces for available hostnames. The action persists the choice to a file model. In `setupMain()`, read the selected URL and pass it to the service as an env var or config value.
 
+Where the URL the user picked is an address of the service's own web UI, pass it to `createInterface`'s `preferredLauncherAddress` in `setupInterfaces` as well, so StartOS's **Open UI** control opens the address the service is configured for instead of the one that suits the admin's connection. It has to be a whole URL, and it only does anything on the interface carrying that control — a service whose canonical URL is a bare hostname, or belongs to an interface other than its web UI, has nothing to nominate. See [Nominating an Address to Open](interfaces.md#nominating-an-address-to-open).
+
 There are two variants. For services where the URL can change anytime (Ghost, Gitea, Vaultwarden), register a reactive watcher in `setupOnInit` that monitors the URL via `.const(effects)`. If the selected URL becomes unavailable (e.g., user disables a gateway), create a critical task prompting the user to pick a new one. For services where the hostname is permanent and cannot change after initial setup (Synapse), use a critical task on install with `visibility: 'hidden'` so it's a one-time choice.
 
 **Reference:** [Actions](actions.md) · [Interfaces](interfaces.md) · [Initialization](init.md) · [Tasks](tasks.md)

--- a/projects/start-sdk/lib/StartSdk.ts
+++ b/projects/start-sdk/lib/StartSdk.ts
@@ -560,6 +560,11 @@ export class StartSdk<Manifest extends T.SDKManifest> {
           schemeOverride: { ssl: Scheme; noSsl: Scheme } | null
           /** mask the url (recommended if it contains credentials such as an API key or password) */
           masked: boolean
+          /** An absolute interface URL that StartOS should prefer for Open UI.
+           *
+           * @see {@link https://docs.start9.com/packaging/interfaces.html#nominating-an-address-to-open Nominating an Address to Open}
+           */
+          preferredLauncherAddress?: string | null
         },
       ) => new ServiceInterfaceBuilder({ ...options, effects }),
       /**

--- a/projects/start-sdk/lib/test/host.test.ts
+++ b/projects/start-sdk/lib/test/host.test.ts
@@ -28,6 +28,74 @@ describe('host', () => {
     }
   })
 
+  describe('Origin.export', () => {
+    async function uiOrigin(effects: Effects) {
+      return sdk.MultiHost.of(effects, 'ui').bindPort(80, {
+        protocol: 'http' as const,
+        preferredExternalPort: 80,
+      })
+    }
+
+    // Inline literals preserve excess-property checking.
+    test('carries a nominated launcher address through to the effect', async () => {
+      const exportServiceInterface = jest.fn(async () => null)
+      const effects = {
+        bind: jest.fn(async () => null),
+        exportServiceInterface,
+      } as unknown as Effects
+      const origin = await uiOrigin(effects)
+
+      await origin.export([
+        sdk.createInterface(effects, {
+          name: 'Web UI',
+          id: 'ui',
+          description: 'The web interface',
+          type: 'ui',
+          masked: false,
+          schemeOverride: null,
+          username: null,
+          path: '',
+          query: {},
+          preferredLauncherAddress: 'https://pad.example.com',
+        }),
+      ])
+
+      expect(exportServiceInterface).toHaveBeenCalledWith(
+        expect.objectContaining({
+          preferredLauncherAddress: 'https://pad.example.com',
+        }),
+      )
+    })
+
+    test('nominates nothing when the option is omitted', async () => {
+      const exportServiceInterface = jest.fn(async () => null)
+      const effects = {
+        bind: jest.fn(async () => null),
+        exportServiceInterface,
+      } as unknown as Effects
+      const origin = await uiOrigin(effects)
+
+      await origin.export([
+        sdk.createInterface(effects, {
+          name: 'Web UI',
+          id: 'ui',
+          description: 'The web interface',
+          type: 'ui',
+          masked: false,
+          schemeOverride: null,
+          username: null,
+          path: '',
+          query: {},
+        }),
+      ])
+
+      const [params] = exportServiceInterface.mock.calls[0] as unknown as [
+        Record<string, unknown>,
+      ]
+      expect(params['preferredLauncherAddress']).toBeUndefined()
+    })
+  })
+
   test('host.get returns interfaces whose addressInfo is pre-filled', () => {
     async function _typecheck(effects: Effects) {
       const host = await sdk.host.getOwn(effects, 'ui').const()

--- a/shared-libs/crates/start-core/src/net/domain_redirect.rs
+++ b/shared-libs/crates/start-core/src/net/domain_redirect.rs
@@ -218,6 +218,7 @@ mod test {
                 suffix: String::new(),
             },
             interface_type: kind,
+            preferred_launcher_address: None,
         }
     }
 

--- a/shared-libs/crates/start-core/src/net/net_controller.rs
+++ b/shared-libs/crates/start-core/src/net/net_controller.rs
@@ -279,6 +279,7 @@ impl NetController {
                         suffix: String::new(),
                     },
                     interface_type: ServiceInterfaceType::Ui,
+                    preferred_launcher_address: None,
                 };
                 db.as_public_mut()
                     .as_server_info_mut()

--- a/shared-libs/crates/start-core/src/net/service_interface.rs
+++ b/shared-libs/crates/start-core/src/net/service_interface.rs
@@ -196,6 +196,9 @@ pub struct ServiceInterface {
     pub address_info: AddressInfo,
     #[serde(rename = "type")]
     pub interface_type: ServiceInterfaceType,
+    /// The interface address Open UI should prefer.
+    #[ts(optional = nullable)]
+    pub preferred_launcher_address: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, TS)]

--- a/shared-libs/crates/start-core/src/service/effects/net/interface.rs
+++ b/shared-libs/crates/start-core/src/service/effects/net/interface.rs
@@ -13,11 +13,7 @@ use crate::service::effects::prelude::*;
 use crate::service::rpc::CallbackId;
 use crate::{HostId, PackageId, ServiceInterfaceId};
 
-// Every service interface lives under the binding it was exported from
-// (`hosts/{hostId}/bindings/{internalPort}/interfaces/{id}` for single-port
-// `Origin.export`, `hosts/{hostId}/bindingRanges/{internalStartPort}/interface`
-// for `RangeOrigin.export`). The flat `PackageDataEntry.serviceInterfaces` map
-// is gone — these effects read/write the host tree directly.
+// Service interfaces are stored under the binding that exported them.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export)]
 #[serde(rename_all = "camelCase")]
@@ -28,7 +24,11 @@ pub struct ExportServiceInterfaceParams {
     masked: bool,
     address_info: AddressInfo,
     r#type: ServiceInterfaceType,
+    /// The interface address Open UI should prefer.
+    #[ts(optional = nullable)]
+    preferred_launcher_address: Option<String>,
 }
+
 pub async fn export_service_interface(
     context: EffectContext,
     ExportServiceInterfaceParams {
@@ -38,6 +38,7 @@ pub async fn export_service_interface(
         masked,
         address_info,
         r#type,
+        preferred_launcher_address,
     }: ExportServiceInterfaceParams,
 ) -> Result<(), Error> {
     let context = context.deref()?;
@@ -52,6 +53,7 @@ pub async fn export_service_interface(
         masked,
         address_info,
         interface_type: r#type,
+        preferred_launcher_address,
     };
 
     context

--- a/shared-libs/ts-modules/start-core/lib/interfaces/Origin.ts
+++ b/shared-libs/ts-modules/start-core/lib/interfaces/Origin.ts
@@ -39,9 +39,6 @@ export class Origin {
    * @description A function to register a group of origins (<PROTOCOL> :// <HOSTNAME> : <PORT>) with StartOS
    *
    *   The returned addressReceipt serves as proof that the addresses were registered
-   *
-   * @param addressInfo
-   * @returns
    */
   async export(
     serviceInterfaces: ServiceInterfaceBuilder[],
@@ -58,6 +55,7 @@ export class Origin {
         query: search,
         schemeOverride,
         masked,
+        preferredLauncherAddress,
       } = serviceInterface.options
 
       const addressInfo = this.build({
@@ -74,6 +72,7 @@ export class Origin {
         addressInfo,
         type,
         masked,
+        preferredLauncherAddress,
       })
 
       addressesInfo.push(addressInfo)

--- a/shared-libs/ts-modules/start-core/lib/interfaces/ServiceInterfaceBuilder.ts
+++ b/shared-libs/ts-modules/start-core/lib/interfaces/ServiceInterfaceBuilder.ts
@@ -26,6 +26,7 @@ export class ServiceInterfaceBuilder {
       query: Record<string, string>
       schemeOverride: { ssl: Scheme; noSsl: Scheme } | null
       masked: boolean
+      preferredLauncherAddress?: string | null
     },
   ) {}
 }

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ExportServiceInterfaceParams.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ExportServiceInterfaceParams.ts
@@ -10,4 +10,8 @@ export type ExportServiceInterfaceParams = {
   masked: boolean
   addressInfo: AddressInfo
   type: ServiceInterfaceType
+  /**
+   * The interface address Open UI should prefer.
+   */
+  preferredLauncherAddress?: string | null
 }

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ServiceInterface.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ServiceInterface.ts
@@ -10,4 +10,8 @@ export type ServiceInterface = {
   masked: boolean
   addressInfo: AddressInfo
   type: ServiceInterfaceType
+  /**
+   * The interface address Open UI should prefer.
+   */
+  preferredLauncherAddress?: string | null
 }

--- a/shared-libs/ts-modules/start-core/lib/test/selectLaunchableAddress.test.ts
+++ b/shared-libs/ts-modules/start-core/lib/test/selectLaunchableAddress.test.ts
@@ -1,0 +1,320 @@
+import { AddressInfo, BindInfo, Host, HostnameInfo } from '../osBindings'
+import {
+  LauncherAccess,
+  selectLaunchableAddress,
+} from '../util/selectLaunchableAddress'
+
+const addressInfo: AddressInfo = {
+  username: null,
+  hostId: 'ui',
+  internalPort: 80,
+  scheme: 'http',
+  sslScheme: 'https',
+  suffix: '/app?from=startos',
+}
+
+function hostname(
+  hostname: string,
+  options: {
+    ssl?: boolean
+    public?: boolean
+    port?: number | null
+    metadata?: HostnameInfo['metadata']
+  } = {},
+): HostnameInfo {
+  return {
+    ssl: options.ssl ?? true,
+    public: options.public ?? false,
+    hostname,
+    port: options.port === undefined ? 443 : options.port,
+    metadata: options.metadata ?? {
+      kind: 'private-domain',
+      gateways: ['eth0'],
+    },
+  }
+}
+
+function hostWith(
+  available: HostnameInfo[],
+  options: { disabled?: Array<[string, number]> } = {},
+) {
+  const binding = {
+    enabled: [],
+    disabled: options.disabled ?? [],
+    guaWan: [],
+    available,
+  }
+  const bindInfo = {
+    enabled: true,
+    options: {
+      preferredExternalPort: 80,
+      addSsl: null,
+      secure: null,
+    },
+    net: { assignedPort: 80, assignedSslPort: 443 },
+    addresses: binding,
+    interfaces: {},
+  } as BindInfo
+  const host = {
+    bindings: { 80: bindInfo },
+    bindingRanges: {},
+    publicDomains: {},
+    privateDomains: {},
+    portForwards: [],
+  } as Host
+  return host
+}
+
+function select(
+  preferred: string | null | undefined,
+  accessType: LauncherAccess['accessType'],
+  available: HostnameInfo[],
+  options: {
+    disabled?: Array<[string, number]>
+    hostname?: string
+  } = {},
+): string {
+  const ui = {
+    id: 'ui',
+    name: 'Web UI',
+    description: '',
+    masked: false,
+    addressInfo,
+    type: 'ui' as const,
+    preferredLauncherAddress: preferred,
+  }
+  return selectLaunchableAddress(ui, hostWith(available, options), {
+    accessType,
+    hostname: options.hostname ?? '',
+  })
+}
+
+const privateDomain = hostname('pad.home')
+const publicDomain = hostname('pad.example.com', {
+  public: true,
+  metadata: { kind: 'public-domain', gateway: 'eth0' },
+})
+const onion = hostname('pad123.onion', {
+  metadata: {
+    kind: 'plugin',
+    packageId: 'tor',
+    removeAction: null,
+    overflowActions: [],
+    info: null,
+  },
+})
+
+describe('selectLaunchableAddress', () => {
+  const localIp = hostname('192.168.1.10', {
+    ssl: false,
+    port: 80,
+    metadata: { kind: 'ipv4', gateway: 'eth0' },
+  })
+  const publicIp = hostname('203.0.113.10', {
+    ssl: false,
+    public: true,
+    port: null,
+    metadata: { kind: 'ipv4', gateway: 'eth0' },
+  })
+  const ipv6 = hostname('2001:db8::10', {
+    ssl: false,
+    port: 80,
+    metadata: { kind: 'ipv6', gateway: 'eth0', scopeId: 0 },
+  })
+  const localhost = hostname('localhost', {
+    ssl: false,
+    port: 80,
+    metadata: { kind: 'ipv4', gateway: 'lo' },
+  })
+  const mdns = hostname('pad.local', {
+    ssl: false,
+    port: 80,
+    metadata: { kind: 'mdns', gateways: ['eth0'] },
+  })
+  const candidates = [
+    localIp,
+    publicIp,
+    ipv6,
+    localhost,
+    mdns,
+    publicDomain,
+    onion,
+  ]
+
+  test.each([
+    ['ipv4', '192.168.1.10', 'http://192.168.1.10/app?from=startos'],
+    ['ipv6', '2001:db8::10', 'http://[2001:db8::10]/app?from=startos'],
+    ['localhost', '', 'http://localhost/app?from=startos'],
+    ['mdns', '', 'http://pad.local/app?from=startos'],
+    ['domain', '', 'https://pad.example.com/app?from=startos'],
+    ['tor', '', 'https://pad123.onion/app?from=startos'],
+    ['wan-ipv4', '', 'http://203.0.113.10/app?from=startos'],
+  ] as const)(
+    'preserves %s session selection without a nomination',
+    (accessType, sessionHostname, expected) => {
+      expect(
+        select(undefined, accessType, candidates, {
+          hostname: sessionHostname,
+        }),
+      ).toBe(expected)
+    },
+  )
+  test.each<LauncherAccess['accessType']>([
+    'ipv4',
+    'ipv6',
+    'localhost',
+    'mdns',
+    'domain',
+    'tor',
+    'wan-ipv4',
+  ])('selects a public nomination from a %s session', accessType => {
+    expect(select('https://PAD.EXAMPLE.COM/', accessType, [publicDomain])).toBe(
+      'https://pad.example.com/app?from=startos',
+    )
+  })
+
+  test.each<LauncherAccess['accessType']>([
+    'ipv4',
+    'ipv6',
+    'localhost',
+    'mdns',
+    'domain',
+    'wan-ipv4',
+  ])('selects a private nomination from a %s session', accessType => {
+    expect(select('https://pad.home', accessType, [privateDomain])).toBe(
+      'https://pad.home/app?from=startos',
+    )
+  })
+
+  test.each([
+    ['tor', 'https://pad123.onion', onion],
+    ['tor', 'https://pad.home', privateDomain],
+    ['domain', 'https://pad123.onion', onion],
+    [
+      'tor',
+      'https://plugin.example',
+      hostname('plugin.example', {
+        public: true,
+        metadata: {
+          kind: 'plugin',
+          packageId: 'other-plugin',
+          removeAction: null,
+          overflowActions: [],
+          info: null,
+        },
+      }),
+    ],
+  ] as const)(
+    'returns the transport-compatible nomination for %s to %s',
+    (accessType, preferred, candidate) => {
+      expect(select(preferred, accessType, [candidate])).toBe(
+        candidate === onion && accessType === 'tor'
+          ? 'https://pad123.onion/app?from=startos'
+          : candidate === privateDomain
+            ? 'https://pad.home/app?from=startos'
+            : '',
+      )
+    },
+  )
+
+  test('matches the nominated SSL leg by origin', () => {
+    const plain = hostname('pad.example.com', {
+      ssl: false,
+      public: true,
+      port: 80,
+      metadata: { kind: 'public-domain', gateway: 'eth0' },
+    })
+    expect(
+      select('https://pad.example.com', 'domain', [plain, publicDomain]),
+    ).toBe('https://pad.example.com/app?from=startos')
+  })
+
+  test.each([
+    [
+      'missing',
+      undefined,
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'null',
+      null,
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'blank',
+      '',
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'whitespace',
+      ' \n\t ',
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'invalid',
+      'not a url',
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'vanished',
+      'https://gone.example',
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'wrong port',
+      'https://pad.example.com:8443',
+      [publicDomain],
+      {},
+      'https://pad.example.com/app?from=startos',
+    ],
+    [
+      'disabled',
+      'https://pad.home',
+      [privateDomain],
+      { disabled: [['pad.home', 443]] },
+      '',
+    ],
+    [
+      'loopback',
+      'https://localhost',
+      [hostname('localhost', { metadata: { kind: 'ipv4', gateway: 'lo' } })],
+      {},
+      '',
+    ],
+    [
+      'bridge',
+      'https://10.0.3.1',
+      [
+        hostname('10.0.3.1', {
+          metadata: { kind: 'ipv4', gateway: 'lxcbr0' },
+        }),
+      ],
+      {},
+      '',
+    ],
+  ] as const)(
+    'falls back correctly when the nomination is %s',
+    (_name, preferred, values, options, expected) => {
+      expect(
+        select(preferred, 'domain', [...values], {
+          disabled:
+            'disabled' in options
+              ? options.disabled.map(([host, port]) => [host, port])
+              : undefined,
+        }),
+      ).toBe(expected)
+    },
+  )
+})

--- a/shared-libs/ts-modules/start-core/lib/util/selectLaunchableAddress.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/selectLaunchableAddress.ts
@@ -1,0 +1,115 @@
+import { Host, HostnameInfo, ServiceInterface } from '../osBindings'
+import { filledAddress } from './filledAddress'
+
+export type LauncherAccess = {
+  accessType:
+    | 'tor'
+    | 'mdns'
+    | 'localhost'
+    | 'ipv4'
+    | 'ipv6'
+    | 'domain'
+    | 'wan-ipv4'
+  hostname: string
+}
+
+function origin(url: string | null | undefined): string {
+  if (!url) return ''
+
+  try {
+    const { protocol, host } = new URL(url)
+    return host ? `${protocol}//${host.toLowerCase()}` : ''
+  } catch {
+    return ''
+  }
+}
+
+function isResolvable(
+  h: HostnameInfo,
+  accessType: LauncherAccess['accessType'],
+) {
+  if (h.metadata.kind === 'plugin')
+    return h.metadata.packageId === 'tor' && accessType === 'tor'
+
+  return accessType !== 'tor' || h.public
+}
+
+export function selectLaunchableAddress(
+  ui: ServiceInterface,
+  host: Host,
+  access: LauncherAccess,
+): string {
+  const addresses = filledAddress(host, ui.addressInfo)
+  if (!addresses.hostnames.length) return ''
+
+  const preferredOrigin = origin(ui.preferredLauncherAddress)
+  if (preferredOrigin) {
+    for (const h of addresses.nonLocal.hostnames) {
+      const url = addresses.toUrl(h)
+      if (isResolvable(h, access.accessType) && origin(url) === preferredOrigin)
+        return url
+    }
+  }
+
+  const publicDomains = addresses.filter({
+    kind: 'domain',
+    visibility: 'public',
+  })
+  const wanIp = addresses.filter({ kind: 'ipv4', visibility: 'public' })
+  const bestPublic = [publicDomains, wanIp].flatMap(h =>
+    h.format('urlstring'),
+  )[0]
+  const privateDomains = addresses.filter({
+    kind: 'domain',
+    visibility: 'private',
+  })
+  const mdns = addresses.filter({ kind: 'mdns' })
+  const bestPrivate = [privateDomains, mdns].flatMap(h =>
+    h.format('urlstring'),
+  )[0]
+
+  let matching: string | undefined
+  let onLan = false
+  switch (access.accessType) {
+    case 'ipv4':
+      matching = addresses.nonLocal
+        .filter({
+          kind: 'ipv4',
+          predicate: h => h.hostname === access.hostname,
+        })
+        .format('urlstring')[0]
+      onLan = true
+      break
+    case 'ipv6':
+      matching = addresses.nonLocal
+        .filter({
+          kind: 'ipv6',
+          predicate: h => h.hostname === access.hostname,
+        })
+        .format('urlstring')[0]
+      break
+    case 'localhost':
+      matching = addresses.filter({ kind: 'localhost' }).format('urlstring')[0]
+      onLan = true
+      break
+    case 'mdns':
+      matching = mdns.format('urlstring')[0]
+      onLan = true
+      break
+    case 'domain':
+      matching = publicDomains.format('urlstring')[0]
+      break
+    case 'tor':
+      matching = addresses.filter({ pluginId: 'tor' }).format('urlstring')[0]
+      break
+    case 'wan-ipv4':
+      matching = wanIp.format('urlstring')[0]
+      break
+  }
+
+  if (matching) return matching
+  if (onLan && bestPrivate) return bestPrivate
+  if (bestPublic) return bestPublic
+  if (bestPrivate) return bestPrivate
+  return ''
+}


### PR DESCRIPTION
Closes #3715

## Summary

`createInterface` accepts an optional `preferredLauncherAddress`, allowing an origin-sensitive UI to nominate the enabled address used by StartOS's Open UI control. Missing, malformed, disabled, unmatched, or transport-incompatible nominations fall through to the existing address selection.

The backend stores the optional string as interface metadata without interpreting it. Launcher selection parses it and matches scheme, normalized hostname, and effective port against an address StartOS assigned and kept enabled. The opened URL still comes from the generated interface address, preserving its path, query, and username without creating a general redirect primitive.

Transport restrictions remain session-aware for Tor and plugin addresses. Existing interface records and packages that omit the field retain the prior behavior.

## Verification

- committed 35-case launcher-selection suite
- `make start-core-test`
- `cargo check -p start-core`
- generated TS bindings
- start-core TS tests/typecheck/build
- Start SDK tests/typecheck/bundle
- root TypeScript and i18n checks
- UI production build
- container-runtime tests/typecheck
- Rust and Prettier formatting checks
- docs build
