### PR TITLE
fix(net): give back the external ports a rebind swapped between a binding's legs

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -204,12 +204,17 @@ file tracks notable changes since the move to the monorepo.
   StartOS labels a failure that came from the runtime `Service Runtime Error`
   rather than `Unknown Error`.
 
-- **A service that adds an SSL port keeps the address you already had.** When a
-  service gained an SSL port alongside a plaintext one it already had, the new
-  SSL port took over the existing number and the plaintext port was moved to an
-  arbitrary one — changing an address you may have saved. Each now keeps its
-  own: the port you already had stays where it is, and the one being added takes
-  the port the service asks for.
+- **A service that adds an SSL port keeps the address you already had, and a
+  server where the two were already exchanged is put back.** When a service
+  gained an SSL port alongside a plaintext one it already had, the new SSL port
+  took over the existing number and the plaintext port moved to an arbitrary
+  one — so an address you had saved kept its number but began requiring SSL,
+  and a client pointed at it failed with a timeout that named nothing.
+  Servers upgraded from 0.3.5.1 running Electrs or Fulcrum are where this
+  showed. Each port now keeps its own, and updating restores the pair on a
+  server where they had been exchanged, so a client that worked before this
+  works again — turn its SSL setting back off if you switched it on to get
+  around it.
 
 - **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
   0.4.0.1 gave the interface a high-numbered port instead, and nothing answered

--- a/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
+++ b/shared-libs/crates/start-core/src/version/v0_4_0_2.rs
@@ -1,3 +1,6 @@
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+
 use exver::VersionRange;
 
 use super::v0_3_5::V0_3_0_COMPAT;
