### PR TITLE
fix(packaging): scaffold a .dockerignore that filters the build context

### DIFF
--- a/projects/start-sdk/docs/package-template/.dockerignore
+++ b/projects/start-sdk/docs/package-template/.dockerignore
@@ -1,2 +1,7 @@
 .git
 .gitmodules
+node_modules
+javascript
+ncc-cache
+docker-images
+*.s9pk

--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -36,6 +36,7 @@ my-service-startos/
 │   ├── sdk.ts              # SDK initialization (boilerplate)
 │   ├── utils.ts            # Package-specific utilities
 │   └── versions/           # Version management and migrations
+├── .dockerignore           # Build-context filter (see below)
 ├── .gitignore
 ├── AGENTS.md               # Agent context: repo identity + how to work in this repo
 ├── CLAUDE.md               # One-line `@AGENTS.md` import for Claude Code
@@ -59,6 +60,7 @@ my-service-startos/
 These files typically require minimal modification:
 
 - `.gitignore`
+- `.dockerignore` - Docker does not read `.gitignore`, so a package that builds from source needs this to keep `node_modules`, `.git`, and built `.s9pk`s out of the build context that `s9pk pack` uploads on every arch
 - `Makefile` - Includes the SDK's `s9pk.mk` from `node_modules` (see [Makefile](./makefile.md))
 - `package.json` / `package-lock.json`
 - `tsconfig.json`


### PR DESCRIPTION
The package template shipped a `.dockerignore` of `.git` + `.gitmodules` only. Every package scaffolded from it that builds from source therefore hands the docker daemon its **entire working tree** as build context, once per arch, on every `s9pk pack`. Docker does not read `.gitignore`, so the entries there never applied.

`init-package` copies this directory out of the workspace's `start-technologies` checkout (`start-core/src/s9pk/init.rs`, `TEMPLATE_SUBPATH`), so the fix reaches new packages as soon as a packager's session-start sync pulls master. It is not book content — `book.toml` sets `src = "src"`, and `package-template/` is a sibling of it — so this lands on master like ordinary repo content.

## Scale

Measured on `cln-startos`, whose `Dockerfile` copies only two submodule directories:

| | |
| --- | --- |
| Context uploaded, per arch | **408 MB** |
| What the `Dockerfile` consumes | ~12 MB |
| Built `c-lightning_x86_64.s9pk` in the repo root | 227 MB |
| `node_modules` | 123 MB |
| `.git` | 53 MB |

Across both registries, **67 packages declare `dockerBuild`**. Of those:

- 20 have no `.dockerignore` at all
- 37 carry only the template's `.git`/`.gitmodules`
- 9 filter `node_modules`, `.git`, and `*.s9pk`
- 1 partial

So 57 of 67 upload `node_modules` and any built `.s9pk` on every arch build. Start9Labs' own `bitcoin-core` (four branches), `bitcoin-knots` (two), `lnd`, `nextcloud`, and `lnbits` are in the no-file group.

## The entries

Mirrors the template's own `.gitignore`, so what git ignores is what the daemon never sees:

```
.git
.gitmodules
node_modules
javascript
ncc-cache
docker-images
*.s9pk
```

Excluding `.git` is safe for the metadata: `s9pk pack` reads the commit hash by running `git rev-parse` on the host (`GitHash::from_path`), not from inside the build context, so `metadata.gitHash` is unaffected. The pattern is root-anchored, so a vendored submodule's own `.git` is left alone.

`project-structure.md` never listed `.dockerignore` even though the template already shipped one; it now appears in the tree and the boilerplate list with the one fact a reader can't derive — that Docker ignores `.gitignore`.

Existing packages are not touched here; they need the file added repo by repo. `cln-startos` already has it (Start9Labs/cln-startos#189).