### PR TITLE
fix(ui): render an action's message as markdown, and unify how results copy

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -248,17 +248,6 @@ file tracks notable changes since the move to the monorepo.
   settings excluded. StartOS now rejects the overlapping claim and names both
   ports, so the service reports the conflict instead of serving it.
 
-- **The message an action returns is rendered as Markdown, and its line breaks
-  are kept.** A service action that reports back over several lines — a
-  diagnostic report, a list of what succeeded and what failed — reads as the
-  service wrote it, and can use headings, lists, tables, code blocks, emphasis
-  and links.
-
-- **The copy button beside a value in a grouped action result copies the whole
-  value.** Copying from a group dropped any line breaks the value contained and
-  gave no confirmation that anything had been copied. It now copies exactly
-  what the action returned, and confirms, like every other copy button.
-
 ### Security
 
 - **Service mount paths are validated and confined to their intended

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -248,6 +248,17 @@ file tracks notable changes since the move to the monorepo.
   settings excluded. StartOS now rejects the overlapping claim and names both
   ports, so the service reports the conflict instead of serving it.
 
+- **Line breaks in the message an action returns are kept.** A service action
+  that reports back over several lines — a diagnostic report, a list of what
+  succeeded and what failed — had every line run together into one paragraph.
+  The message now reads as the service wrote it, matching what `start-cli`
+  shows for the same action.
+
+- **The copy button beside a value in a grouped action result copies the whole
+  value.** Copying from a group dropped any line breaks the value contained and
+  gave no confirmation that anything had been copied. It now copies exactly
+  what the action returned, and confirms, like every other copy button.
+
 ### Security
 
 - **Service mount paths are validated and confined to their intended

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -248,11 +248,11 @@ file tracks notable changes since the move to the monorepo.
   settings excluded. StartOS now rejects the overlapping claim and names both
   ports, so the service reports the conflict instead of serving it.
 
-- **Line breaks in the message an action returns are kept.** A service action
-  that reports back over several lines — a diagnostic report, a list of what
-  succeeded and what failed — had every line run together into one paragraph.
-  The message now reads as the service wrote it, matching what `start-cli`
-  shows for the same action.
+- **The message an action returns is rendered as Markdown, and its line breaks
+  are kept.** A service action that reports back over several lines — a
+  diagnostic report, a list of what succeeded and what failed — reads as the
+  service wrote it, and can use headings, lists, tables, code blocks, emphasis
+  and links.
 
 - **The copy button beside a value in a grouped action result copies the whole
   value.** Copying from a group dropped any line breaks the value contained and

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-member.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-member.component.ts
@@ -1,20 +1,8 @@
-import {
-  Component,
-  ElementRef,
-  inject,
-  Input,
-  TemplateRef,
-  ViewChild,
-} from '@angular/core'
+import { Component, inject, Input, TemplateRef } from '@angular/core'
 import { FormsModule } from '@angular/forms'
-import { DialogService, i18nPipe } from '@start9labs/shared'
+import { CopyService, DialogService, i18nPipe } from '@start9labs/shared'
 import { T } from '@start9labs/start-core'