@@ -29,6 +32,7 @@ impl VersionT for Version {
     #[instrument(skip_all)]
     fn up(self, db: &mut Value, _: Self::PreUpRes) -> Result<Value, Error> {
         rehome_admin_ui_port(db);
+        unswap_carried_legs(db);
         Ok(Value::Null)
     }
     fn down(self, _db: &mut Value) -> Result<(), Error> {
@@ -77,6 +81,191 @@ fn rehome_admin_ui_port(db: &mut Value) {
         available.remove(&InternedString::from_display(&held));
     }
     available.insert(InternedString::from_display(&UI_PORT), Value::Bool(false));
+}
+
+/// The lowest port [`crate::net::forward::AvailablePorts::alloc`] hands out.
+const EPHEMERAL_START: u64 = 49152;
+
+/// Give back the external ports a rebind swapped between a binding's two legs.
+///
+/// Before #3638 `BindInfo::update` carried the one number a binding held to
+/// whichever leg reclaimed first, and the TLS leg reclaims first. A binding that
+/// arrived holding only a plaintext port and then gained `addSsl` therefore
+/// handed that number to TLS and dropped its own leg onto an ephemeral port, so
+/// a client configured against the number before the rebind now speaks plaintext
+/// to a TLS listener.
+///
+/// Servers migrated from 0.3.5.1 are the population. The v1 compat shim binds
+/// each `tor-config` port with `addSsl: null` (it comes only from `lan-config`),
+/// and the 0.4 package then rebinds the same host and internal port with one.
+///
+/// The fingerprint is not reachable any other way: `BindInfo::new` allocates the
+/// TLS leg from `addSsl` first and the plaintext leg from `preferredExternalPort`
+/// second, so a binding that lost either race lands on an ephemeral port for that
+/// leg rather than on the other leg's number.
+fn unswap_carried_legs(db: &mut Value) {
+    let Some(mut ports) = db
+        .get("private")
+        .and_then(|p| p.get("availablePorts"))
+        .and_then(|a| a.as_object())
+        .map(|a| {
+            a.iter()
+                .filter_map(|(k, v)| Some((k.parse::<u64>().ok()?, v.as_bool()?)))
+                .collect::<BTreeMap<_, _>>()
+        })
+    else {
+        return;
+    };
+
+    let mut moved = false;
+    for_each_binding(db, |bind| {
+        let Some(options) = bind.get("options") else {
+            return;
+        };
+        // A container that serves its own TLS has no plaintext leg to swap.
+        if options
+            .get("secure")
+            .and_then(|s| s.get("ssl"))
+            .and_then(|s| s.as_bool())
+            == Some(true)
+        {
+            return;
+        }
+        let Some(plain) = options
+            .get("preferredExternalPort")
+            .and_then(|p| p.as_u64())
+        else {
+            return;
+        };
+        let Some(ssl) = options
+            .get("addSsl")
+            .and_then(|s| s.get("preferredExternalPort"))
+            .and_then(|p| p.as_u64())
+        else {
+            return;
+        };
+        let net = bind.get("net");
+        let held_ssl = net
+            .and_then(|n| n.get("assignedSslPort"))
+            .and_then(|p| p.as_u64());
+        let held_plain = net
+            .and_then(|n| n.get("assignedPort"))
+            .and_then(|p| p.as_u64());
+
+        // TLS sitting on the plaintext leg's number, with the plaintext leg
+        // pushed into the range only `alloc` hands out.
+        if held_ssl != Some(plain) {
+            return;
+        }
+        let Some(held_plain) = held_plain.filter(|p| *p >= EPHEMERAL_START) else {
+            return;
+        };
+        // Someone else took the number the TLS leg asked for; moving onto it
+        // would break them instead.
+        if ports.contains_key(&ssl) {
+            return;
+        }
+
+        if let Some(net) = bind.get_mut("net").and_then(|n| n.as_object_mut()) {
+            net.insert("assignedPort".into(), Value::from(plain));
+            net.insert("assignedSslPort".into(), Value::from(ssl));
+        }
+        // The overrides are keyed by port, and both ports move at once — a
+        // rekey per leg would carry the first leg's entries twice.
+        if let Some(addresses) = bind.get_mut("addresses") {
+            swap_override_ports(addresses, held_plain, plain, ssl);
+        }
+        ports.remove(&held_plain);
+        ports.insert(plain, false);
+        ports.insert(ssl, true);
+        moved = true;
+    });
+
+    if !moved {
+        return;
+    }
+    if let Some(private) = db.get_mut("private").and_then(|p| p.as_object_mut()) {
+        private.insert(
+            "availablePorts".into(),
+            Value::Object(
+                ports
+                    .into_iter()
+                    .map(|(k, v)| (InternedString::from_display(&k), Value::Bool(v)))
+                    .collect(),
+            ),
+        );
+    }
+}
+
+/// Move every `enabled` / `disabled` / `guaWan` override off the two ports the
+/// legs just exchanged: the plaintext leg's from `old_plain` to `new_plain`, and
+/// the TLS leg's from `new_plain` to `new_ssl`. Losing one would silently
+/// re-enable an address the operator turned off.
+fn swap_override_ports(addresses: &mut Value, old_plain: u64, new_plain: u64, new_ssl: u64) {
+    let remap = |port: u64| {
+        if port == old_plain {
+            new_plain
+        } else if port == new_plain {
+            new_ssl
+        } else {
+            port
+        }
+    };
+    for key in ["enabled", "guaWan"] {
+        if let Some(list) = addresses.get_mut(key).and_then(|l| l.as_array_mut()) {
+            for entry in list.iter_mut() {
+                let Some(mut addr) = entry.as_str().and_then(|s| s.parse::<SocketAddr>().ok())
+                else {
+                    continue;
+                };
+                let port = remap(addr.port() as u64);
+                addr.set_port(port as u16);
+                *entry = Value::String(addr.to_string().into());
+            }
+        }
+    }
+    if let Some(list) = addresses.get_mut("disabled").and_then(|l| l.as_array_mut()) {
+        for entry in list.iter_mut() {
+            let Some(port) = entry.get(1).and_then(|p| p.as_u64()) else {
+                continue;
+            };
+            if let Some(pair) = entry.as_array_mut() {
+                pair.set(1, Value::from(remap(port)));
+            }
+        }
+    }
+}
+
+/// Every binding on the server host and on every installed package.
+fn for_each_binding(db: &mut Value, mut f: impl FnMut(&mut Value)) {
+    let mut visit = |host: &mut Value| {
+        if let Some(bindings) = host.get_mut("bindings").and_then(|b| b.as_object_mut()) {
+            for (_, bind) in bindings.iter_mut() {
+                f(bind);
+            }
+        }
+    };
+    if let Some(host) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("serverInfo"))
+        .and_then(|s| s.get_mut("network"))
+        .and_then(|n| n.get_mut("host"))
+    {
+        visit(host);
+    }
+    if let Some(packages) = db
+        .get_mut("public")
+        .and_then(|p| p.get_mut("packageData"))
+        .and_then(|p| p.as_object_mut())
+    {
+        for (_, package) in packages.iter_mut() {
+            if let Some(hosts) = package.get_mut("hosts").and_then(|h| h.as_object_mut()) {
+                for (_, host) in hosts.iter_mut() {
+                    visit(host);
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -153,6 +342,141 @@ mod test {
             db["private"]["availablePorts"],
             json!({ "80": false, "443": true })
         );
+    }
+
+    fn pkg_db(net: Value, addresses: Value, available_ports: Value) -> Value {
+        json!({
+            "public": { "packageData": { "electrs": { "hosts": { "electrum": { "bindings": {
+                "50001": {
+                    "options": {
+                        "preferredExternalPort": 50001,
+                        "addSsl": { "preferredExternalPort": 50002 },
+                        "secure": Value::Null,
+                    },
+                    "net": net,
+                    "addresses": addresses,
+                },
+            } } } } } },
+            "private": { "availablePorts": available_ports }
+        })
+    }
+
+    fn pkg_bind(db: &Value) -> &Value {
+        &db["public"]["packageData"]["electrs"]["hosts"]["electrum"]["bindings"]["50001"]
+    }
+
+    fn no_overrides() -> Value {
+        json!({ "enabled": [], "disabled": [], "guaWan": [], "available": [] })
+    }
+
+    // A server migrated from 0.3.5.1: the v1 compat shim bound 50001 with no
+    // `addSsl`, and the 0.4 package's rebind handed that number to the TLS leg.
+    #[test]
+    fn unswaps_a_binding_that_gained_add_ssl() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 51820, "assignedSslPort": 50001 }),
+            no_overrides(),
+            json!({ "50001": true, "51820": false }),
+        );
+        unswap_carried_legs(&mut db);
+        assert_eq!(pkg_bind(&db)["net"]["assignedPort"], json!(50001));
+        assert_eq!(pkg_bind(&db)["net"]["assignedSslPort"], json!(50002));
+        assert_eq!(
+            db["private"]["availablePorts"],
+            json!({ "50001": false, "50002": true })
+        );
+    }
+
+    // Both ports move at once, so the overrides have to cross rather than shift:
+    // losing a `disabled` entry silently re-enables an address the operator
+    // turned off.
+    #[test]
+    fn carries_the_overrides_across_the_swap() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 51820, "assignedSslPort": 50001 }),
+            json!({
+                "enabled": ["1.2.3.4:50001", "1.2.3.4:8443"],
+                "disabled": [["electrs.local", 51820], ["other.local", 9735]],
+                "guaWan": ["[2001:db8::1]:51820"],
+                "available": [],
+            }),
+            json!({ "50001": true, "51820": false }),
+        );
+        unswap_carried_legs(&mut db);
+        let addresses = &pkg_bind(&db)["addresses"];
+        // The TLS leg's WAN opt-in follows TLS to 50002; the unrelated one stays.
+        assert_eq!(
+            addresses["enabled"],
+            json!(["1.2.3.4:50002", "1.2.3.4:8443"])
+        );
+        // The plaintext leg's disable follows plaintext to 50001.
+        assert_eq!(
+            addresses["disabled"],
+            json!([["electrs.local", 50001], ["other.local", 9735]])
+        );
+        assert_eq!(addresses["guaWan"], json!(["[2001:db8::1]:50001"]));
+    }
+
+    #[test]
+    fn leaves_a_healthy_binding_alone() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 50001, "assignedSslPort": 50002 }),
+            no_overrides(),
+            json!({ "50001": false, "50002": true }),
+        );
+        let before = db.clone();
+        unswap_carried_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    // Fulcrum already holds 50002. Moving onto it would break that binding
+    // instead, so this one keeps its ports and stays broken.
+    #[test]
+    fn leaves_a_binding_alone_when_the_ssl_number_is_taken() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 51820, "assignedSslPort": 50001 }),
+            no_overrides(),
+            json!({ "50001": true, "50002": true, "51820": false }),
+        );
+        let before = db.clone();
+        unswap_carried_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    // Losing the race for `addSsl`'s number puts the TLS leg on an ephemeral
+    // port, not on the plaintext leg's — a shape `new` produces legitimately.
+    #[test]
+    fn leaves_a_binding_whose_ssl_leg_merely_lost_a_race_alone() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 50001, "assignedSslPort": 51820 }),
+            no_overrides(),
+            json!({ "50001": false, "51820": true }),
+        );
+        let before = db.clone();
+        unswap_carried_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    #[test]
+    fn leaves_a_native_tls_binding_alone() {
+        let mut db = pkg_db(
+            json!({ "assignedPort": 51820, "assignedSslPort": 50001 }),
+            no_overrides(),
+            json!({ "50001": true, "51820": false }),
+        );
+        db["public"]["packageData"]["electrs"]["hosts"]["electrum"]["bindings"]["50001"]["options"]
+            ["secure"] = json!({ "ssl": true });
+        let before = db.clone();
+        unswap_carried_legs(&mut db);
+        assert_eq!(db, before);
+    }
+
+    #[test]
+    fn tolerates_a_db_with_no_packages() {
+        let mut db = json!({ "public": { "serverInfo": {} }, "private": { "availablePorts": {} } });
+        let before = db.clone();
+        unswap_carried_legs(&mut db);
+        assert_eq!(db, before);
     }
 
     #[test]


