### PR TITLE
docs(start-sdk): prefer the address-filter shorthands over a predicate

### DIFF
--- a/projects/start-sdk/docs/src/interfaces.md
+++ b/projects/start-sdk/docs/src/interfaces.md
@@ -350,11 +350,25 @@ Otherwise prefer `addSsl`. Passthrough gives up everything the proxy does on you
 - `sdk.getOsIp` (`10.0.3.1`) — the bridge, where other services reach you
 - `127.0.0.1` — your own subcontainers, which share the service's network namespace
 - `sdk.getContainerIp` — the container itself
-- any other address you expect a client to use
+- **every address the interface is published at** — LAN IPs, the server's `.local` name, private and public domains, and any onion a plugin has exported
+
+Those three constants are the internal half, and naming only them is the mistake to avoid: an off-box client dialing the LAN address or the `.local` name gets a certificate matching none of them. Take the external half from the interface itself, so it follows the addresses the operator adds and removes:
 
 ```typescript
 export const setupCerts = sdk.setupOnInit(async effects => {
-  const hostnames = [await sdk.getContainerIp(effects).const(), '127.0.0.1', await sdk.getOsIp(effects)]
+  const served = await sdk.host
+    .getOwn(effects, 'grpc', host => {
+      const iface =
+        host &&
+        Object.values(host.bindings)
+          .flatMap(b => Object.values(b.interfaces))
+          .find(i => i.id === 'grpc')
+      // everything except the WAN IPv4, which getSslCertificate refuses to sign
+      return iface ? iface.addressInfo.matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }]).hostnames.map(h => h.hostname) : []
+    })
+    .const()
+
+  const hostnames = [await sdk.getContainerIp(effects).const(), '127.0.0.1', await sdk.getOsIp(effects), ...served]
   const cert = (await sdk.getSslCertificate(effects, hostnames).const()).join('')
   const key = await sdk.getSslKey(effects, { hostnames })
   await writeFile('/media/startos/volumes/main/tls.cert', cert)
@@ -362,7 +376,11 @@ export const setupCerts = sdk.setupOnInit(async effects => {
 })
 ```
 
