### PR TITLE
fix(core): refuse an impossible migration before the service is stopped

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -49,6 +49,10 @@ file tracks notable changes since the move to the monorepo.
 
 ### Fixed
 
+- **A downgrade to a version that cannot take over the service's data is refused
+  before anything is downloaded or stopped**, with an explanation of what to do
+  instead.
+
 - **A service that fails to install, update, restore or uninstall says so right
   away.** The notification naming what went wrong was held back until StartOS had
   finished cleaning up after the attempt, which can take several minutes. It now

--- a/projects/start-os/docs/src/installing.md
+++ b/projects/start-os/docs/src/installing.md
@@ -18,6 +18,8 @@ When newer versions of installed services are available, you can update them fro
 
 If a service listing shows an older version than what you have installed, the Marketplace will display a **Downgrade** button instead of Install or Update.
 
+Not every service can go back — the older version has to be able to take over the data the service has now, and StartOS refuses the downgrade when it cannot, leaving the running service untouched. To go back anyway, uninstall the service — which deletes its data — and [restore a backup](backup-restore.md) made while it was running that version.
+
 ## Switching Flavors
 
 If multiple [flavors](flavors.md) of a service exist, the Marketplace will display a **Switch** button when viewing a different flavor than the one currently installed.

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -52,6 +52,10 @@
 
 ### Fixed
 
+- **`VersionGraph` reports a missing migration path in terms a service owner can
+  act on**, rather than as an assertion about the version range the host handed
+  it
+
 - `i18n()` no longer throws when a number or a `Date` is interpolated: a service
   container's `LANG=C.UTF-8` reduces to a locale `Intl` rejects
 

--- a/projects/start-sdk/docs/src/versions.md
+++ b/projects/start-sdk/docs/src/versions.md
@@ -256,6 +256,8 @@ Use `IMPOSSIBLE` for the `down` migration when:
 - It is the initial version (nothing to roll back to)
 - The migration involves breaking changes that cannot be reversed
 
+`IMPOSSIBLE` keeps the version out of `canMigrateTo`, and StartOS refuses a downgrade it cannot reach — telling the user to uninstall and restore a backup instead.
+
 ```typescript
 migrations: {
   up: async ({ effects }) => {

--- a/projects/start-sdk/lib/version/VersionGraph.ts
+++ b/projects/start-sdk/lib/version/VersionGraph.ts
@@ -261,7 +261,7 @@ export class VersionGraph<CurrentVersion extends string>
       }
     }
     throw new Error(
-      `cannot migrate from ${from.toString()} to ${to.toString()}`,
+      `this service has no migration path from ${from.toString()} to ${to.toString()}, so its data cannot be carried over`,
     )
   }
   /**
@@ -346,7 +346,7 @@ export class VersionGraph<CurrentVersion extends string>
     if (target) {
       if (isRange(target) && !target.satisfiable()) {
         throw new Error(
-          `uninit target range \`${target.toString()}\` is unsatisfiable — no version can satisfy it (host contract violation)`,
+          `this service has no migration path to the version being installed, so its data cannot be carried over`,
         )
       }
       const from = await getDataVersion(effects)

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -2526,6 +2526,20 @@ service.service-map.installing-failed:
   fr_FR: "Échec de l'installation"
   pl_PL: "Instalacja nie powiodła się"
 