### PR DESCRIPTION
Repairs servers already in the state #3638 stopped producing. Companion to Start9Labs/tor-startos#23.

## The state

Before #3638, `BindInfo::update` did:

```rust
let carried = match (held.assigned_port, held.assigned_ssl_port) {
    (Some(port), None) | (None, Some(port)) => Some(port), _ => None };
let want = held.or(carried).unwrap_or(preferred);
```

with the TLS leg reclaiming first. A binding that arrived holding **only** a plaintext port and then gained `addSsl` therefore handed that number to TLS, and its own leg — finding the number gone — fell through to `alloc()`, a port at or above 49152.

#3638 stops that happening again and deliberately does not move a binding already assigned, so the servers it happened to stay that way. **This is not a moved address.** The number the user has saved still answers; it now speaks TLS. A client configured against it before the rebind fails with a generic timeout that names neither TLS nor a certificate.

## Who is affected

Servers migrated from 0.3.5.1. The v1 compat shim binds each `tor-config` port with `addSsl: null` — `addSsl` comes only from `lan-config` (`projects/start-os/container-runtime/src/Adapters/Systems/SystemForEmbassy/index.ts:528-540`) — and the 0.4 package then rebinds the same host id and internal port with one.

Electrs is the reported case. Its 0.3.x manifest:

