### PR TITLE
fix(core): gate h2 extended CONNECT on backend support and send GOAWAY on upstream failure

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -117,6 +117,15 @@ file tracks notable changes since the move to the monorepo.
   reply. The proxy now closes the client's half as soon as the service closes
   its own, which is the signal the client is waiting for.
 
+- **Connections between your browser and a service that speak HTTP/2 behave
+  correctly when the service restarts.** StartOS's reverse proxy used to tell
+  the browser that WebSocket-over-HTTP/2 was available even when the service
+  would reject it, leaving WebSockets broken against such services — the fix
+  offers it only when the service supports it, so the browser falls back to
+  its ordinary HTTP/1.1 route. And when a service's HTTP/2 connection ended
+  unexpectedly, responses already on their way to the browser were cut off;
+  they now finish instead.
+
 - Trim whitespace on form inputs.
 
 - **Marketplace search matches anywhere in a package's name, ID or

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -117,17 +117,6 @@ file tracks notable changes since the move to the monorepo.
   reply. The proxy now closes the client's half as soon as the service closes
   its own, which is the signal the client is waiting for.
 
-- **WebSocket-over-HTTP/2 is offered only when a service actually supports
-  it.** StartOS's reverse proxy used to tell the browser it was available even
-  when the service would reject it, leaving WebSockets broken against such
-  services. The proxy now mirrors what the service itself advertises, so the
-  browser falls back to its ordinary HTTP/1.1 route where needed.
-
-- **Responses in flight survive a service's HTTP/2 connection dying.** When a
-  service's HTTP/2 connection ended unexpectedly — its container restarting,
-  say — responses already on their way to the browser were cut off mid-flight;
-  they now finish instead.
-
 - Trim whitespace on form inputs.
 
 - **Marketplace search matches anywhere in a package's name, ID or
@@ -358,9 +347,9 @@ file tracks notable changes since the move to the monorepo.
   settled on HTTP/1.1, so StartOS wrote HTTP/1 requests onto a connection the
   service was reading as HTTP/2. StartOS now offers the client exactly the
   protocol the service chose, so both halves of the connection carry the same
-  one. A service whose HTTP/2 listener does not answer extended CONNECT
-  (RFC 8441) should advertise only `http/1.1`, which keeps WebSocket clients on
-  HTTP/1.1 where a WebSocket is an ordinary upgrade.
+  one. For HTTP/2, StartOS advertises WebSocket extended CONNECT when the
+  service includes support in its opening settings. If the service connection
+  ends, StartOS sends GOAWAY so the browser follows HTTP/2's orderly shutdown.
 
 ### Security
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -117,13 +117,15 @@ file tracks notable changes since the move to the monorepo.
   reply. The proxy now closes the client's half as soon as the service closes
   its own, which is the signal the client is waiting for.
 
-- **Connections between your browser and a service that speak HTTP/2 behave
-  correctly when the service restarts.** StartOS's reverse proxy used to tell
-  the browser that WebSocket-over-HTTP/2 was available even when the service
-  would reject it, leaving WebSockets broken against such services — the fix
-  offers it only when the service supports it, so the browser falls back to
-  its ordinary HTTP/1.1 route. And when a service's HTTP/2 connection ended
-  unexpectedly, responses already on their way to the browser were cut off;
+- **WebSocket-over-HTTP/2 is offered only when a service actually supports
+  it.** StartOS's reverse proxy used to tell the browser it was available even
+  when the service would reject it, leaving WebSockets broken against such
+  services. The proxy now mirrors what the service itself advertises, so the
+  browser falls back to its ordinary HTTP/1.1 route where needed.
+
+- **Responses in flight survive a service's HTTP/2 connection dying.** When a
+  service's HTTP/2 connection ended unexpectedly — its container restarting,
+  say — responses already on their way to the browser were cut off mid-flight;
   they now finish instead.
 
 - Trim whitespace on form inputs.

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -295,20 +295,8 @@ const H2_SETTINGS_FRAME: u8 = 0x4;
 /// `SETTINGS_ENABLE_CONNECT_PROTOCOL`, the RFC 8441 WebSocket setting.
 const ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 
