### PR TITLE
fix(start-os): one certificate per name, not per route to it

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -77,6 +77,22 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **An app that remembers your server's certificate sees the same certificate
+  across every route to that name.** Wallets and other apps that pin the first
+  certificate they are shown — Sparrow and the Electrum clients most visibly —
+  raised a man-in-the-middle warning when the same name resolved through a
+  different address or the server's public IP changed. StartOS now reuses one
+  certificate per name until renewal.
+
+  This changes how one address behaves, on a server reached through a NAT
+  router: typing its public IP address while on the same network as the server
+  now produces a certificate warning, because the router rewrites such a
+  connection to the LAN address and the server cannot see which of the two you
+  asked for. Reach it from inside your own network by its `.local` name, by a
+  domain you have assigned to it, or by its LAN IP address. A server that holds
+  its public address directly, or that is reached over StartTunnel, is
+  unaffected. See [Public IP](https://docs.start9.com/start-os/public-ip.html).
+
 - **A downgrade to a version that cannot take over the service's data is refused
   before anything is downloaded or stopped**, with an explanation of what to do
   instead.

--- a/projects/start-os/docs/src/public-ip.md
+++ b/projects/start-os/docs/src/public-ip.md
@@ -4,6 +4,9 @@ Access a service interface directly using a gateway's public IP address and port
 
 For hosting websites or APIs that people access in a browser, use a [public domain](clearnet.md) instead. Public IPs accessed in a browser will display certificate warnings because Let's Encrypt does not sign certificates for IP addresses. Visitors would need to [trust your Root CA](trust-ca.md), which is not reasonable for public access.
 
+> [!NOTE]
+> A public IP address reaches your server from the Internet. If your server is behind a NAT router, typing that address from a device on the same network as the server produces a certificate warning: the router rewrites the connection to your server's LAN address, so your server sees a local connection and presents the certificate for that address instead. Use its [`.local` address, a private domain, or its LAN IP](lan.md) from inside your own network. A server that holds its public address directly, or that you reach over [StartTunnel](/start-tunnel/), is unaffected.
+
 ## Watch The Video
 
 <div class="yt-video" data-id="xKYhCMNN3gw" data-title="Public IP"></div>

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -39,7 +39,9 @@ use crate::net::forward::{START9_BRIDGE_IFACE, nft_ensure_base};
 use crate::net::gateway::device::DeviceProxy;
 use crate::net::host::all_hosts;
 use crate::net::port_map::{candidate_gateways, probe};
-use crate::net::utils::{bind_mio_listener, find_wifi_iface, ipv6_is_link_local, ipv6_is_local};
+use crate::net::utils::{
+    bind_mio_listener, find_wifi_iface, ipv6_is_link_local, ipv6_is_local, is_global_ip,
+};
 use crate::net::web_server::{Accept, AcceptStream, MetadataVisitor, TcpMetadata};
 use crate::prelude::*;
 use crate::util::Invoke;
@@ -1469,11 +1471,19 @@ async fn get_wan_ipv4(
         .error_for_status()?
         .text()
         .await?;
+    parse_echoip(&text)
+}
+
+/// A routable WAN address from an echoip response.
+fn parse_echoip(text: &str) -> Result<Option<Ipv4Addr>, Error> {
     let trimmed = text.trim();
     if trimmed.is_empty() {
         return Ok(None);
     }
-    Ok(Some(trimmed.parse()?))
+    let ip: Ipv4Addr = trimmed.parse()?;
+    Ok(Some(ip).filter(|&ip| {
+        crate::net::port_map::upnp::is_wan_candidate(ip) && is_global_ip(IpAddr::V4(ip))
+    }))
 }
 
 struct PolicyRoutingGuard {
@@ -3380,6 +3390,42 @@ mod lookup_tests {
         let ip_info = gateway_holding("192.168.1.5/24");
         let compatible: SocketAddr = "[::192.168.1.5]:80".parse().unwrap();
         assert!(lookup_info_by_addr(&ip_info, compatible).is_none());
+    }
+}
+
+#[cfg(test)]
+mod parse_echoip_tests {
+    use super::*;
+
+    #[test]
+    fn an_unroutable_echoip_answer_is_no_wan_address() {
+        for text in [
+            "0.0.0.0",
+            "255.255.255.255",
+            "100.100.1.5",
+            "192.0.2.1",
+            "192.168.1.10",
+        ] {
+            assert_eq!(parse_echoip(text).unwrap(), None, "{text}");
+        }
+    }
+
+    #[test]
+    fn a_routable_echoip_answer_is_the_wan_address() {
+        assert_eq!(
+            parse_echoip(" 8.8.8.8\n").unwrap(),
+            Some(Ipv4Addr::new(8, 8, 8, 8))
+        );
+    }
+
+    #[test]
+    fn an_empty_echoip_answer_is_no_wan_address() {
+        assert_eq!(parse_echoip("\n").unwrap(), None);
+    }
+
+    #[test]
+    fn a_malformed_echoip_answer_is_an_error() {
+        assert!(parse_echoip("<html>oops</html>").is_err());
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/mdns.rs
+++ b/shared-libs/crates/start-core/src/net/mdns.rs
@@ -15,8 +15,8 @@ use crate::util::Invoke;
 /// hard-coded 5s timeout, which is why `curl` resolves a name that `start-cli` cannot.
 ///
 /// Rewriting the URL once here, at context build, means every consumer downstream — the HTTP
-/// client and the websocket path alike — is handed an address rather than a name. The server's
-/// cert carries IP SANs (see [`crate::net::ssl`]), so TLS still verifies.
+/// client and the websocket path alike — is handed an address rather than a name. The server
+/// certifies the address a client reaches it at (see [`crate::net::ssl`]), so TLS still verifies.
 #[cfg(target_os = "linux")]
 pub fn pin_mdns_host(url: &mut Url) -> Result<(), Error> {
     let Some(hostname) = url

--- a/shared-libs/crates/start-core/src/net/ssl.rs
+++ b/shared-libs/crates/start-core/src/net/ssl.rs
@@ -36,10 +36,12 @@ use crate::SOURCE_DATE;
 use crate::account::AccountInfo;
 use crate::context::{CliContext, RpcContext};
 use crate::db::model::Database;
+use crate::db::model::public::IpInfo;
 use crate::db::{DbAccess, DbAccessMut};
 use crate::init::check_time_is_synchronized;
 use crate::net::gateway::GatewayInfo;
 use crate::net::tls::{TlsHandler, TlsHandlerAction};
+use crate::net::utils::is_global_ip;
 use crate::net::web_server::{Accept, ExtractVisitor, TcpMetadata, extract};
 use crate::prelude::*;
 use crate::util::serde::{HandlerExtSerde, Pem};
@@ -120,7 +122,7 @@ impl CertStore {
     }
 }
 impl Model<CertStore> {
-    /// This function will grant any cert for any domain. It is up to the *caller* to enusure that the calling service has permission to sign a cert for the requested domain
+    /// The caller must establish entitlement to every requested name.
     pub fn cert_for(
         &mut self,
         hostnames: &BTreeSet<InternedString>,
@@ -724,6 +726,30 @@ pub async fn generate_certificate(
     })
 }
 
+fn served_name(
+    server_name: Option<&str>,
+    tcp: Option<TcpMetadata>,
+    gateway: Option<&IpInfo>,
+) -> Option<InternedString> {
+    if let Some(host) = server_name {
+        return Some(InternedString::from(host));
+    }
+    let tcp = tcp?;
+    let dst = tcp.local_addr.ip().to_canonical();
+    let src = tcp.peer_addr.ip().to_canonical();
+    let translated = !is_global_ip(dst)
+        && is_global_ip(src)
+        && !gateway.is_some_and(|gw| gw.subnets.iter().any(|s| s.contains(&src)));
+    let wan = gateway
+        .and_then(|gw| gw.wan_ip)
+        .filter(|wan| is_global_ip(IpAddr::V4(*wan)));
+    let dialed = match (dst, wan) {
+        (IpAddr::V4(_), Some(wan)) if translated => IpAddr::V4(wan),
+        _ => dst,
+    };
+    Some(InternedString::from_display(&dialed))
+}
+
 pub struct RootCaTlsHandler<M: HasModel> {
     pub db: TypedPatchDb<M>,
     pub crypto_provider: Arc<CryptoProvider>,
@@ -755,24 +781,14 @@ where
         hello: &ClientHello<'_>,
         metadata: &<A as Accept>::Metadata,
     ) -> Option<TlsHandlerAction> {
-        let hostnames: BTreeSet<InternedString> = hello
-            .server_name()
-            .map(InternedString::from)
-            .into_iter()
-            .chain(
-                extract::<TcpMetadata, _>(metadata)
-                    .map(|m| m.local_addr.ip())
-                    .as_ref()
-                    .map(InternedString::from_display),
-            )
-            .chain(
-                extract::<GatewayInfo, _>(metadata)
-                    .and_then(|i| i.info.ip_info)
-                    .and_then(|i| i.wan_ip)
-                    .as_ref()
-                    .map(InternedString::from_display),
-            )
-            .collect();
+        let gateway = extract::<GatewayInfo, _>(metadata).and_then(|i| i.info.ip_info);
+        let hostnames = [served_name(
+            hello.server_name(),
+            extract::<TcpMetadata, _>(metadata),
+            gateway.as_deref(),
+        )?]
+        .into_iter()
+        .collect();
         let branding = self.branding.clone();
         let cert = self
             .db
@@ -862,5 +878,235 @@ mod cert_validity_tests {
         let expired = cert_expiring_in(-1);
         assert!(!should_use_cert(&expired).unwrap());
         assert!(!cert_is_unexpired(&expired).unwrap());
+    }
+}
+
+#[cfg(test)]
+mod served_name_tests {
+    use std::net::Ipv4Addr;
+
+    use ipnet::IpNet;
+
+    use super::*;
+
+    const LAN: &str = "192.168.0.5:443";
+    const LAN_V6: &str = "[2001:db8::5]:443";
+    const ULA_V6: &str = "[fd00:3::1]:443";
+    const WAN: Ipv4Addr = Ipv4Addr::new(203, 0, 113, 7);
+
+    fn from(peer: &str, local: &str) -> Option<TcpMetadata> {
+        Some(TcpMetadata {
+            peer_addr: peer.parse().unwrap(),
+            local_addr: local.parse().unwrap(),
+        })
+    }
+
+    fn gateway(subnets: &[&str], wan_ip: Option<Ipv4Addr>) -> IpInfo {
+        IpInfo {
+            subnets: subnets
+                .iter()
+                .map(|s| s.parse::<IpNet>().unwrap())
+                .collect(),
+            wan_ip,
+            ..Default::default()
+        }
+    }
+
+    fn name(sni: Option<&str>, tcp: Option<TcpMetadata>, gw: Option<&IpInfo>) -> Option<String> {
+        served_name(sni, tcp, gw).map(|n| n.to_string())
+    }
+
+    #[test]
+    fn a_host_is_certified_by_name_alone_on_every_listener() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        let sni = Some("mybox.local");
+        for local in [LAN, LAN_V6, "127.0.0.1:443", "10.0.3.1:443"] {
+            let tcp = from("198.51.100.9:51000", local);
+            assert_eq!(
+                name(sni, tcp, Some(&gw)).as_deref(),
+                Some("mybox.local"),
+                "listener {local}"
+            );
+        }
+        assert_eq!(name(sni, None, None).as_deref(), Some("mybox.local"));
+    }
+
+    #[test]
+    fn an_address_dialed_from_its_own_network_is_certified_as_itself() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(None, from("192.168.0.90:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+        let bridge = gateway(&["10.0.3.1/24"], Some(WAN));
+        assert_eq!(
+            name(None, from("10.0.3.20:51000", "10.0.3.1:443"), Some(&bridge)).as_deref(),
+            Some("10.0.3.1")
+        );
+    }
+
+    #[test]
+    fn an_ipv4_address_dialed_from_the_internet_is_certified_as_the_wan_address() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(None, from("198.51.100.9:51000", LAN), Some(&gw)).as_deref(),
+            Some("203.0.113.7")
+        );
+    }
+
+    #[test]
+    fn an_address_dialed_over_a_vpn_is_certified_as_itself() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(None, from("10.59.88.2:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+    }
+
+    #[test]
+    fn an_address_dialed_from_a_public_subnet_of_this_gateway_is_certified_as_itself() {
+        let gw = gateway(&["192.168.0.5/24", "198.51.100.2/29"], Some(WAN));
+        assert_eq!(
+            name(None, from("198.51.100.3:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+    }
+
+    #[test]
+    fn a_routable_address_is_certified_as_itself() {
+        let gw = gateway(&["192.168.0.5/24", "198.51.100.2/29"], Some(WAN));
+        assert_eq!(
+            name(
+                None,
+                from("203.0.113.99:51000", "198.51.100.3:443"),
+                Some(&gw)
+            )
+            .as_deref(),
+            Some("198.51.100.3")
+        );
+    }
+
+    #[test]
+    fn an_address_is_certified_as_itself_while_the_wan_address_is_unreachable() {
+        let gw = gateway(&["192.168.0.5/24"], Some(Ipv4Addr::new(100, 88, 0, 1)));
+        assert_eq!(
+            name(None, from("198.51.100.9:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+    }
+
+    #[test]
+    fn an_address_dialed_from_shared_address_space_is_certified_as_itself() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(None, from("100.100.1.5:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+    }
+
+    #[test]
+    fn an_address_dialed_from_the_internet_onto_shared_address_space_is_certified_as_the_wan_address()
+     {
+        let gw = gateway(&["100.64.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(
+                None,
+                from("198.51.100.9:51000", "100.64.0.5:443"),
+                Some(&gw)
+            )
+            .as_deref(),
+            Some("203.0.113.7")
+        );
+    }
+
+    #[test]
+    fn an_address_is_certified_as_itself_while_the_wan_address_is_unknown() {
+        let gw = gateway(&["192.168.0.5/24"], None);
+        assert_eq!(
+            name(None, from("198.51.100.9:51000", LAN), Some(&gw)).as_deref(),
+            Some("192.168.0.5")
+        );
+        assert_eq!(
+            name(None, from("198.51.100.9:51000", LAN), None).as_deref(),
+            Some("192.168.0.5")
+        );
+    }
+
+    #[test]
+    fn an_ipv6_address_is_certified_as_itself_whatever_the_source() {
+        let gw = gateway(&["2001:db8::5/64"], Some(WAN));
+        for (peer, local, expected) in [
+            ("[2001:db8::90]:51000", LAN_V6, "2001:db8::5"),
+            ("[2001:db8:1::9]:51000", LAN_V6, "2001:db8::5"),
+            ("[2001:db8:1::9]:51000", ULA_V6, "fd00:3::1"),
+        ] {
+            assert_eq!(
+                name(None, from(peer, local), Some(&gw)).as_deref(),
+                Some(expected),
+                "peer {peer} listener {local}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_ip_literal_sni_is_certified_as_the_named_address() {
+        let gw = gateway(&["192.168.0.5/24"], None);
+        for address in ["203.0.113.7", "2001:db8::5"] {
+            assert_eq!(
+                name(Some(address), from("192.168.0.90:51000", LAN), Some(&gw)).as_deref(),
+                Some(address)
+            );
+        }
+    }
+
+    #[test]
+    fn a_mapped_ipv4_dial_is_certified_as_the_ipv4_address_it_carries() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(
+            name(
+                None,
+                from("[::ffff:192.168.0.90]:51000", "[::ffff:192.168.0.5]:443"),
+                Some(&gw)
+            )
+            .as_deref(),
+            Some("192.168.0.5")
+        );
+        assert_eq!(
+            name(
+                None,
+                from("[::ffff:198.51.100.9]:51000", "[::ffff:192.168.0.5]:443"),
+                Some(&gw)
+            )
+            .as_deref(),
+            Some("203.0.113.7")
+        );
+    }
+
+    #[test]
+    fn a_connection_naming_nothing_gets_no_certificate() {
+        let gw = gateway(&["192.168.0.5/24"], Some(WAN));
+        assert_eq!(name(None, None, Some(&gw)), None);
+    }
+}
+
+#[cfg(test)]
+mod cert_store_tests {
+    use super::*;
+
+    #[test]
+    fn a_singleton_certificate_reuses_its_key() {
+        let account = AccountInfo::new("password", SystemTime::now(), None).unwrap();
+        let branding = CertBranding::start_os(account.hostname.as_ref());
+        let mut store =
+            Model::<CertStore>::new(&CertStore::new(&account, &branding).unwrap()).unwrap();
+        let hostnames = [InternedString::from("mybox.local")].into_iter().collect();
+
+        let first = store.cert_for(&hostnames, &branding).unwrap();
+        let second = store.cert_for(&hostnames, &branding).unwrap();
+
+        assert_eq!(
+            first.leaf.keys.ed25519.private_key_to_der().unwrap(),
+            second.leaf.keys.ed25519.private_key_to_der().unwrap()
+        );
     }
 }

--- a/shared-libs/crates/start-core/src/net/utils.rs
+++ b/shared-libs/crates/start-core/src/net/utils.rs
@@ -147,6 +147,19 @@ pub fn is_private_ip(addr: IpAddr) -> bool {
     }
 }
 
+pub fn ipv4_is_cgnat(addr: Ipv4Addr) -> bool {
+    let [a, b, ..] = addr.octets();
+    a == 100 && (64..128).contains(&b)
+}
+
+/// Outside private, loopback, link-local, and shared address space.
+pub fn is_global_ip(addr: IpAddr) -> bool {
+    match addr.to_canonical() {
+        IpAddr::V4(v4) => !is_private_ip(v4.into()) && !ipv4_is_cgnat(v4),
+        v6 => !is_private_ip(v6),
+    }
+}
+
 /// The box's own IPv6 global-unicast addresses (GUAs) on `gateways` — the
 /// non-link-local, non-ULA v6 subnet addresses. Used to populate a vhost's
 /// per-IP `public_v6`, since one gateway may carry several GUAs.
@@ -392,3 +405,50 @@ impl TcpListeners {
 //     }
 // }
 // TODO
+
+#[cfg(test)]
+mod is_global_ip_tests {
+    use super::*;
+
+    fn global(addr: &str) -> bool {
+        is_global_ip(addr.parse().unwrap())
+    }
+
+    #[test]
+    fn cgnat_space_ends_where_the_block_does() {
+        assert!(!global("100.64.0.0"));
+        assert!(!global("100.127.255.255"));
+        assert!(global("100.63.255.255"));
+        assert!(global("100.128.0.0"));
+    }
+
+    #[test]
+    fn the_ranges_a_network_hands_out_are_not_global() {
+        for addr in [
+            "10.0.3.1",
+            "172.16.0.1",
+            "192.168.0.5",
+            "127.0.0.1",
+            "169.254.1.1",
+            "::1",
+            "fd00:3::1",
+            "fe80::1",
+        ] {
+            assert!(!global(addr), "{addr}");
+        }
+    }
+
+    #[test]
+    fn a_routable_address_is_global() {
+        for addr in ["203.0.113.7", "198.51.100.9", "2001:db8::5"] {
+            assert!(global(addr), "{addr}");
+        }
+    }
+
+    #[test]
+    fn an_ipv4_mapped_address_is_classified_as_the_address_it_carries() {
+        assert!(!global("::ffff:192.168.0.90"));
+        assert!(!global("::ffff:100.100.1.5"));
+        assert!(global("::ffff:203.0.113.7"));
+    }
+}


### PR DESCRIPTION
Closes #3718

## Summary

StartOS now reuses one server certificate per served name instead of deriving its certificate-store key from each route and listener address. The existing certificate-store model remains unchanged: server listeners request the selected name as a singleton set, while package certificate grants continue through the same API.

## Network selection

A DNS SNI value selects that server name. A connection without SNI is certified for the destination address unless an Internet-side IPv4 connection was translated through the gateway, in which case it uses the validated WAN address. IPv4-mapped listener addresses are canonicalized before classification, and unusable echo-IP results are rejected.

## Verification

- `cargo test -p start-core --features=test` — 735 passed, 3 ignored; 52 doctests passed
- focused certificate-store, served-name, gateway lookup, echo-IP, and address-classification tests
- `cargo check -p start-core --all-targets`
- `make start-core-format-check`
- `mdbook build projects/start-os/docs`