```yaml
interfaces:
  electrum:
    tor-config: { port-mapping: { 50001: "50001" } }
    # lan-config: …
```

→ `{assignedPort: 50001, assignedSslPort: None}`, then the 0.4 package's `addSsl: {preferredExternalPort: 50002}` → `{assignedPort: <ephemeral>, assignedSslPort: 50001}`. 50001 was plain TCP on 0.3.5.1 and is TLS on 0.4.0.1, so Sparrow and Trezor Suite stopped connecting. Fulcrum has the same binding shape but never shipped on 0.3.5.1, so it cannot be in this state.

## The repair

`unswap_carried_legs` runs in `v0_4_0_2::up` and matches only:

- `addSsl` present and the container does not serve its own TLS (both legs are meant to exist)
- `assignedSslPort == options.preferredExternalPort` (TLS holds the plaintext leg's number)
- `assignedPort >= 49152` (the plaintext leg is in the range only `alloc` hands out)
- `addSsl.preferredExternalPort` is free in `availablePorts`

**The fingerprint is not reachable any other way.** `BindInfo::new` takes the TLS leg from `addSsl` first and the plaintext leg from `preferredExternalPort` second, so a binding that lost either race lands on an ephemeral port *for that leg* rather than on the other leg's number — `leaves_a_binding_whose_ssl_leg_merely_lost_a_race_alone` pins that shape.

A binding whose `addSsl` number is held by someone else is skipped rather than moved onto it — better to leave one service broken than break a second.

**The overrides are swapped, not rekeyed per leg.** `enabled` / `disabled` / `guaWan` are keyed by port and both ports move at once, so a rekey of the plaintext leg followed by one of the TLS leg would carry the first leg's entries twice. That matters beyond tidiness: `disabled` is opt-**out**, so losing an entry silently re-enables an address the operator turned off.

## Why this is worth moving a port when #3638 declined to

#3638's reasoning was that an external port is in the user's address book, so a binding that once lost a race shouldn't later migrate off an address someone bookmarked. That holds when the number is merely *unexpected*. Here the number didn't move — its **protocol** inverted — so the address in the user's book is the one that stopped working, and leaving it alone preserves the break rather than the bookmark.

It also repairs the Tor address on these servers without touching the tor package. The onion entry was written by `migrateOnionAddresses` against the **pre-swap** binding, so restoring that layout makes the stored `HiddenServicePort` target correct again. Start9Labs/tor-startos#23 independently reconciles the entry against the live binding; the two converge on the same result, in either order.

**The one regression:** anyone who already diagnosed this and switched their client's SSL setting on at the old number will break again on update, toward the documented state. The changelog entry says so and tells them to switch it back.

## Changelog

`0.4.0.2` has no origin tag (latest is `start-os/v0.4.0.1`), so it is unreleased, and #3638's entry for the forward-looking half is already under it. Per AGENTS.md this extends that entry rather than adding a second `### Fixed` line — to the user it is one behavior, and the migration instruction belongs with it.

## Verification

`cargo check -p start-core` is clean and `make start-core-format-check` passes. **The seven unit tests are unrun** — my local `cargo test -p start-core` (`[profile.test] opt-level = 3`, full debuginfo, outside `docker.slice` so uncapped) took the machine down, and I'm deliberately leaving it to CI rather than retrying. Please don't merge on a red `make test`.

Tests added, all against `unswap_carried_legs` directly:

- `unswaps_a_binding_that_gained_add_ssl` — the migrated-electrs shape
- `carries_the_overrides_across_the_swap` — `enabled` / `disabled` / `guaWan` cross correctly, unrelated ports untouched
- `leaves_a_healthy_binding_alone`
- `leaves_a_binding_alone_when_the_ssl_number_is_taken`
- `leaves_a_binding_whose_ssl_leg_merely_lost_a_race_alone`
- `leaves_a_native_tls_binding_alone`
- `tolerates_a_db_with_no_packages`