+service.service-map.no-downgrade-path:
+  en_US: "This service cannot be downgraded from %{from} to %{to}: it provides no migration path back to %{to}, so the data it has now cannot be carried over. To return to %{to}, uninstall the service — which deletes its data — and restore a backup made while it was running %{to}."
+  de_DE: "Dieser Dienst kann nicht von %{from} auf %{to} herabgestuft werden: Es gibt keinen Migrationspfad zurück zu %{to}, sodass die vorhandenen Daten nicht übernommen werden können. Um zu %{to} zurückzukehren, deinstallieren Sie den Dienst — dabei werden seine Daten gelöscht — und stellen Sie eine Sicherung wieder her, die unter %{to} erstellt wurde."
+  es_ES: "Este servicio no puede volver de %{from} a %{to}: no ofrece una ruta de migración de regreso a %{to}, por lo que los datos actuales no se pueden conservar. Para volver a %{to}, desinstale el servicio — lo que borra sus datos — y restaure un respaldo hecho mientras ejecutaba %{to}."
+  fr_FR: "Ce service ne peut pas être rétrogradé de %{from} vers %{to} : il ne fournit aucun chemin de migration de retour vers %{to}, donc ses données actuelles ne peuvent pas être reprises. Pour revenir à %{to}, désinstallez le service — ce qui supprime ses données — puis restaurez une sauvegarde effectuée sous %{to}."
+  pl_PL: "Tej usługi nie można cofnąć z %{from} do %{to}: nie udostępnia ścieżki migracji z powrotem do %{to}, więc obecnych danych nie da się przenieść. Aby wrócić do %{to}, odinstaluj usługę — co usunie jej dane — i przywróć kopię zapasową wykonaną na wersji %{to}."
+
+service.service-map.no-migration-path:
+  en_US: "This service cannot go from %{from} to %{to}: it provides no migration path between those versions, so the data it has now cannot be carried over. Try a version in between, or uninstall the service — which deletes its data — and restore a backup made while it was running %{to}."
+  de_DE: "Dieser Dienst kann nicht von %{from} zu %{to} wechseln: Zwischen diesen Versionen gibt es keinen Migrationspfad, sodass die vorhandenen Daten nicht übernommen werden können. Versuchen Sie eine Version dazwischen oder deinstallieren Sie den Dienst — dabei werden seine Daten gelöscht — und stellen Sie eine Sicherung wieder her, die unter %{to} erstellt wurde."
+  es_ES: "Este servicio no puede pasar de %{from} a %{to}: no ofrece una ruta de migración entre esas versiones, por lo que los datos actuales no se pueden conservar. Pruebe una versión intermedia, o desinstale el servicio — lo que borra sus datos — y restaure un respaldo hecho mientras ejecutaba %{to}."
+  fr_FR: "Ce service ne peut pas passer de %{from} à %{to} : aucun chemin de migration n'existe entre ces versions, donc ses données actuelles ne peuvent pas être reprises. Essayez une version intermédiaire, ou désinstallez le service — ce qui supprime ses données — puis restaurez une sauvegarde effectuée sous %{to}."
+  pl_PL: "Ta usługa nie może przejść z %{from} do %{to}: nie udostępnia ścieżki migracji między tymi wersjami, więc obecnych danych nie da się przenieść. Spróbuj wersji pośredniej albo odinstaluj usługę — co usunie jej dane — i przywróć kopię zapasową wykonaną na wersji %{to}."
+
 service.service-map.operation-failed:
   en_US: "%{operation} Failed"
   de_DE: "%{operation} fehlgeschlagen"

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -25,7 +25,7 @@ use crate::notifications::{NotificationLevel, notify};
 use crate::prelude::*;
 use crate::progress::{FullProgressTracker, PhaseProgressTrackerHandle, ProgressTrackerWriter};
 use crate::s9pk::S9pk;
-use crate::s9pk::manifest::PackageId;
+use crate::s9pk::manifest::{Manifest, PackageId};
 use crate::s9pk::merkle_archive::source::FileSource;
 use crate::service::rpc::{ExitParams, InitKind};
 use crate::service::{LoadDisposition, Service, ServiceRef, get_data_version};
@@ -59,6 +59,47 @@ fn s9pk_installed_path(commitment: &MerkleArchiveCommitment) -> PathBuf {
         .join("installed")
         .join(Base32(commitment.root_sighash.0).to_lower_string())
         .with_extension("s9pk")
+}
+
+fn uninit_target(data_ver: &str, prev: &Manifest, next: &Manifest) -> Result<ExitParams, Error> {
+    let next_accepts_data_ver = if let Ok(data_ver_ev) = data_ver.parse::<exver::ExtendedVersion>()
+    {
+        data_ver_ev.satisfies(&next.can_migrate_from)
+    } else if let Ok(data_ver_range) = data_ver.parse::<VersionRange>() {
+        data_ver_range.intersects(&next.can_migrate_from)
+    } else {
+        false
+    };
+    if next_accepts_data_ver {
+        Ok(ExitParams::target_str(data_ver))
+    } else if next.version.satisfies(&prev.can_migrate_to) {
+        Ok(ExitParams::target_version(&next.version))
+    } else if prev.can_migrate_to.intersects(&next.can_migrate_from) {
+        Ok(ExitParams::target_range(&VersionRange::and(
+            prev.can_migrate_to.clone(),
+            next.can_migrate_from.clone(),
+        )))
+    } else {
+        Err(Error::new(
+            eyre!(
+                "{}",
+                if next.version < prev.version {
+                    t!(
+                        "service.service-map.no-downgrade-path",
+                        from = prev.version.as_str(),
+                        to = next.version.as_str()
+                    )
+                } else {
+                    t!(
+                        "service.service-map.no-migration-path",
+                        from = prev.version.as_str(),
+                        to = next.version.as_str()
+                    )
+                }
+            ),
+            ErrorKind::VersionIncompatible,
+        ))
+    }
 }
 
 /// This is the structure to contain all the services
