### PR TITLE
chore(core): drop the JSON-RPC payload dumps from RpcClient

### DIFF
--- a/shared-libs/crates/start-core/src/util/rpc_client.rs
+++ b/shared-libs/crates/start-core/src/util/rpc_client.rs
@@ -47,7 +47,7 @@ impl RpcClient {
                 let mut lines = BufReader::new(reader).lines();
                 while let Some(line) = lines.next_line().await.transpose() {
                     match line.map_err(Error::from).and_then(|l| {
-                        serde_json::from_str::<RpcResponse>(crate::dbg!(&l))
+                        serde_json::from_str::<RpcResponse>(&l)
                             .with_kind(ErrorKind::Deserialization)
                     }) {
                         Ok(l) => {
@@ -114,7 +114,7 @@ impl RpcClient {
             let (send, recv) = oneshot::channel();
             w.lock().await.insert(id.clone(), send);
             self.writer
-                .write_all((crate::dbg!(serde_json::to_string(&request))? + "\n").as_bytes())
+                .write_all((serde_json::to_string(&request)? + "\n").as_bytes())
                 .await
                 .map_err(|e| {
                     let mut err = rpc_toolkit::yajrc::INTERNAL_ERROR.clone();
@@ -154,7 +154,7 @@ impl RpcClient {
             params,
         };
         self.writer
-            .write_all((crate::dbg!(serde_json::to_string(&request))? + "\n").as_bytes())
+            .write_all((serde_json::to_string(&request)? + "\n").as_bytes())
             .await
             .map_err(|e| {
                 let mut err = rpc_toolkit::yajrc::INTERNAL_ERROR.clone();


### PR DESCRIPTION
Removes the three `crate::dbg!` calls in `RpcClient`, as requested on Matrix.

`crate::dbg!` expands to `tracing::debug!`, so these were not inert in a
release build. `projects/start-os/startd.service:6` ships
`Environment=RUST_LOG=warn,start_core=debug` and `logger.rs:76` builds the
filter with `from_env_lossy()`, so the `start_core=debug` directive wins and
all three emitted into the `startd` journal on every box. `RpcClient::request`
serializes `ExecuteParams`, whose `input: Value` is what a user types into an
action form — including a field a package marks `masked`, which
`service/action.rs` documents as the channel for a password.

The container-side substitute holds for the case it was raised for:
`RpcListener.ts` logs the inbound line and the outbound response under
`isDevBuild`, which reads `STARTOS_ENVIRONMENT`. Worth stating explicitly
that it is a **build-time** gate with no runtime switch, and `ENVIRONMENT` is
empty on master, so it covers dev builds and nothing else. Production loses
this logging rather than relocating it. If either leg is wanted in the field,
`crate::dev_log!` keys off the same `ENVIRONMENT` value and would keep the two
ends symmetric at no production cost.

## Verification

- `cargo check -p start-core` — clean, no new warnings.
- `make start-core-format-check` — clean.
- The macro is value- and type-transparent (`{ let e = $e; tracing::debug!(…); e }`),
  so the bytes written and the framing are unchanged; `?` still applies to the
  same `Result`.

## Left alone deliberately — your call

1. **The same file still Debug-prints response payloads on three paths, two of
   them above the level just removed**: `res.send(l.result)` returns the payload
   on failure and logs it at `warn`, the unknown-id branch logs `l.result` at
   `warn`, and the notification branch logs the whole response at `info`. The
   first is reachable whenever a request times out and the response lands late,
   which `GetActionInput` does at 30s. Narrowing those needs a redaction
   decision, so it seemed wrong to fold into a one-line request.
2. **No `CHANGELOG.md` entry.** The rule keys on user-visible behavior, and this
   alone is not. If you read it as closing a leak, the entry belongs with item 1
   rather than here — claiming it now would overstate what this diff does.
3. **`crate::dbg!` in `prelude.rs` has no call sites left.** `#[macro_export]`
   suppresses `unused_macros`, so nothing will flag it. Kept, since it is a
   deliberate debugging aid, but happy to delete it.