-import {
-  TuiButton,
-  TuiInputDirective,
-  TuiTitle,
-  TuiInput,
-} from '@taiga-ui/core'
+import { TuiButton, TuiInput, TuiTitle } from '@taiga-ui/core'
 import { QRComponent } from 'src/app/components/qr.component'
 
 @Component({
@@ -51,7 +39,7 @@ import { QRComponent } from 'src/app/components/qr.component'
           tabindex="-1"
           iconStart="@tui.copy"
           [style.pointer-events]="'auto'"
-          (click)="copy()"
+          (click)="copy.copy(member.value)"
         >
           {{ 'Copy' | i18n }}
         </button>
@@ -109,9 +97,8 @@ import { QRComponent } from 'src/app/components/qr.component'
   imports: [FormsModule, TuiInput, TuiButton, QRComponent, TuiTitle, i18nPipe],
 })
 export class ActionSuccessMemberComponent {
-  @ViewChild(TuiInputDirective, { read: ElementRef })
-  private readonly input!: ElementRef<HTMLInputElement>
   private readonly dialog = inject(DialogService)
+  readonly copy = inject(CopyService)
 
   @Input()
   member!: T.ActionResultMember & { type: 'single' }
@@ -127,19 +114,5 @@ export class ActionSuccessMemberComponent {
       .subscribe({
         complete: () => (this.masked = masked),
       })
-  }
-
-  copy() {
-    const el = this.input.nativeElement
-
-    if (!el) {
-      return
-    }
-
-    el.type = 'text'
-    el.focus()
-    el.select()
-    el.ownerDocument.execCommand('copy')
-    el.type = this.masked && this.member.masked ? 'password' : 'text'
   }
 }

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
@@ -16,7 +16,7 @@ import { ActionResponse } from './types'
   template: `
     @if (message) {
       <div
-        class="message"
+        class="g-markdown"
         safeLinks
         [innerHTML]="message | i18n | markdown: options | dompurify"
       ></div>
@@ -26,31 +26,6 @@ import { ActionResponse } from './types'
     }
     @if (group) {
       <app-action-success-group [group]="group" />
-    }
-  `,
-  styles: `
-    .message {
-      ::ng-deep > :first-child {
-        margin-block-start: 0;
-      }
-
-      ::ng-deep > :last-child {
-        margin-block-end: 0;
-      }
-
-      ::ng-deep pre {
-        white-space: pre-wrap;
-        overflow-wrap: anywhere;
-      }
-
-      ::ng-deep table {
-        border-collapse: collapse;
-      }
-
-      ::ng-deep :is(td, th) {
-        border: 1px solid var(--tui-border-normal);
-        padding: 0.25rem 0.75rem;
-      }
     }
   `,
   imports: [

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
@@ -1,14 +1,15 @@
 import { Component } from '@angular/core'
+import { i18nKey, i18nPipe } from '@start9labs/shared'
 import { TuiDialogContext } from '@taiga-ui/core'
 import { injectContext } from '@taiga-ui/polymorpheus'
 import { ActionSuccessGroupComponent } from './action-success-group.component'
 import { ActionSuccessSingleComponent } from './action-success-single.component'
-import { ActionResponseWithResult } from './types'
+import { ActionResponse } from './types'
 
 @Component({
   template: `
-    @if (data.message) {
-      <p>{{ data.message }}</p>
+    @if (message) {
+      <p>{{ message | i18n }}</p>
     }
     @if (single) {
       <app-action-success-single [single]="single" />
@@ -17,12 +18,27 @@ import { ActionResponseWithResult } from './types'
       <app-action-success-group [group]="group" />
     }
   `,
-  imports: [ActionSuccessGroupComponent, ActionSuccessSingleComponent],
+  styles: `
+    p {
+      margin-block-start: 0;
+      white-space: pre-wrap;
+    }
+
+    p:last-child {
+      margin-block-end: 0;
+    }
+  `,
+  imports: [
+    ActionSuccessGroupComponent,
+    ActionSuccessSingleComponent,
+    i18nPipe,
+  ],
 })
 export class ActionSuccessPage {
-  readonly data =
-    injectContext<TuiDialogContext<void, ActionResponseWithResult>>().data
+  readonly data = injectContext<TuiDialogContext<void, ActionResponse>>().data
 
-  readonly single = this.data.result.type === 'single' ? this.data.result : null
-  readonly group = this.data.result.type === 'group' ? this.data.result : null
+  readonly message = this.data.message as i18nKey | null
+  readonly single =
+    this.data.result?.type === 'single' ? this.data.result : null
+  readonly group = this.data.result?.type === 'group' ? this.data.result : null
 }

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
@@ -1,6 +1,12 @@
 import { Component } from '@angular/core'
-import { i18nKey, i18nPipe } from '@start9labs/shared'
+import {
+  i18nKey,
+  i18nPipe,
+  MarkdownPipe,
+  SafeLinksDirective,
+} from '@start9labs/shared'
 import { TuiDialogContext } from '@taiga-ui/core'
+import { NgDompurifyPipe } from '@taiga-ui/dompurify'
 import { injectContext } from '@taiga-ui/polymorpheus'
 import { ActionSuccessGroupComponent } from './action-success-group.component'
 import { ActionSuccessSingleComponent } from './action-success-single.component'
@@ -9,7 +15,11 @@ import { ActionResponse } from './types'
 @Component({
   template: `
     @if (message) {
-      <p>{{ message | i18n }}</p>
+      <div
+        class="message"
+        safeLinks
+        [innerHTML]="message | i18n | markdown: options | dompurify"
+      ></div>
     }
     @if (single) {
       <app-action-success-single [single]="single" />
@@ -19,18 +29,36 @@ import { ActionResponse } from './types'
     }
   `,
   styles: `
-    p {
-      margin-block-start: 0;
-      white-space: pre-wrap;
-    }
+    .message {
+      ::ng-deep > :first-child {
+        margin-block-start: 0;
+      }
 
-    p:last-child {
-      margin-block-end: 0;
+      ::ng-deep > :last-child {
+        margin-block-end: 0;
+      }
+
+      ::ng-deep pre {
+        white-space: pre-wrap;
+        overflow-wrap: anywhere;
+      }
+
+      ::ng-deep table {
+        border-collapse: collapse;
+      }
+
+      ::ng-deep :is(td, th) {
+        border: 1px solid var(--tui-border-normal);
+        padding: 0.25rem 0.75rem;
+      }
     }
   `,
   imports: [
     ActionSuccessGroupComponent,
     ActionSuccessSingleComponent,
+    NgDompurifyPipe,
+    MarkdownPipe,
+    SafeLinksDirective,
     i18nPipe,
   ],
 })
@@ -41,4 +69,6 @@ export class ActionSuccessPage {
   readonly single =
     this.data.result?.type === 'single' ? this.data.result : null
   readonly group = this.data.result?.type === 'group' ? this.data.result : null
+
+  readonly options = { breaks: true }
 }

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/types.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/types.ts
@@ -1,7 +1,6 @@
 import { ActionRes } from 'src/app/services/api/api.types'
 
-type ActionResponse = NonNullable<ActionRes>
+export type ActionResponse = NonNullable<ActionRes>
 type ActionResult = NonNullable<ActionResponse['result']>
-export type ActionResponseWithResult = ActionResponse & { result: ActionResult }
 export type SingleResult = ActionResult & { type: 'single' }
 export type GroupResult = ActionResult & { type: 'group' }

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/routes/instructions.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/routes/instructions.component.ts
@@ -16,7 +16,11 @@ import { ApiService } from 'src/app/services/api/embassy-api.service'
     @if (value() === undefined) {
       <tui-loader textContent="Loading" [style.height.%]="100" />
     } @else if (value(); as value) {
-      <article safeLinks [innerHTML]="value | markdown | dompurify"></article>
+      <article
+        class="g-markdown"
+        safeLinks
+        [innerHTML]="value | markdown | dompurify"
+      ></article>
     } @else {
       <div tuiNotification appearance="neutral">
         {{ 'This version has no instructions. Please update.' | i18n }}
@@ -27,22 +31,6 @@ import { ApiService } from 'src/app/services/api/embassy-api.service'
     article {
       max-width: 48rem;
       font: var(--tui-typography-body-l);
-
-      ::ng-deep pre {
-        padding: 0.75rem 1rem;
-        border-radius: var(--tui-radius-m);
-        background: var(--tui-background-neutral-1);
-        overflow-x: auto;
-      }
-
-      ::ng-deep table {
-        border-collapse: collapse;
-      }
-
-      ::ng-deep :is(td, th) {
-        border: 1px solid var(--tui-border-normal);
-        padding: 0.25rem 0.75rem;
-      }
     }
   `,
   host: { class: 'g-subpage' },

--- a/projects/start-os/web/ui/src/app/services/action.service.ts
+++ b/projects/start-os/web/ui/src/app/services/action.service.ts
@@ -63,16 +63,12 @@ export class ActionService {
 
       if (!res) return
 
-      if (res.result) {
+      if (res.result || res.message) {
         this.dialog
           .openComponent(new PolymorpheusComponent(ActionSuccessPage), {
             label: res.title as i18nKey,
             data: res,
           })
-          .subscribe()
-      } else if (res.message) {
-        this.dialog
-          .openAlert(res.message as i18nKey, { label: res.title as i18nKey })
           .subscribe()
       }
     } catch (e: any) {

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -1502,7 +1502,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
     version: '1',
     title: 'New Password',
     message:
-      'Action was run successfully and smoothly and fully and all is good on the western front.',
+      'Action was run successfully and smoothly and fully and all is good on the western front.\n\nRestart the service for the new password to take effect.',
     result: null,
   }
 

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -1502,7 +1502,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
     version: '1',
     title: 'New Password',
     message:
-      'Action was run successfully and smoothly and fully and all is good on the western front.\n\nRestart the service for the new password to take effect.',
+      '### Rotated\n\n- node-1\n- node-2\n- node-3\n\n**Restart the service** for the new password to take effect.\nThe old password stops working immediately.',
     result: null,
   }
 

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -1629,6 +1629,25 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
       }),
     )
 
+  export const getRpcSpec = async (): Promise<IST.InputSpec> =>
+    configBuilderToSpec(
+      ISB.InputSpec.of({
+        rpcuser: ISB.Value.text({
+          name: 'RPC Username',
+          description: 'rpc username',
+          required: true,
+          default: 'defaultrpcusername',
+        }),
+        rpcpass: ISB.Value.text({
+          name: 'RPC User Password',
+          description: 'rpc password',
+          required: true,
+          default: { charset: 'a-z,A-Z,2-9', len: 20 },
+          masked: true,
+        }),
+      }),
+    )
+
   export const getActionInputSpec = async (): Promise<IST.InputSpec> =>
     configBuilderToSpec(
       ISB.InputSpec.of({

--- a/projects/start-os/web/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/projects/start-os/web/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -1258,6 +1258,14 @@ export class MockApiService extends ApiService {
       }
     }
 
+    if (params.actionId === 'rpc') {
+      return {
+        eventId: 'ANZXNWIFRTTBZ6T52KQPZILIQQODDHXQ',
+        value: null,
+        spec: await Mock.getRpcSpec(),
+      }
+    }
+
     return {
       eventId: 'ANZXNWIFRTTBZ6T52KQPZILIQQODDHXQ',
       value: Mock.MockConfig,

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -94,7 +94,23 @@ export const actions = sdk.Actions.of().addAction(setAdminPassword)
 
 Actions return structured results that the StartOS UI renders for the user.
 
-`message` is prose shown under the title, and **line breaks in it are preserved** — put anything with its own line structure there. `result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR and masking, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
+`message` is prose shown under the title. It is rendered as **Markdown** — headings, lists, tables, code blocks, emphasis and links all work — and a single newline is kept as a line break, so text written as plain lines arrives as plain lines. Anything with its own line structure goes here.
+
+`result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR and masking, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
+
+```typescript
+return {
+  version: '1',
+  title: 'Diagnostics',
+  message: `### Checks
+
+- database: **ok**
+- search index: **rebuilding**
+
+Restart the service once the rebuild finishes.`,
+  result: null,
+}
+```
 
 ### Single Value
 

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -94,6 +94,8 @@ export const actions = sdk.Actions.of().addAction(setAdminPassword)
 
 Actions return structured results that the StartOS UI renders for the user.
 
+`message` is prose shown under the title, and **line breaks in it are preserved** — put anything with its own line structure there. `result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR and masking, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
+
 ### Single Value
 
 ```typescript

--- a/shared-libs/crates/start-core/src/action.rs
+++ b/shared-libs/crates/start-core/src/action.rs
@@ -165,7 +165,7 @@ impl fmt::Display for ActionResultV0 {
 pub struct ActionResultV1 {
     /// Primary text to display as the header of the response modal. e.g. "Success!", "Name Updated", or "Service Information", whatever makes sense
     pub title: String,
-    /// (optional) A general message for the user, just under the title. Line breaks are preserved.
+    /// (optional) A general message for the user, just under the title. Rendered as Markdown, with a single line break kept as a line break.
     pub message: Option<String>,
     /// (optional) Structured data to present inside the modal
     pub result: Option<ActionResultValue>,

--- a/shared-libs/crates/start-core/src/action.rs
+++ b/shared-libs/crates/start-core/src/action.rs
@@ -165,7 +165,7 @@ impl fmt::Display for ActionResultV0 {
 pub struct ActionResultV1 {
     /// Primary text to display as the header of the response modal. e.g. "Success!", "Name Updated", or "Service Information", whatever makes sense
     pub title: String,
-    /// (optional) A general message for the user, just under the title
+    /// (optional) A general message for the user, just under the title. Line breaks are preserved.
     pub message: Option<String>,
     /// (optional) Structured data to present inside the modal
     pub result: Option<ActionResultValue>,
@@ -189,7 +189,8 @@ pub struct ActionResultMember {
 #[serde(tag = "type")]
 pub enum ActionResultValue {
     Single {
-        /// The actual string value to display
+        /// The actual string value to display. The UI renders it as a single-line field —
+        /// multi-line text belongs in the result's `message`.
         value: String,
         /// Whether or not to include a copy to clipboard icon to copy the value
         copyable: bool,

--- a/shared-libs/ts-modules/shared/src/components/markdown.component.ts
+++ b/shared-libs/ts-modules/shared/src/components/markdown.component.ts
@@ -20,17 +20,15 @@ import { getErrorMessage } from '../services/error.service'
     }
 
     @if (content(); as result) {
-      <div safeLinks [innerHTML]="result | markdown | dompurify"></div>
+      <div
+        class="g-markdown"
+        safeLinks
+        [innerHTML]="result | markdown | dompurify"
+      ></div>
     } @else {
       @if (!error()) {
         <tui-loader textContent="Loading" [style.height.%]="100" />
       }
-    }
-  `,
-  styles: `
-    :host ::ng-deep pre {
-      white-space: pre-wrap;
-      overflow-wrap: anywhere;
     }
   `,
   host: { class: 'g-subpage' },

--- a/shared-libs/ts-modules/shared/src/pipes/markdown.pipe.ts
+++ b/shared-libs/ts-modules/shared/src/pipes/markdown.pipe.ts
@@ -5,7 +5,7 @@ import { marked } from 'marked'
   name: 'markdown',
 })
 export class MarkdownPipe implements PipeTransform {
-  transform(value: string): string {
-    return value?.length ? marked(value) : ''
+  transform(value: string, options?: marked.MarkedOptions): string {
+    return value?.length ? marked(value, options) : ''
   }
 }

--- a/shared-libs/ts-modules/shared/styles/shared.scss
+++ b/shared-libs/ts-modules/shared/styles/shared.scss
@@ -96,3 +96,31 @@ tui-textfield:has(tui-icon[tuiPassword], input[type='password'])
 .g-secondary {
   color: var(--tui-text-secondary) !important;
 }
+
+// Body of markdown rendered through `| markdown | dompurify`. The innerHTML it
+// produces is unencapsulated, so these rules have to be global.
+.g-markdown {
+  > :first-child {
+    margin-block-start: 0;
+  }
+
+  > :last-child {
+    margin-block-end: 0;
+  }
+
+  pre {
+    padding: 0.75rem 1rem;
+    border-radius: var(--tui-radius-m);
+    background: var(--tui-background-neutral-1);
+    overflow-x: auto;
+  }
+
+  table {
+    border-collapse: collapse;
+  }
+
+  :is(td, th) {
+    border: 1px solid var(--tui-border-normal);
+    padding: 0.25rem 0.75rem;
+  }
+}

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
@@ -13,7 +13,8 @@ export type ActionResultMember = {
   | {
       type: 'single'
       /**
-       * The actual string value to display
+       * The actual string value to display. The UI renders it as a single-line field —
+       * multi-line text belongs in the result's `message`.
        */
       value: string
       /**

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultV1.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultV1.ts
@@ -7,7 +7,7 @@ export type ActionResultV1 = {
    */
   title: string
   /**
-   * (optional) A general message for the user, just under the title
+   * (optional) A general message for the user, just under the title. Line breaks are preserved.
    */
   message: string | null
   /**

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultV1.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultV1.ts
@@ -7,7 +7,7 @@ export type ActionResultV1 = {
    */
   title: string
   /**
-   * (optional) A general message for the user, just under the title. Line breaks are preserved.
+   * (optional) A general message for the user, just under the title. Rendered as Markdown, with a single line break kept as a line break.
    */
   message: string | null
   /**

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
@@ -5,7 +5,8 @@ export type ActionResultValue =
   | {
       type: 'single'
       /**
-       * The actual string value to display
+       * The actual string value to display. The UI renders it as a single-line field —
+       * multi-line text belongs in the result's `message`.
        */
       value: string
       /**


### PR DESCRIPTION
Closes #3792.

## The report, and what's actually true

[#3792](https://github.com/Start9Labs/start-technologies/issues/3792) says "action result fields do not support newline characters," using Vikunja's `doctor` action as the example. That's half right, and not in the half the title names — there are three fields here and they want different answers.

Vikunja returns the raw report in **both** `message` and `result.single.value`, which is two rendering paths:

| Field | Rendered as | Newlines |
| --- | --- | --- |
| `message` | `<p>{{ data.message }}</p>` | HTML whitespace collapse — `\n` becomes a space |
| `single.value` | `<input tuiInput>` | the input value-sanitization algorithm *strips* CR/LF outright |

The screenshot in the issue has spaces where the line breaks were, so what the reporter is looking at is the collapsed `message`.

## What this changes

**`message` renders as Markdown.** It's prose, the collapse was an HTML default nobody chose, and `ActionResultV1`'s `Display` impl already prints the same payload with the breaks intact — so the UI and `start-cli` disagreed about one response. It now goes through the path service instructions and release notes already use: `| markdown | dompurify` with `safeLinks`, so package-authored HTML is sanitized and external links get `target=_blank rel=noreferrer`.

It renders with **`breaks: true`**, and that part is load-bearing rather than a flourish. CommonMark folds a single newline into a space, so plain Markdown would have left #3792 exactly where it was: the payloads in question separate lines with a single `\n` — Vikunja's report, and garage's `` `${message}\n\nFailed to delete:\n${errors.join('\n')}` ``. A lone `\n` therefore stays a line break and everything else is normal Markdown, which is the convention GitHub renders comments under and matches how packagers write these — a template literal, not a document. It's passed per call rather than made the `MarkdownPipe` default, because `instructions.md` and release notes *are* authored as documents and hard-wrapped source lines there would sprout `<br>`s.

I scanned every `message:` under `startos/**` in `start9-registry`, `community-registry` and `needs-review` for text Markdown would now reinterpret. **One hit, and it argues for the change**: nextcloud's `disableUnstableApps` builds `` `… <ul>${apps.map(a => `<li>${a}</li>`)}</ul>` `` into its message, which today shows the user literal angle brackets. Everything else is plain prose with `${}` interpolation.

**The two dialog paths become one.** A message-only result opened a plain alert; a result-bearing one opened `ActionSuccessPage`. Two renderings of the same field, and only the alert put it through the i18n pipe. `ActionSuccessPage` now takes the whole response and tolerates a null `result`, so `message` is rendered in exactly one place.

**Markdown body styling is one global class.** The HTML the pipe produces is unencapsulated, so each site that styled it reached for `::ng-deep` and carried its own copy of the `pre` and table rules — `instructions.component.ts` had one set, shared `MarkdownComponent` another, and this dialog would have been a third. `.g-markdown` now holds them once in `shared-libs/ts-modules/shared/styles/shared.scss`, beside the other global classes the shared libs depend on and that every host loads, and all three sites use it. Net −61/+39 lines and three `::ng-deep` blocks gone. One behavior change falls out: code blocks in the dialogs `MarkdownComponent` opens (release notes, service About, sideload, marketplace preview) now keep their line structure and scroll instead of wrapping, matching the instructions page, and pick up its padding/radius/background.

**Copy is unified on `CopyService`.** This one is a plain bug independent of the newline question: `ActionSuccessSingleComponent` copies via CDK Clipboard, while `ActionSuccessMemberComponent` selected its `<input>` and called `execCommand` — copying the value *after* the browser stripped its line breaks, and showing no confirmation toast. So the same `copyable: true` produced different clipboard contents depending on whether the value sat at the top level or inside a group. Both now copy the string the action returned, and the DOM juggling (`ViewChild`, the `type` swap around masked fields) goes away with it.

## What this deliberately does not change

**A `single` value stays single-line.** It carries `copyable`, `qr` and `masked` and renders as a labeled textfield: masking a multi-line blob is meaningless, QR-encoding a diagnostic report is absurd, and a `<textarea>` breaks the whole affordance set. `ActionResultV1` exists to be *structured* output — it replaced V0's free-text `message` + `value`. Dumping terminal output into it is misuse.

Both facts are now stated where a packager actually meets them, which is the part that would have prevented this: the `///` doc comments on `ActionResultV1::message` and `ActionResultValue::Single::value`. ts-rs carries those into `ActionResultV1.ts`, `ActionResultValue.ts` and `ActionResultMember.ts`, which ship inside `@start9labs/start-sdk` — so they are the editor hover when someone types `message:`. The regenerated bindings are in this PR (`make start-core-ts-bindings`; the only deltas are those three files). `projects/start-sdk/docs/src/actions.md` § Result Types says the same thing in prose, with an example.

**`start-cli` still prints the raw source.** Markdown source is legible in a terminal and rendering it there would mean choosing an ANSI dialect for tables and headings; the payload is what it is.

**No new result member type.** An earlier draft of this description flagged that action *inputs* have a `textarea` spec (`inputSpecTypes.ts`) with no counterpart on results, and proposed one for "show the user this block of text." Markdown closes that: a fenced code block in `message` is monospace, preformatted and copyable without a new type.

## Verification

`npm run check` (all eight projects), `npm run check:i18n`, and AOT builds of both hosts that render `MarkdownComponent` — `npm run build:ui:dev` and `npm run build:brochure` — all clean; prettier clean. Confirmed `.g-markdown` lands in each app's compiled global stylesheet. Bindings regenerated rather than hand-written, so the `Generated Artifacts` job has nothing to catch. The default mock (`Mock.ActionResMessage`) now carries a heading, a list, emphasis and a bare `\n`, so `npm run start:ui` → any service action shows the behavior.

## Downstream

[Start9-Community/vikunja-startos#6](https://github.com/Start9-Community/vikunja-startos/pull/6) drops the duplication and the false comment; the report can now be a fenced code block in `message`. It should land after this ships in 0.4.0.2 — before then it isn't yet an improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
