### PR TITLE
docs(packaging): a package repo is not a fork of the application

### DIFF
--- a/projects/start-sdk/docs/src/agent-context.md
+++ b/projects/start-sdk/docs/src/agent-context.md
@@ -99,6 +99,7 @@ Understand these before writing any code (full detail on the pages above):
 - **Start from intent, not from API.** Find the recipe before diving into reference pages.
 - **Code lives in reference pages and packages, not recipes.** Recipes describe the pattern; reference pages have the API; real packages have production implementations.
 - **Match existing patterns — but a neighbouring package is not the authority.** Read a package's code before introducing a new pattern. Then check it against the recipe: the fleet is mid-migration, so the package you happened to grep may itself be non-conformant. "It matches the package next door" is not a quality bar. A recipe and its named reference implementation outrank a package you found by searching.
+- **The package repo is not a fork of the application.** Take the application from a published image, a git submodule, or a Start9-built image — never by copying upstream's source in and merging releases into it. Carrying a patch upstream hasn't taken uses the submodule plus `patches/`, not a fork. (`project-structure.md`)
 
 ## Working discipline (every change)
 

--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -52,6 +52,29 @@ my-service-startos/
 └── upstream-project/       # Git submodule (optional)
 ```
 
+## The Package Repo Is Not a Fork of the Application
+
+A package repo holds **packaging** — `startos/`, the manifest, the docs, the CI. The
+application itself comes from one of three sources, and `UPDATING.md` records which one:
+
+- **A published upstream image**, pinned at `images.<id>.source.dockerTag`. The default, and
+  what most packages use — see [Package a Prebuilt Docker Image](recipe-prebuilt-image.md).
+- **A git submodule** at `upstream-project/`, built by the package's own `Dockerfile`, when
+  upstream publishes no image, or none for an architecture StartOS needs.
+- **A Start9-built image**, when the software needs a build only we produce.
+
+**Copying the application's source into the package repo and merging upstream releases into it
+is not a fourth option.** A fork turns every upstream release into a hand-merge, moves the
+application's tests, lockfiles, CI and dependency churn into a repo whose reviewers are
+packagers, and leaves the packaged version defined by a merge result instead of a pinned ref.
+It also breaks the property the layout exists for: every package reads the same way, so a
+reviewer or a tool that knows one knows all of them.
+
+Carrying a fix upstream has not taken does not require a fork. Use the submodule with a
+`patches/` directory, each patch stating the condition under which it retires —
+[`electrs-startos`](https://github.com/Start9-Community/electrs-startos) is the reference
+implementation.
+
 ## Core Files
 
 ### Boilerplate Files


### PR DESCRIPTION
States a rule the standard layout has only ever implied.

A package repo holds **packaging**. The application comes from one of three sources — a published upstream image, a git submodule at `upstream-project/`, or a Start9-built image — and `UPDATING.md` records which. Copying the application's source into the package repo and merging upstream releases into it is **not** a fourth option.

Why it earns a stated rule rather than a review comment each time: a fork makes every upstream release a hand-merge, moves the application's tests, lockfiles, CI and dependency churn into a repo whose reviewers are packagers, and leaves the packaged version defined by a merge result instead of a pinned ref. It costs the property the standard layout exists to provide — every package reads the same way, so a reviewer or a tool that knows one knows all of them.

The submodule escape hatch is stated explicitly, and `electrs-startos` named as the reference, so this does not read as a ban on carrying a patch upstream has not taken. Submodules are used cleanly by a number of packages today and stay supported.

Targets `live-docs`: it is true of the shipped SDK and packaging process now, not text accompanying unreleased code.

Adds a section to `project-structure.md` (whose layout block already lists `upstream-project/` as the sanctioned way to have upstream source) and a one-line golden rule to `agent-context.md`, the always-on context every packager and agent loads.