-async fn take_initial_settings<S: AsyncRead + Unpin>(
-    io: &mut S,
-) -> std::io::Result<(Vec<(u16, u32)>, Vec<u8>)> {
-    let mut head = [0u8; 9];
-    io.read_exact(&mut head).await?;
-    let len = ((head[0] as usize) << 16) | ((head[1] as usize) << 8) | head[2] as usize;
-    if head[3] != H2_SETTINGS_FRAME || len > 4096 {
-        return Ok((Vec::new(), head.to_vec()));
-    }
-    let mut payload = vec![0u8; len];
-    io.read_exact(&mut payload).await?;
-    let mut raw = head.to_vec();
-    raw.extend_from_slice(&payload);
-    let entries = payload
+fn parse_settings_entries(payload: &[u8]) -> Vec<(u16, u32)> {
+    payload
         .chunks_exact(6)
         .map(|c| {
             (
@@ -316,7 +304,22 @@ async fn take_initial_settings<S: AsyncRead + Unpin>(
                 u32::from_be_bytes([c[2], c[3], c[4], c[5]]),
             )
         })
-        .collect();
+        .collect()
+}
+
+async fn take_initial_settings<S: AsyncRead + Unpin>(
+    io: &mut S,
+) -> std::io::Result<(Vec<(u16, u32)>, Vec<u8>)> {
+    let mut raw = vec![0u8; 9];
+    io.read_exact(&mut raw).await?;
+    let len = ((raw[0] as usize) << 16) | ((raw[1] as usize) << 8) | raw[2] as usize;
+    if raw[3] != H2_SETTINGS_FRAME || len > 4096 {
+        // The unread payload stays in the stream and flows through on its own.
+        return Ok((Vec::new(), raw));
+    }
+    raw.resize(9 + len, 0);
+    io.read_exact(&mut raw[9..]).await?;
+    let entries = parse_settings_entries(&raw[9..]);
     Ok((entries, raw))
 }
 
@@ -335,7 +338,7 @@ impl<S: AsyncRead + Unpin> AsyncRead for Replay<S> {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         let this = &mut *self;
-        if this.taken < this.bytes.len() {
+        if this.taken < this.bytes.len() && buf.remaining() > 0 {
             let n = (this.bytes.len() - this.taken).min(buf.remaining());
             buf.put_slice(&this.bytes[this.taken..this.taken + n]);
             this.taken += n;
@@ -371,7 +374,12 @@ async fn goaway_only<F: ReadWriter + Unpin + Send + 'static>(from: F) -> Result<
     let mut conn = Box::pin(server.serve_connection(
         TokioIo::new(from),
         service_fn(|_| async {
-            Ok::<Response<ProxyBody>, hyper::Error>(Response::new(box_full(Bytes::new())))
+            Ok::<Response<ProxyBody>, hyper::Error>(
+                Response::builder()
+                    .status(http::StatusCode::BAD_GATEWAY)
+                    .body(box_full(Bytes::from_static(b"502 Bad Gateway")))
+                    .expect("static 502 response is well-formed"),
+            )
         }),
     ));
     conn.as_mut().graceful_shutdown();
@@ -396,7 +404,17 @@ where
     let sniff = tokio::time::timeout(Duration::from_secs(5), take_initial_settings(&mut to)).await;
     let (entries, replay) = match sniff {
         Ok(Ok(res)) => res,
-        _ => (Vec::new(), Vec::new()),
+        // A backend that cannot even deliver its opening frame is no good,
+        // and bytes already consumed must not reach the handshake.
+        Ok(Err(e)) => {
+            tracing::warn!("Backend http2 connection died before its opening SETTINGS: {e}");
+            tracing::debug!("{e:?}");
+            return goaway_only(from).await;
+        }
+        Err(_) => {
+            tracing::warn!("Backend http2 connection never sent its opening SETTINGS within 5s");
+            return goaway_only(from).await;
+        }
     };
     let extended_connect = entries
         .iter()
@@ -875,10 +893,11 @@ mod tests {
 
     // Minimal h2 frame plumbing for exercising run_http2_proxy without a
     // real backend.
+    use super::{
+        ENABLE_CONNECT_PROTOCOL, H2_SETTINGS_FRAME as SETTINGS_FRAME, parse_settings_entries,
+    };
     const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
-    const SETTINGS_FRAME: u8 = 0x4;
     const GOAWAY_FRAME: u8 = 0x7;
-    const ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
 
     async fn write_frame(s: &mut DuplexStream, kind: u8, payload: &[u8]) {
         let len = payload.len() as u32;
@@ -914,18 +933,6 @@ mod tests {
         let mut payload = vec![0u8; len];
         s.read_exact(&mut payload).await?;
         Ok((head[3], payload))
-    }
-
-    fn settings_entries(payload: &[u8]) -> Vec<(u16, u32)> {
-        payload
-            .chunks_exact(6)
-            .map(|c| {
-                (
-                    u16::from_be_bytes([c[0], c[1]]),
-                    u32::from_be_bytes([c[2], c[3], c[4], c[5]]),
-                )
-            })
-            .collect()
     }
 
     /// RFC 8441 extended CONNECT is only advertised to the client once the
@@ -970,7 +977,7 @@ mod tests {
             .await
             .expect("the proxy never sent its client-facing SETTINGS");
             assert_eq!(
-                settings_entries(&frame)
+                parse_settings_entries(&frame)
                     .iter()
                     .any(|&(id, _)| id == ENABLE_CONNECT_PROTOCOL),
                 advertised,

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -1,10 +1,8 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -17,8 +15,8 @@ use hyper::body::{Body as HyperBody, Incoming};
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
-use tokio::sync::{Mutex, Notify};
+use tokio::sync::{Mutex, Notify, oneshot};
+use tokio_util::io::InspectReader;
 
 use crate::net::host::binding::ProxyAuth;
 use crate::prelude::*;
@@ -290,105 +288,122 @@ where
     }
 }
 
-/// SETTINGS frame type.
 const H2_SETTINGS_FRAME: u8 = 0x4;
-/// `SETTINGS_ENABLE_CONNECT_PROTOCOL`, the RFC 8441 WebSocket setting.
 const ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
+const MAX_SETTINGS_PAYLOAD: usize = 16_384;
 
-fn parse_settings_entries(payload: &[u8]) -> Vec<(u16, u32)> {
-    payload
-        .chunks_exact(6)
-        .map(|c| {
-            (
-                u16::from_be_bytes([c[0], c[1]]),
-                u32::from_be_bytes([c[2], c[3], c[4], c[5]]),
-            )
-        })
-        .collect()
+type OpeningSettingsResult = Result<bool, &'static str>;
+
+struct OpeningSettingsObserver {
+    result: Option<oneshot::Sender<OpeningSettingsResult>>,
+    header: [u8; 9],
+    header_len: usize,
+    payload_remaining: usize,
+    entry: [u8; 6],
+    entry_len: usize,
+    extended_connect: bool,
 }
 
-async fn take_initial_settings<S: AsyncRead + Unpin>(
-    io: &mut S,
-) -> std::io::Result<(Vec<(u16, u32)>, Vec<u8>)> {
-    let mut raw = vec![0u8; 9];
-    io.read_exact(&mut raw).await?;
-    let len = ((raw[0] as usize) << 16) | ((raw[1] as usize) << 8) | raw[2] as usize;
-    if raw[3] != H2_SETTINGS_FRAME || len > 4096 {
-        // The unread payload stays in the stream and flows through on its own.
-        return Ok((Vec::new(), raw));
-    }
-    raw.resize(9 + len, 0);
-    io.read_exact(&mut raw[9..]).await?;
-    let entries = parse_settings_entries(&raw[9..]);
-    Ok((entries, raw))
-}
-
-/// Replays sniffed bytes to the reader before handing over to the inner
-/// stream.
-struct Replay<S> {
-    bytes: Vec<u8>,
-    taken: usize,
-    inner: S,
-}
-
-impl<S: AsyncRead + Unpin> AsyncRead for Replay<S> {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf<'_>,
-    ) -> Poll<std::io::Result<()>> {
-        let this = &mut *self;
-        if this.taken < this.bytes.len() && buf.remaining() > 0 {
-            let n = (this.bytes.len() - this.taken).min(buf.remaining());
-            buf.put_slice(&this.bytes[this.taken..this.taken + n]);
-            this.taken += n;
-            return Poll::Ready(Ok(()));
+impl OpeningSettingsObserver {
+    fn new(result: oneshot::Sender<OpeningSettingsResult>) -> Self {
+        Self {
+            result: Some(result),
+            header: [0; 9],
+            header_len: 0,
+            payload_remaining: 0,
+            entry: [0; 6],
+            entry_len: 0,
+            extended_connect: false,
         }
-        Pin::new(&mut this.inner).poll_read(cx, buf)
-    }
-}
-
-impl<S: AsyncWrite + Unpin> AsyncWrite for Replay<S> {
-    fn poll_write(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &[u8],
-    ) -> Poll<std::io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_write(cx, buf)
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_flush(cx)
+    fn inspect(&mut self, mut bytes: &[u8]) {
+        if self.result.is_none() {
+            return;
+        }
+
+        if self.header_len < self.header.len() {
+            let len = bytes.len().min(self.header.len() - self.header_len);
+            self.header[self.header_len..self.header_len + len].copy_from_slice(&bytes[..len]);
+            self.header_len += len;
+            bytes = &bytes[len..];
+            if self.header_len < self.header.len() {
+                return;
+            }
+            self.payload_remaining = ((self.header[0] as usize) << 16)
+                | ((self.header[1] as usize) << 8)
+                | self.header[2] as usize;
+            if self.header[3] != H2_SETTINGS_FRAME {
+                return self.finish(Err("backend did not open with SETTINGS"));
+            }
+            if self.header[4] & 0x1 != 0 {
+                return self.finish(Err("backend opening SETTINGS was an acknowledgement"));
+            }
+            let stream_id = u32::from_be_bytes([
+                self.header[5],
+                self.header[6],
+                self.header[7],
+                self.header[8],
+            ]) & 0x7fff_ffff;
+            if stream_id != 0 {
+                return self.finish(Err("backend opening SETTINGS used a nonzero stream"));
+            }
+            if self.payload_remaining > MAX_SETTINGS_PAYLOAD {
+                return self.finish(Err("backend opening SETTINGS exceeded the maximum payload"));
+            }
+            if self.payload_remaining % self.entry.len() != 0 {
+                return self.finish(Err("backend opening SETTINGS had a partial entry"));
+            }
+            if self.payload_remaining == 0 {
+                return self.finish(Ok(false));
+            }
+        }
+
+        while !bytes.is_empty() && self.result.is_some() {
+            let len = bytes.len().min(self.entry.len() - self.entry_len);
+            self.entry[self.entry_len..self.entry_len + len].copy_from_slice(&bytes[..len]);
+            self.entry_len += len;
+            self.payload_remaining -= len;
+            bytes = &bytes[len..];
+
+            if self.entry_len == self.entry.len() {
+                let id = u16::from_be_bytes([self.entry[0], self.entry[1]]);
+                let value = u32::from_be_bytes([
+                    self.entry[2],
+                    self.entry[3],
+                    self.entry[4],
+                    self.entry[5],
+                ]);
+                if id == ENABLE_CONNECT_PROTOCOL {
+                    match value {
+                        0 => self.extended_connect = false,
+                        1 => self.extended_connect = true,
+                        _ => {
+                            return self.finish(Err(
+                                "backend opening SETTINGS had an invalid ENABLE_CONNECT_PROTOCOL",
+                            ));
+                        }
+                    }
+                }
+                self.entry_len = 0;
+            }
+
+            if self.payload_remaining == 0 {
+                self.finish(Ok(self.extended_connect));
+            }
+        }
     }
 
-    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
-        Pin::new(&mut self.inner).poll_shutdown(cx)
+    fn finish(&mut self, result: OpeningSettingsResult) {
+        if let Some(sender) = self.result.take() {
+            let _ = sender.send(result);
+        }
     }
-}
-
-/// Serves the client leg only long enough to deliver GOAWAY, for when the
-/// backend died before the proxy could relay anything.
-async fn goaway_only<F: ReadWriter + Unpin + Send + 'static>(from: F) -> Result<(), Error> {
-    let mut server = hyper::server::conn::http2::Builder::new(TokioExecutor::new());
-    server.timer(TokioTimer::new()).adaptive_window(true);
-    let mut conn = Box::pin(server.serve_connection(
-        TokioIo::new(from),
-        service_fn(|_| async {
-            Ok::<Response<ProxyBody>, hyper::Error>(
-                Response::builder()
-                    .status(http::StatusCode::BAD_GATEWAY)
-                    .body(box_full(Bytes::from_static(b"502 Bad Gateway")))
-                    .expect("static 502 response is well-formed"),
-            )
-        }),
-    ));
-    conn.as_mut().graceful_shutdown();
-    conn.await.map_err(|e| Error::new(e, ErrorKind::Network))
 }
 
 pub async fn run_http2_proxy<F, T>(
     from: F,
-    mut to: T,
+    to: T,
     src_ip: Option<IpAddr>,
     add_forwarded: bool,
     gate: Option<AuthGate>,
@@ -397,50 +412,35 @@ where
     F: ReadWriter + Unpin + Send + 'static,
     T: ReadWriter + Unpin + Send + 'static,
 {
-    // An extended CONNECT is forwarded verbatim, including its `:protocol`, so
-    // advertise RFC 8441 only once the backend's opening SETTINGS shows it
-    // will not reset such streams; otherwise the browser falls back to
-    // HTTP/1.1 for its WebSockets.
-    let sniff = tokio::time::timeout(Duration::from_secs(5), take_initial_settings(&mut to)).await;
-    let (entries, replay) = match sniff {
-        Ok(Ok(res)) => res,
-        // A backend that cannot even deliver its opening frame is no good,
-        // and bytes already consumed must not reach the handshake.
-        Ok(Err(e)) => {
-            tracing::warn!("Backend http2 connection died before its opening SETTINGS: {e}");
-            tracing::debug!("{e:?}");
-            return goaway_only(from).await;
-        }
-        Err(_) => {
-            tracing::warn!("Backend http2 connection never sent its opening SETTINGS within 5s");
-            return goaway_only(from).await;
-        }
-    };
-    let extended_connect = entries
-        .iter()
-        .any(|&(id, value)| id == ENABLE_CONNECT_PROTOCOL && value == 1);
-    let to = Replay {
-        bytes: replay,
-        taken: 0,
-        inner: to,
-    };
-    let (client, to) = match hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+    // Hyper fixes ENABLE_CONNECT_PROTOCOL when it creates the frontend connection.
+    let (settings_sender, mut settings_receiver) = oneshot::channel();
+    let mut settings_observer = OpeningSettingsObserver::new(settings_sender);
+    let to = InspectReader::new(to, move |bytes| settings_observer.inspect(bytes));
+    let (client, to) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
         .timer(TokioTimer::new())
         .adaptive_window(true)
         .keep_alive_interval(Duration::from_secs(25))
         .keep_alive_timeout(Duration::from_secs(300))
         .handshake(TokioIo::new(to))
-        .await
-    {
-        Ok(pair) => pair,
-        // Nothing was ever relayed, but the client still deserves GOAWAY
-        // rather than a bare abort.
-        Err(e) => {
-            tracing::warn!("Backend http2 connection failed during handshake: {e}");
-            tracing::debug!("{e:?}");
-            return goaway_only(from).await;
+        .await?;
+    let mut to = Box::pin(to.fuse());
+    let settings = tokio::select! {
+        settings = &mut settings_receiver => {
+            settings.map_err(|e| Error::new(e, ErrorKind::Network))?
+        }
+        res = to.as_mut() => match settings_receiver.try_recv() {
+            Ok(settings) => settings,
+            Err(_) => {
+                res?;
+                return Err(Error::new(
+                    eyre!("backend http2 connection ended before opening SETTINGS"),
+                    ErrorKind::Network,
+                ));
+            }
         }
     };
+    let extended_connect =
+        settings.map_err(|message| Error::new(eyre!(message), ErrorKind::Network))?;
     let from = {
         let mut server = hyper::server::conn::http2::Builder::new(TokioExecutor::new());
         server
@@ -497,14 +497,10 @@ where
         )
     };
     let mut from = Box::pin(from);
-    let mut to = Box::pin(to.fuse());
     loop {
         tokio::select! {
             res = from.as_mut() => return Ok(res?),
             res = to.as_mut() => {
-                // The upstream is gone whether it ended cleanly or errored;
-                // either way the client gets GOAWAY plus drain, so in-flight
-                // streams still finish instead of being aborted.
                 if let Err(e) = res {
                     tracing::warn!("Error proxying http2 connection to backend: {e}");
                     tracing::debug!("{e:?}");
@@ -891,11 +887,7 @@ mod tests {
         assert_eq!(&echoed, b"ping");
     }
 
-    // Minimal h2 frame plumbing for exercising run_http2_proxy without a
-    // real backend.
-    use super::{
-        ENABLE_CONNECT_PROTOCOL, H2_SETTINGS_FRAME as SETTINGS_FRAME, parse_settings_entries,
-    };
+    use super::{ENABLE_CONNECT_PROTOCOL, H2_SETTINGS_FRAME as SETTINGS_FRAME};
     const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
     const GOAWAY_FRAME: u8 = 0x7;
 
@@ -935,82 +927,153 @@ mod tests {
         Ok((head[3], payload))
     }
 
-    /// RFC 8441 extended CONNECT is only advertised to the client once the
-    /// backend advertises it too; against a backend that will reset such
-    /// streams, the client falls back to HTTP/1.1 for its WebSockets.
+    async fn read_client_opening(s: &mut DuplexStream) {
+        let mut preface = [0; H2_PREFACE.len()];
+        s.read_exact(&mut preface).await.unwrap();
+        assert_eq!(&preface, H2_PREFACE);
+
+        let mut header = [0; 9];
+        s.read_exact(&mut header).await.unwrap();
+        assert_eq!(header[3], SETTINGS_FRAME);
+        assert_eq!(header[4], 0);
+        assert_eq!(&header[5..9], &[0; 4]);
+        let len = ((header[0] as usize) << 16) | ((header[1] as usize) << 8) | header[2] as usize;
+        let mut payload = vec![0; len];
+        s.read_exact(&mut payload).await.unwrap();
+    }
+
+    async fn read_opening_settings(s: &mut DuplexStream) -> Vec<u8> {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let (kind, payload) = read_frame(s).await.unwrap();
+                if kind == SETTINGS_FRAME {
+                    return payload;
+                }
+            }
+        })
+        .await
+        .expect("the proxy never sent its client-facing SETTINGS")
+    }
+
+    fn extended_connect_enabled(payload: &[u8]) -> bool {
+        payload.chunks_exact(6).any(|entry| {
+            u16::from_be_bytes([entry[0], entry[1]]) == ENABLE_CONNECT_PROTOCOL
+                && u32::from_be_bytes([entry[2], entry[3], entry[4], entry[5]]) == 1
+        })
+    }
+
     #[tokio::test]
-    async fn extended_connect_is_advertised_only_when_the_backend_advertises_it() {
+    async fn extended_connect_follows_the_backend_opening_settings() {
         for (backend_settings, advertised) in [
-            (&[][..], false),
-            (&[(ENABLE_CONNECT_PROTOCOL, 1u32)][..], true),
+            (Vec::new(), false),
+            (vec![(ENABLE_CONNECT_PROTOCOL, 1u32)], true),
         ] {
             let (mut client, client_facing) = tokio::io::duplex(4096);
             let (backend_facing, mut backend) = tokio::io::duplex(4096);
 
-            tokio::spawn(run_http2_proxy(
+            let proxy = tokio::spawn(run_http2_proxy(
                 client_facing,
                 backend_facing,
                 None,
                 false,
                 None,
             ));
-            tokio::spawn(async move {
-                // A conformant h2 server opens with its SETTINGS.
-                let mut payload = Vec::new();
-                for &(id, value) in backend_settings {
+            let backend = tokio::spawn(async move {
+                read_client_opening(&mut backend).await;
+                let mut payload = Vec::with_capacity(backend_settings.len() * 6);
+                for (id, value) in backend_settings {
                     payload.extend_from_slice(&id.to_be_bytes());
                     payload.extend_from_slice(&value.to_be_bytes());
                 }
                 write_frame(&mut backend, SETTINGS_FRAME, &payload).await;
-                std::future::pending::<()>().await;
             });
 
             write_client_preface(&mut client, &[]).await;
-            let frame = tokio::time::timeout(Duration::from_secs(5), async {
-                loop {
-                    let (kind, payload) = read_frame(&mut client).await.unwrap();
-                    if kind == SETTINGS_FRAME {
-                        return payload;
-                    }
-                }
-            })
-            .await
-            .expect("the proxy never sent its client-facing SETTINGS");
             assert_eq!(
-                parse_settings_entries(&frame)
-                    .iter()
-                    .any(|&(id, _)| id == ENABLE_CONNECT_PROTOCOL),
+                extended_connect_enabled(&read_opening_settings(&mut client).await),
                 advertised,
-                "backend settings {backend_settings:?}"
             );
+            backend.await.unwrap();
+            drop(client);
+            tokio::time::timeout(Duration::from_secs(5), proxy)
+                .await
+                .expect("proxy did not close with the client")
+                .unwrap()
+                .unwrap();
         }
     }
 
-    /// A backend dying mid-connection reaches the client as GOAWAY plus a
-    /// clean drain, not as an abort of everything still in flight.
     #[tokio::test]
-    async fn an_upstream_error_reaches_the_client_as_goaway_not_a_bare_abort() {
+    async fn maximum_opening_settings_is_observed() {
         let (mut client, client_facing) = tokio::io::duplex(4096);
-        let (backend_facing, mut backend) = tokio::io::duplex(4096);
-
-        tokio::spawn(run_http2_proxy(
+        let (backend_facing, mut backend) = tokio::io::duplex(32 * 1024);
+        let proxy = tokio::spawn(run_http2_proxy(
             client_facing,
             backend_facing,
             None,
             false,
             None,
         ));
-        tokio::spawn(async move {
-            // A backend that answers the handshake and dies immediately,
-            // the way a restarting container does.
-            write_frame(&mut backend, SETTINGS_FRAME, &[]).await;
-            drop(backend);
+        let backend = tokio::spawn(async move {
+            let mut settings = vec![(0xa000u16, 0u32); 2_730];
+            settings[1_365] = (ENABLE_CONNECT_PROTOCOL, 1);
+            let mut payload = Vec::with_capacity(settings.len() * 6);
+            for (id, value) in settings {
+                payload.extend_from_slice(&id.to_be_bytes());
+                payload.extend_from_slice(&value.to_be_bytes());
+            }
+            write_frame(&mut backend, SETTINGS_FRAME, &payload).await;
+            read_client_opening(&mut backend).await;
         });
 
         write_client_preface(&mut client, &[]).await;
-        // The proxy answers the dead backend with GOAWAY rather than leaving
-        // the connection to abort. (The leg then lingers until the client
-        // acknowledges or closes, which a raw-socket test never does.)
+        assert!(extended_connect_enabled(
+            &read_opening_settings(&mut client).await
+        ));
+        backend.await.unwrap();
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), proxy)
+            .await
+            .expect("proxy did not close with the client")
+            .unwrap()
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn backend_failure_before_opening_settings_returns_without_a_client_preface() {
+        let (_client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, backend) = tokio::io::duplex(4096);
+        drop(backend);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            run_http2_proxy(client_facing, backend_facing, None, false, None),
+        )
+        .await
+        .expect("proxy waited for the client after the backend failed");
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn established_backend_failure_sends_goaway() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        let proxy = tokio::spawn(run_http2_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        let backend = tokio::spawn(async move {
+            read_client_opening(&mut backend).await;
+            write_frame(&mut backend, SETTINGS_FRAME, &[]).await;
+            assert_eq!(read_frame(&mut backend).await.unwrap().0, SETTINGS_FRAME);
+        });
+
+        write_client_preface(&mut client, &[]).await;
+        backend.await.unwrap();
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
                 match read_frame(&mut client).await.unwrap() {
@@ -1021,6 +1084,12 @@ mod tests {
         })
         .await
         .expect("no GOAWAY after the upstream errored");
+        drop(client);
+        tokio::time::timeout(Duration::from_secs(5), proxy)
+            .await
+            .expect("proxy did not close with the client")
+            .unwrap()
+            .unwrap();
     }
 
     fn req_with_auth(auth: Option<&str>) -> Request<()> {

--- a/shared-libs/crates/start-core/src/net/http.rs
+++ b/shared-libs/crates/start-core/src/net/http.rs
@@ -1,8 +1,10 @@
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::net::IpAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -15,6 +17,7 @@ use hyper::body::{Body as HyperBody, Incoming};
 use hyper::service::service_fn;
 use hyper::{Request, Response};
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, ReadBuf};
 use tokio::sync::{Mutex, Notify};
 
 use crate::net::host::binding::ProxyAuth;
@@ -287,9 +290,97 @@ where
     }
 }
 
+/// SETTINGS frame type.
+const H2_SETTINGS_FRAME: u8 = 0x4;
+/// `SETTINGS_ENABLE_CONNECT_PROTOCOL`, the RFC 8441 WebSocket setting.
+const ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
+
+async fn take_initial_settings<S: AsyncRead + Unpin>(
+    io: &mut S,
+) -> std::io::Result<(Vec<(u16, u32)>, Vec<u8>)> {
+    let mut head = [0u8; 9];
+    io.read_exact(&mut head).await?;
+    let len = ((head[0] as usize) << 16) | ((head[1] as usize) << 8) | head[2] as usize;
+    if head[3] != H2_SETTINGS_FRAME || len > 4096 {
+        return Ok((Vec::new(), head.to_vec()));
+    }
+    let mut payload = vec![0u8; len];
+    io.read_exact(&mut payload).await?;
+    let mut raw = head.to_vec();
+    raw.extend_from_slice(&payload);
+    let entries = payload
+        .chunks_exact(6)
+        .map(|c| {
+            (
+                u16::from_be_bytes([c[0], c[1]]),
+                u32::from_be_bytes([c[2], c[3], c[4], c[5]]),
+            )
+        })
+        .collect();
+    Ok((entries, raw))
+}
+
+/// Replays sniffed bytes to the reader before handing over to the inner
+/// stream.
+struct Replay<S> {
+    bytes: Vec<u8>,
+    taken: usize,
+    inner: S,
+}
+
+impl<S: AsyncRead + Unpin> AsyncRead for Replay<S> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let this = &mut *self;
+        if this.taken < this.bytes.len() {
+            let n = (this.bytes.len() - this.taken).min(buf.remaining());
+            buf.put_slice(&this.bytes[this.taken..this.taken + n]);
+            this.taken += n;
+            return Poll::Ready(Ok(()));
+        }
+        Pin::new(&mut this.inner).poll_read(cx, buf)
+    }
+}
+
+impl<S: AsyncWrite + Unpin> AsyncWrite for Replay<S> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+/// Serves the client leg only long enough to deliver GOAWAY, for when the
+/// backend died before the proxy could relay anything.
+async fn goaway_only<F: ReadWriter + Unpin + Send + 'static>(from: F) -> Result<(), Error> {
+    let mut server = hyper::server::conn::http2::Builder::new(TokioExecutor::new());
+    server.timer(TokioTimer::new()).adaptive_window(true);
+    let mut conn = Box::pin(server.serve_connection(
+        TokioIo::new(from),
+        service_fn(|_| async {
+            Ok::<Response<ProxyBody>, hyper::Error>(Response::new(box_full(Bytes::new())))
+        }),
+    ));
+    conn.as_mut().graceful_shutdown();
+    conn.await.map_err(|e| Error::new(e, ErrorKind::Network))
+}
+
 pub async fn run_http2_proxy<F, T>(
     from: F,
-    to: T,
+    mut to: T,
     src_ip: Option<IpAddr>,
     add_forwarded: bool,
     gate: Option<AuthGate>,
@@ -298,20 +389,51 @@ where
     F: ReadWriter + Unpin + Send + 'static,
     T: ReadWriter + Unpin + Send + 'static,
 {
-    let (client, to) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+    // An extended CONNECT is forwarded verbatim, including its `:protocol`, so
+    // advertise RFC 8441 only once the backend's opening SETTINGS shows it
+    // will not reset such streams; otherwise the browser falls back to
+    // HTTP/1.1 for its WebSockets.
+    let sniff = tokio::time::timeout(Duration::from_secs(5), take_initial_settings(&mut to)).await;
+    let (entries, replay) = match sniff {
+        Ok(Ok(res)) => res,
+        _ => (Vec::new(), Vec::new()),
+    };
+    let extended_connect = entries
+        .iter()
+        .any(|&(id, value)| id == ENABLE_CONNECT_PROTOCOL && value == 1);
+    let to = Replay {
+        bytes: replay,
+        taken: 0,
+        inner: to,
+    };
+    let (client, to) = match hyper::client::conn::http2::Builder::new(TokioExecutor::new())
         .timer(TokioTimer::new())
         .adaptive_window(true)
         .keep_alive_interval(Duration::from_secs(25))
         .keep_alive_timeout(Duration::from_secs(300))
         .handshake(TokioIo::new(to))
-        .await?;
-    let from = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
-        .timer(TokioTimer::new())
-        .enable_connect_protocol()
-        .adaptive_window(true)
-        .keep_alive_interval(Duration::from_secs(25)) // Add this
-        .keep_alive_timeout(Duration::from_secs(300))
-        .serve_connection(
+        .await
+    {
+        Ok(pair) => pair,
+        // Nothing was ever relayed, but the client still deserves GOAWAY
+        // rather than a bare abort.
+        Err(e) => {
+            tracing::warn!("Backend http2 connection failed during handshake: {e}");
+            tracing::debug!("{e:?}");
+            return goaway_only(from).await;
+        }
+    };
+    let from = {
+        let mut server = hyper::server::conn::http2::Builder::new(TokioExecutor::new());
+        server
+            .timer(TokioTimer::new())
+            .adaptive_window(true)
+            .keep_alive_interval(Duration::from_secs(25))
+            .keep_alive_timeout(Duration::from_secs(300));
+        if extended_connect {
+            server.enable_connect_protocol();
+        }
+        server.serve_connection(
             TokioIo::new(from),
             service_fn(move |mut req| {
                 let mut client = client.clone();
@@ -354,15 +476,21 @@ where
                     Ok::<_, hyper::Error>(res.map(box_incoming))
                 }
             }),
-        );
+        )
+    };
     let mut from = Box::pin(from);
     let mut to = Box::pin(to.fuse());
     loop {
         tokio::select! {
             res = from.as_mut() => return Ok(res?),
             res = to.as_mut() => {
-                res?;
-                // GOAWAY plus drain, so in-flight streams still finish.
+                // The upstream is gone whether it ended cleanly or errored;
+                // either way the client gets GOAWAY plus drain, so in-flight
+                // streams still finish instead of being aborted.
+                if let Err(e) = res {
+                    tracing::warn!("Error proxying http2 connection to backend: {e}");
+                    tracing::debug!("{e:?}");
+                }
                 from.as_mut().graceful_shutdown();
             }
         }
@@ -743,6 +871,149 @@ mod tests {
             .expect("tunnel stalled")
             .unwrap();
         assert_eq!(&echoed, b"ping");
+    }
+
+    // Minimal h2 frame plumbing for exercising run_http2_proxy without a
+    // real backend.
+    const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    const SETTINGS_FRAME: u8 = 0x4;
+    const GOAWAY_FRAME: u8 = 0x7;
+    const ENABLE_CONNECT_PROTOCOL: u16 = 0x8;
+
+    async fn write_frame(s: &mut DuplexStream, kind: u8, payload: &[u8]) {
+        let len = payload.len() as u32;
+        let head = [
+            (len >> 16) as u8,
+            (len >> 8) as u8,
+            len as u8,
+            kind,
+            0,
+            0,
+            0,
+            0,
+            0,
+        ];
+        s.write_all(&head).await.unwrap();
+        s.write_all(payload).await.unwrap();
+    }
+
+    async fn write_client_preface(s: &mut DuplexStream, settings: &[(u16, u32)]) {
+        s.write_all(H2_PREFACE).await.unwrap();
+        let mut payload = Vec::new();
+        for &(id, value) in settings {
+            payload.extend_from_slice(&id.to_be_bytes());
+            payload.extend_from_slice(&value.to_be_bytes());
+        }
+        write_frame(s, SETTINGS_FRAME, &payload).await;
+    }
+
+    async fn read_frame(s: &mut DuplexStream) -> std::io::Result<(u8, Vec<u8>)> {
+        let mut head = [0u8; 9];
+        s.read_exact(&mut head).await?;
+        let len = ((head[0] as usize) << 16) | ((head[1] as usize) << 8) | head[2] as usize;
+        let mut payload = vec![0u8; len];
+        s.read_exact(&mut payload).await?;
+        Ok((head[3], payload))
+    }
+
+    fn settings_entries(payload: &[u8]) -> Vec<(u16, u32)> {
+        payload
+            .chunks_exact(6)
+            .map(|c| {
+                (
+                    u16::from_be_bytes([c[0], c[1]]),
+                    u32::from_be_bytes([c[2], c[3], c[4], c[5]]),
+                )
+            })
+            .collect()
+    }
+
+    /// RFC 8441 extended CONNECT is only advertised to the client once the
+    /// backend advertises it too; against a backend that will reset such
+    /// streams, the client falls back to HTTP/1.1 for its WebSockets.
+    #[tokio::test]
+    async fn extended_connect_is_advertised_only_when_the_backend_advertises_it() {
+        for (backend_settings, advertised) in [
+            (&[][..], false),
+            (&[(ENABLE_CONNECT_PROTOCOL, 1u32)][..], true),
+        ] {
+            let (mut client, client_facing) = tokio::io::duplex(4096);
+            let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+            tokio::spawn(run_http2_proxy(
+                client_facing,
+                backend_facing,
+                None,
+                false,
+                None,
+            ));
+            tokio::spawn(async move {
+                // A conformant h2 server opens with its SETTINGS.
+                let mut payload = Vec::new();
+                for &(id, value) in backend_settings {
+                    payload.extend_from_slice(&id.to_be_bytes());
+                    payload.extend_from_slice(&value.to_be_bytes());
+                }
+                write_frame(&mut backend, SETTINGS_FRAME, &payload).await;
+                std::future::pending::<()>().await;
+            });
+
+            write_client_preface(&mut client, &[]).await;
+            let frame = tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let (kind, payload) = read_frame(&mut client).await.unwrap();
+                    if kind == SETTINGS_FRAME {
+                        return payload;
+                    }
+                }
+            })
+            .await
+            .expect("the proxy never sent its client-facing SETTINGS");
+            assert_eq!(
+                settings_entries(&frame)
+                    .iter()
+                    .any(|&(id, _)| id == ENABLE_CONNECT_PROTOCOL),
+                advertised,
+                "backend settings {backend_settings:?}"
+            );
+        }
+    }
+
+    /// A backend dying mid-connection reaches the client as GOAWAY plus a
+    /// clean drain, not as an abort of everything still in flight.
+    #[tokio::test]
+    async fn an_upstream_error_reaches_the_client_as_goaway_not_a_bare_abort() {
+        let (mut client, client_facing) = tokio::io::duplex(4096);
+        let (backend_facing, mut backend) = tokio::io::duplex(4096);
+
+        tokio::spawn(run_http2_proxy(
+            client_facing,
+            backend_facing,
+            None,
+            false,
+            None,
+        ));
+        tokio::spawn(async move {
+            // A backend that answers the handshake and dies immediately,
+            // the way a restarting container does.
+            write_frame(&mut backend, SETTINGS_FRAME, &[]).await;
+            drop(backend);
+        });
+
+        write_client_preface(&mut client, &[]).await;
+        // The proxy answers the dead backend with GOAWAY rather than leaving
+        // the connection to abort. (The leg then lingers until the client
+        // acknowledges or closes, which a raw-socket test never does.)
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match read_frame(&mut client).await.unwrap() {
+                    (GOAWAY_FRAME, _) => break,
+                    _ => {}
+                }
+            }
+        })
+        .await
+        .expect("no GOAWAY after the upstream errored");
     }
 
     fn req_with_auth(auth: Option<&str>) -> Request<()> {


### PR DESCRIPTION
Closes #3775.

## What

Two fixes to `run_http2_proxy` (`shared-libs/crates/start-core/src/net/http.rs`), both reachable for `protocol: 'https' | 'wss'` bindings once the client-facing ALPN is reflected (#3777).

### 1. Extended CONNECT follows the backend's opening HTTP/2 settings

The client-facing HTTP/2 server previously advertised `SETTINGS_ENABLE_CONNECT_PROTOCOL` unconditionally. A browser could then send an RFC 8441 extended CONNECT to a backend that rejects it, breaking that WebSocket.

Hyper fixes the setting when it constructs the client-facing connection, but its backend handshake returns before the peer's SETTINGS arrive. The proxy now wraps the backend stream in Tokio's pass-through `InspectReader`, lets Hyper send and drive its client preface normally, and incrementally observes the backend's opening SETTINGS without consuming, replaying, or buffering the frame. The client-facing connection advertises extended CONNECT only when that opening frame enables it.

This is deliberately scoped to the opening SETTINGS. RFC 8441 permits a backend to enable extended CONNECT later, but Hyper's public server API cannot change the setting after connection construction. Withholding the capability is protocol-valid and avoids falsely advertising support.

### 2. Established backend failures produce client-facing GOAWAY

An upstream error previously returned early and dropped the browser leg without GOAWAY. Once both legs are established, backend completion or failure now triggers graceful shutdown of the client-facing connection. Failures before a valid opening SETTINGS return immediately rather than starting another client-side HTTP/2 handshake.

## Tests

- `extended_connect_follows_the_backend_opening_settings` — the backend waits for Hyper's full client preface before advertising support, covering the handshake ordering.
- `maximum_opening_settings_is_observed` — a valid 16,380-byte opening SETTINGS payload is observed across fragmented reads.
- `backend_failure_before_opening_settings_returns_without_a_client_preface` — an early backend failure returns promptly without waiting on the browser.
- `established_backend_failure_sends_goaway` — a failure after both HTTP/2 handshakes reaches the browser as GOAWAY.

Verification:

- `cargo check -p start-core`
- `cargo test -p start-core net::http --features=test` — 15 passed
- `make start-core-test` — 444 passed, 3 ignored (`export_` skipped by the target)
- `make start-core-format-check`
