### PR TITLE
docs(start-os): drop the SSL-port-swap entry

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -204,13 +204,6 @@ file tracks notable changes since the move to the monorepo.
   StartOS labels a failure that came from the runtime `Service Runtime Error`
   rather than `Unknown Error`.
 
-- **A service that adds an SSL port keeps the address you already had.** When a
-  service gained an SSL port alongside a plaintext one it already had, the new
-  SSL port took over the existing number and the plaintext port was moved to an
-  arbitrary one — changing an address you may have saved. Each now keeps its
-  own: the port you already had stays where it is, and the one being added takes
-  the port the service asks for.
-
 - **The StartOS UI is served over plain HTTP on port 80.** Servers set up before
   0.4.0.1 gave the interface a high-numbered port instead, and nothing answered
   on it — so a service that reached the StartOS API over the container bridge,


### PR DESCRIPTION
Removes this from the unreleased `0.4.0.2` section:

> **A service that adds an SSL port keeps the address you already had.** When a service gained an SSL port alongside a plaintext one it already had, the new SSL port took over the existing number and the plaintext port was moved to an arbitrary one — changing an address you may have saved. …

A changelog is read by someone deciding whether an upgrade affects them, and nobody in that position can act on this one. The swap needed `carried`, which `git tag --contains 1e8dbeeed` puts in `start-os/v0.4.0.1` alone — so it only ever happened to a server already running 0.4.0.1, and every reader who could care is past the decision the entry exists to inform. #3638's change still belongs in the code; it just has no audience in the release notes.

Companion to closing #3817, which would have repaired servers already in that state and isn't worth the code — the reasoning is on that PR.