### PR TITLE
fix(start-core): allow digits and hyphens in a domain's final label

### DIFF
--- a/shared-libs/ts-modules/start-core/lib/test/regexes.test.ts
+++ b/shared-libs/ts-modules/start-core/lib/test/regexes.test.ts
@@ -1,0 +1,30 @@
+import { domain } from '../util/regexes'
+
+const matches = new RegExp(domain.matches())
+
+describe('the domain regex', () => {
+  test.each([
+    'db.com',
+    'sub.domain.example.com',
+    'nextcloud.private',
+    'private.domain.internal',
+    'nextcloud.fake-tld', // the example in private-domains.md
+    'nextcloud.lan2', // a non-delegated TLD containing digits
+    'example.xn--p1ai', // IDN A-label TLD (.рф)
+    'a.co',
+  ])('accepts %s', fqdn => {
+    expect(matches.test(fqdn)).toBe(true)
+  })
+
+  test.each([
+    ['1.2.3.4', 'a dotted-decimal IPv4 literal, RFC 1123 § 2.1'],
+    ['nodot', 'a single label is not fully qualified'],
+    ['foo..com', 'an empty label'],
+    ['..foo.com', 'a leading dot'],
+    ['-foo.com', 'a label starting with a hyphen'],
+    ['foo-.com', 'a label ending with a hyphen'],
+    [`${'a'.repeat(64)}.com`, 'a label over 63 characters'],
+  ])('rejects %s (%s)', fqdn => {
+    expect(matches.test(fqdn)).toBe(false)
+  })
+})

--- a/shared-libs/ts-modules/start-core/lib/util/regexes.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/regexes.ts
@@ -79,8 +79,18 @@ export const localUrl = new ComposableRegex(
 // https://ihateregex.io/expr/ascii/
 export const ascii = new ComposableRegex(/[ -~]*/)
 
-/** Composable regex for matching fully qualified domain names. */
-export const domain = new ComposableRegex(/[A-Za-z0-9.-]+\.[A-Za-z]{2,}/)
+/**
+ * Composable regex for matching fully qualified domain names.
+ *
+ * Each label is 1-63 characters, starts and ends alphanumeric, and may contain
+ * hyphens internally. The final label must start with a letter, which keeps a
+ * dotted-decimal IPv4 literal from parsing as a domain (RFC 1123 § 2.1) while
+ * still admitting digits and hyphens in the TLD, as IDN A-labels (`xn--p1ai`)
+ * and non-delegated private TLDs both require.
+ */
+export const domain = new ComposableRegex(
+  /([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?/,
+)
 
 /** Composable regex for matching email addresses. */
 // https://www.regular-expressions.info/email.html


### PR DESCRIPTION
## What

`regexes.domain` requires the final label of an FQDN to be alphabetic-only:

```ts
export const domain = new ComposableRegex(/[A-Za-z0-9.-]+\.[A-Za-z]{2,}/)
```

`ComposableRegex.matches()` anchors that to `^[A-Za-z0-9.-]+\.[A-Za-z]{2,}$`, and that is what
`Patterns.domain` — and therefore the Add Domain dialog — validates against.

The rule is wrong in both directions. It rejects names that are valid, and accepts strings that are
not hostnames at all.

### Rejected today, but valid

| Input | Why it should be accepted |
| --- | --- |
| `nextcloud.fake-tld` | This is **the documented example** in `projects/start-os/docs/src/private-domains.md` |
| `nextcloud.lan2` | A private domain on a non-delegated TLD, which the same page explicitly permits |
| `example.xn--p1ai` | IDN A-label TLD (`.рф`). **Every internationalized TLD is currently unenterable, as a public domain too.** |
| `example.xn--fiqs8s` | IDN A-label TLD (`.中国`) |

### Accepted today, but invalid

| Input | Why it should be rejected |
| --- | --- |
| `..foo.com`, `foo..com` | empty labels |
| `-foo.com`, `foo-.com` | a label may not start or end with a hyphen |
| a 64-character label | RFC 1035 § 2.3.4 caps a label at 63 octets |

## Why this is not only a private-domain issue

The private-domain dialog's own help text reads *"Since the domain is for private use, it can be any
domain you want, even one you do not control."* The same validator backs both forms —
`gateway.component.ts` passes `patterns: [utils.Patterns.domain]` in `addPrivateDomain()` and in
`addPublicDomain()` — so the IDN rejection lands on public domains as well.

Validation is UI-side only. `add_private_domain` in
`shared-libs/crates/start-core/src/net/host/address.rs` lowercases the value and checks for
duplicates, applying no pattern, so this regex is the entire enforcement surface.

## The fix

Require the final label to *start* with a letter, rather than to be entirely letters. That preserves
the one constraint that actually matters, RFC 1123 § 2.1:

> a valid host name can never have the dotted-decimal form #.#.#.#, since at least the highest-level
> component label will be alphabetic

The purpose there is to keep names distinguishable from IPv4 literals, which requires only that the
final label not be *entirely* numeric. `1.2.3.4` is still rejected. The replacement additionally
enforces the per-label rules the old pattern ignored.

It deliberately carries no anchors and no lookaheads, because `email` embeds it through
`domain.asExpr()`; email validation improves by the same change, since `user@foo..com` stops
passing.

## Tests

Adds `lib/test/regexes.test.ts` covering both directions, including the documented `fake-tld`
example, an IDN A-label, and each malformed input that previously passed. Verified failing against
the old pattern before the fix.