@@ -189,6 +230,18 @@ impl ServiceMap {
         let icon = s9pk.icon_data_url().await?;
         let developer_key = s9pk.as_archive().signer();
         let mut service = self.get_mut(&id).await;
+        // Fail before the download and before the service is quiesced.
+        if recovery_source.is_none() {
+            if let Some(prev) = &*service {
+                if let Some(data_ver) = get_data_version(&id).await? {
+                    uninit_target(
+                        &data_ver,
+                        prev.seed.persistent_container.s9pk.as_manifest(),
+                        &manifest,
+                    )?;
+                }
+            }
+        }
         let size = s9pk.size();
         let op_name = if recovery_source.is_none() {
             if service.is_none() {
@@ -345,33 +398,11 @@ impl ServiceMap {
                         // A `.const()` re-run can move the data version while the container comes down.
                         data_version = get_data_version(&id).await?;
                         let uninit = if let Some(ref data_ver) = data_version {
-                            let prev_can_migrate_to = &service
-                                .seed
-                                .persistent_container
-                                .s9pk
-                                .as_manifest()
-                                .can_migrate_to;
-                            let next_version = &s9pk.as_manifest().version;
-                            let next_can_migrate_from = &s9pk.as_manifest().can_migrate_from;
-                            let next_accepts_data_ver = if let Ok(data_ver_ev) =
-                                data_ver.parse::<exver::ExtendedVersion>()
-                            {
-                                data_ver_ev.satisfies(next_can_migrate_from)
-                            } else if let Ok(data_ver_range) = data_ver.parse::<VersionRange>() {
-                                data_ver_range.intersects(next_can_migrate_from)
-                            } else {
-                                false
-                            };
-                            if next_accepts_data_ver {
-                                ExitParams::target_str(data_ver)
-                            } else if next_version.satisfies(prev_can_migrate_to) {
-                                ExitParams::target_version(&s9pk.as_manifest().version)
-                            } else {
-                                ExitParams::target_range(&VersionRange::and(
-                                    prev_can_migrate_to.clone(),
-                                    next_can_migrate_from.clone(),
-                                ))
-                            }
+                            uninit_target(
+                                data_ver,
+                                service.seed.persistent_container.s9pk.as_manifest(),
+                                s9pk.as_manifest(),
+                            )?
                         } else {
                             ExitParams::target_version(
                                 &*service.seed.persistent_container.s9pk.as_manifest().version,


### PR DESCRIPTION
A user downgrading Nextcloud 33.0.8:3 → 33.0.7:0 on 0.4.0.1 got:

> **Updating Failed — Nextcloud**
> Unknown Error: Error: uninit target range `!` is unsatisfiable — no version can satisfy it (host contract violation)

…after the package had downloaded and the running service had already been quiesced and snapshotted.

## Root cause

33.0.8:3 declares `down: IMPOSSIBLE`, so its manifest ships `canMigrateTo = "=33.0.8:3"`. 33.0.7:0 ships `canMigrateFrom = ">=32.0.11:0 && <=33.0.7:0"`. (Both verified by running the real graphs through the built SDK.)

`ServiceMap::install` picks the outgoing container's uninit target through three branches, and the third had no guard:

1. does the data version `33.0.8:3` satisfy the incoming package's `canMigrateFrom`? No.
2. does the incoming version `33.0.7:0` satisfy the outgoing package's `canMigrateTo`? No.
3. fall through → hand the container `and(=33.0.8:3, >=32.0.11:0 && <=33.0.7:0)` — an **empty** range.

`RpcListener.ts` calls `.normalize()` on the incoming target, which collapses that to `!`, and `VersionGraph.uninit`'s internal assertion fired.

## Change

`uninit_target(data_ver, prev, next)` holds the three branches plus the missing fourth case: when `canMigrateTo` and `canMigrateFrom` don't intersect there is no data version the outgoing package can produce and the incoming one can consume, so the transition is impossible rather than merely unrouted. It returns `ErrorKind::VersionIncompatible` (was `Unknown`) with a message worded for whoever pressed Downgrade:

> **Version Incompatible:** This service cannot be downgraded from 33.0.8:3 to 33.0.7:0: it provides no migration path back to 33.0.7:0, so the data it has now cannot be carried over. To return to 33.0.7:0, uninstall the service — which deletes its data — and restore a backup made while it was running 33.0.7:0.

A separate `no-migration-path` string covers the non-downgrade direction. Both are in all five locales.

`install()` calls it **up front** — before the download and before the service is touched — so a doomed transition fails with the service still running, and again at the original site, where the data version is re-read after the container comes down. Restores are exempt (`recovery_source.is_some()`), and `restore_packages` installs the s9pk from the backup itself, so the advice in the message is reachable.

The SDK's two messages now say what happened rather than name the range algebra; the `uninit` guard stays as a backstop for an older host.

## Behavior narrowing worth a look

A package pair whose declared ranges don't intersect but that ships a hand-written `uninit` ignoring the target used to get further before failing (at the incoming package's `init`, or not at all if that were hand-written too). Since `setupManifest` derives both ranges from the `VersionGraph`, an empty intersection is the packager's own declaration that no path exists — but it is a real narrowing.

## Not in this PR

The version picker still offers 33.0.7:0. `updates-refinement.service.ts` already hides unreachable *upgrades* via `sourceVersion`; the downgrade selector has no equivalent filter. That's the fix that stops a user reaching this error at all.