+`getSslCertificate` signs a LAN address and rejects a routable one, so a WAN IPv4 in the list fails the whole call. See [Narrowing the set](main.md#narrowing-the-set) for why that exclusion is a union rather than a two-field `exclude`.
+
 Read the container IP with `.const()` rather than `.once()`: a container that comes back on a new IP must reissue the certificate, or every client dialing the old one fails verification.
+
+Most daemons read their TLS pair once at startup, so reissuing the file is only half the job — something has to restart the service, or it keeps serving the old certificate against the new address set.
 
 > [!WARNING]
 > Do **not** add a `<package-id>.startos` DNS name to the SANs. That overlay DNS is deprecated and slated for removal, and it resolves to the container IP rather than the bridge — so it bypasses the platform entirely. Dependents reach you through the bridge; see [Service-to-Service Networking](service-to-service.md).

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -151,20 +151,27 @@ const allowedHosts = ui?.addressInfo.format('hostname-info').map(h => h.hostname
 
 ### Narrowing the set
 
-Reach for the shorthands first — `.nonLocal`, `.public`, `.bridge` — then `.filter({...})` for a declared `kind` / `visibility` / `pluginId`, then `.matchesAny([...])` when you want the union of several. `.filter()` calls compose as an intersection, so chaining narrows:
+Three shorthands cover most needs:
+
+| shorthand   | keeps                                                                                 |
+| ----------- | ------------------------------------------------------------------------------------- |
+| `.nonLocal` | what a client off the box can reach — drops loopback, IPv6 link-local, and the bridge |
+| `.public`   | only addresses flagged `public` — WAN IPs, public domains, onions                     |
+| `.bridge`   | only the `lxcbr0` addresses other containers reach you on                             |
+
+Beyond those, `.filter({ kind, visibility, pluginId })` composes as an intersection and `.matchesAny([...])` unions:
 
 ```typescript
-addresses.nonLocal.filter({ kind: 'domain' }) // domains, minus loopback and link-local
+addresses.nonLocal.filter({ kind: 'domain' }) // domains, off-box only
 addresses.matchesAny([{ kind: 'mdns' }, { kind: 'domain' }]) // either one
 ```
 
-`predicate` is the escape hatch for a condition the declared fields cannot express. Prefer a shorthand or a declared filter wherever one fits: a predicate is opaque to the type narrowing the other forms give you, and it hides the intent behind a lambda.
+`predicate` is the escape hatch for what those cannot express; it is opaque to the type narrowing the declared forms give you.
 
-**`exclude` removes anything matching _any_ field of the nested filter, not only what matches all of them.** `filter({ exclude: { kind: 'ipv4', visibility: 'public' } })` therefore drops every IPv4 _and_ every public address, not just the public IPv4s — usually a far smaller set than intended. To subtract one combination, take the union of its complements instead:
+**`exclude` drops anything matching _any_ field of the nested filter**, so `exclude: { kind: 'ipv4', visibility: 'public' }` removes every IPv4 _and_ every public address, not just the public IPv4s. Union the complements instead:
 
 ```typescript
-// everything except a public IPv4
-addresses.matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }])
+addresses.matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }]) // everything but a public IPv4
 ```
 
 To react to only a slice of the host, pass a `map` selector (and optional `eq`, default deep-equal) to `getOwn`/`get`. `.const()` then re-runs only when the mapped value changes rather than on any change to the whole host:

--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -136,7 +136,7 @@ const secretKey = await storeJson.read(s => s.secretKey).const(effects)
 
 ## Getting Hostnames
 
-Interfaces are reached through their **host**. `sdk.host.getOwn(effects, hostId)` returns the host (`hostId` is the id you passed to `sdk.MultiHost.of`); the interface you exported lives under one of the host's bindings, and its `addressInfo` comes back **pre-filled** — call `.format(...)` on it for resolvable hostnames/URLs (also `.filter(...)`, `.nonLocal`, `.public`, `.bridge`, `.toUrl`):
+Interfaces are reached through their **host**. `sdk.host.getOwn(effects, hostId)` returns the host (`hostId` is the id you passed to `sdk.MultiHost.of`); the interface you exported lives under one of the host's bindings, and its `addressInfo` comes back **pre-filled** — call `.format(...)` on it for resolvable hostnames/URLs (also `.filter(...)`, `.matchesAny(...)`, `.nonLocal`, `.public`, `.bridge`, `.toUrl`):
 
 ```typescript
 const host = await sdk.host.getOwn(effects, 'ui').const()
@@ -148,6 +148,24 @@ const allowedHosts = ui?.addressInfo.format('hostname-info').map(h => h.hostname
 ```
 
 `.const()` sets up a reactive watcher — `setupMain` re-runs whenever the host's bindings, addresses, or exported interfaces change.
+
+### Narrowing the set
+
+Reach for the shorthands first — `.nonLocal`, `.public`, `.bridge` — then `.filter({...})` for a declared `kind` / `visibility` / `pluginId`, then `.matchesAny([...])` when you want the union of several. `.filter()` calls compose as an intersection, so chaining narrows:
+
+```typescript
+addresses.nonLocal.filter({ kind: 'domain' }) // domains, minus loopback and link-local
+addresses.matchesAny([{ kind: 'mdns' }, { kind: 'domain' }]) // either one
+```
+
+`predicate` is the escape hatch for a condition the declared fields cannot express. Prefer a shorthand or a declared filter wherever one fits: a predicate is opaque to the type narrowing the other forms give you, and it hides the intent behind a lambda.
+
+**`exclude` removes anything matching _any_ field of the nested filter, not only what matches all of them.** `filter({ exclude: { kind: 'ipv4', visibility: 'public' } })` therefore drops every IPv4 _and_ every public address, not just the public IPv4s — usually a far smaller set than intended. To subtract one combination, take the union of its complements instead:
+
+```typescript
+// everything except a public IPv4
+addresses.matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }])
+```
 
 To react to only a slice of the host, pass a `map` selector (and optional `eq`, default deep-equal) to `getOwn`/`get`. `.const()` then re-runs only when the mapped value changes rather than on any change to the whole host:
 


### PR DESCRIPTION
Targets `live-docs`: all of this is true of the shipped SDK, and the guidance it corrects is what produced [lnd-startos#189](https://github.com/Start9Labs/lnd-startos/pull/189).

### Rank the filter forms

`Filled` exposes `.nonLocal`, `.public`, `.bridge`, `.filter()` and `.matchesAny()`. The page named four of them in a parenthetical and defined none, so there was nothing to pick between and `predicate` read as a peer of the declared filters rather than the escape hatch it is.

Adds a three-row table saying what each shorthand keeps, names `matchesAny`, and says what a predicate costs — it is opaque to the type narrowing the declared forms give you. What each shorthand selects was read off `filledAddress` as shipped, which matters for `.nonLocal`: its own doc comment says it "excludes `localhost` and IPv6 link-local addresses", but the filter drops bridge addresses too.

### Say what `exclude` actually does

`exclude` removes anything matching **any** field of the nested filter, not the combination. The obvious spelling of "not a public IPv4" —

```ts
addresses.filter({ exclude: { kind: 'ipv4', visibility: 'public' } })
```

— drops every IPv4 *and* every public address. Against a realistic nine-address set that leaves two entries where eight were intended, which reads as a different bug entirely. Documents the union-of-complements form that works:

```ts
addresses.matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }])
```

Both behaviours verified against `filledAddress` as shipped in `@start9labs/start-sdk` 2.0.9, not inferred from the source.

This is documentation of current behaviour, not an endorsement of it — filed as a question in its own right below.

### Derive the passthrough SANs instead of listing them

§ Minting the certificate listed the three internal constants and then "any other address you expect a client to use". That last line is the half a packager forgets, and lnd is the page's own passthrough exemplar: it shipped SANs for the container address, the bridge and loopback, so every wallet dialing the LAN address, the `.local` name or an onion got a certificate naming none of them. The example now takes the external half from the interface, so it follows the addresses an operator adds and removes, and notes that `getSslCertificate` rejects a WAN IPv4.

Also adds the sentence that would have caught the third defect in that PR: reissuing the file is only half the job when the daemon reads its TLS pair once at startup.

### Not addressed here

`exclude`'s semantics look like a bug rather than a design — the type's own doc comment calls it "a nested filter whose matches are *removed* from the result (logical NOT)", which describes the behaviour it does not have. Changing it would alter every existing call site, so this PR documents the behaviour as it ships and leaves the call to you. Same for the `Filter.predicate` doc comment in `filledAddress.ts`, which is source rather than docs and would want a `master` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
