### PR TITLE
fix(registry): publish canMigrateFrom as a version's sourceVersion

### DIFF
--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `start-registry` (the Start Registry server) are document
 
 ## [1.0.2]
 
+- **An indexed package version now advertises which installed versions can migrate into it**, so a
+  client asking for an upgrade path is offered a version it can actually install. Entries already
+  in an index keep their permissive value until that version is published again.
+
 - **`os asset remove` can be run.** Its `iso`/`img`/`squashfs` handlers were registered as
   RPC-only with no CLI counterpart, so `remove` parsed as a leaf that accepts no arguments — it
   listed with a blank description and rejected `os asset remove iso 0.4.0 x86_64` as an

--- a/shared-libs/crates/start-core/src/registry/package/index.rs
+++ b/shared-libs/crates/start-core/src/registry/package/index.rs
@@ -152,7 +152,7 @@ impl PackageVersionInfo {
             metadata: manifest.metadata.clone(),
             icon,
             dependency_metadata,
-            source_version: None, // TODO
+            source_version: Some(manifest.can_migrate_from.clone()),
             s9pks: vec![(
                 manifest.hardware_requirements.clone(),
                 RegistryAsset {


### PR DESCRIPTION
`PackageVersionInfo::from_s9pk` left `source_version` at `None, // TODO`, so every indexed package version advertises "anything can migrate into me". The live production registry shows it: `"sourceVersion": null` on every entry.

That one gap leaves two mechanisms that already exist doing nothing.

**The registry's own filter.** `get_matching_models` (`registry/package/get.rs:180`) narrows candidates to those the caller can actually migrate into, and `best` is chosen from what survives:

```rust
source_version.as_ref().map_or(Ok(true), |source_version| {
    source_version.satisfies(&info.as_source_version().de()?.unwrap_or(VersionRange::any()))
})
```

With the stored value always `None`, `unwrap_or(any())` lets every version through.

**The Updates page's refinement pass.** `updates-refinement.service.ts` exists specifically to notice that `best` excludes the installed version, refetch with `sourceVersion=<local>`, and swap the row in place — rendering "Finding suitable version…" while it does, and dropping the row if nothing is reachable. Its predicate is `this.exver.satisfies(localVer, pkg.sourceVersion || '*')`, so it has never found a single row.

## What it costs users today

Nextcloud is the live case. An install carried over from StartOS 0.3.5.x sits on `32.0.11:0`. The package's next release bundles Nextcloud 34, and Nextcloud refuses to cross two majors (`$OC_VersionCanBeUpgradedFrom` in `v34.0.3/version.php` is `{33.0, 34.0}`). The Updates tab offers it anyway, init refuses the jump, and StartOS rolls the whole update back. The user's data is safe and the outcome is a failed update with no route out of it except finding the intermediate release by hand in the Marketplace version picker.

With this change the registry answers that query with the 33 release, and the Updates tab shows a version that will actually install. It generalises to every package with a hard upgrade constraint — Postgres majors, Bitcoin Core, anything with a real floor in its version graph.

## Why this is the right place

`sideload.utils.ts:41` already maps `s9pk.manifest.canMigrateFrom` onto `sourceVersion` for a sideloaded s9pk. The registry path is the odd one out; this makes the two agree.

## Notes for review

**`merge_with` needs no change.** It only folds a second asset into a version already indexed, and it returns an error unless `metadata` matches exactly — `git_hash` included. Both sides are therefore the same build and carry the same `can_migrate_from`, so the field cannot go stale through it.

**Only newly-indexed versions are affected.** Entries already in an index keep `null`, which is the permissive value, so nothing currently published changes behaviour. A version picks the field up when it is next published or re-published; alpha and community-beta re-publish on every push, and beta/prod entries pick it up when a new version is promoted.

**This is the change the SDK 2.0.5 changelog anticipated.** That entry records `canMigrateFrom` having been emitted narrower than the truth for any package declaring an `other` version sharing `current`'s upstream, and says the manifests "would have become load-bearing the moment either changed" — noting specifically that the registry index did not yet populate `sourceVersion`. It does now. The fix shipped in SDK 2.0.5 (2026-07-13) and current is 2.0.9, so anything built since carries a correct range; the exposure is limited to publishing a build made with an SDK older than 2.0.5, where a too-narrow range would filter that version out for installs it could in fact serve. Re-publishing corrects it.

**Not built locally.** `cargo check` of `start-core` compiles the whole backend from cold on this machine, so I left it to CI. The change is `Option<VersionRange>` ← `Some(manifest.can_migrate_from.clone())`, against `Manifest.can_migrate_from: VersionRange` (`s9pk/v2/manifest.rs:38`).

**A package still has to declare the truth.** This publishes whatever the version graph derives. A package whose graph is unbounded below advertises a permissive range and nothing changes for it — correctly. Nextcloud's floor is being raised in a companion PR on that repo so its range stops claiming 32 can reach 34.
