### PR TITLE
docs(start-core): describe what Filter.exclude and .nonLocal actually do

### DIFF
--- a/shared-libs/ts-modules/start-core/lib/util/filledAddress.ts
+++ b/shared-libs/ts-modules/start-core/lib/util/filledAddress.ts
@@ -51,20 +51,28 @@ type FilterKinds =
 /**
  * Describes which hostnames to include (or exclude) when filtering a `Filled` address.
  *
- * Every field is optional — omitted fields impose no constraint.
- * Filters are composable: the `.filter()` method intersects successive filters,
- * and the `exclude` field inverts a nested filter.
+ * Every field is optional — omitted fields impose no constraint. Fields set
+ * together are an intersection, and `.filter()` intersects successive filters;
+ * {@link Filled.matchesAny} is the union. Prefer the shorthands
+ * ({@link Filled.nonLocal}, {@link Filled.public}, {@link Filled.bridge}) and
+ * these declared fields over {@link Filter.predicate}.
  */
 export type Filter = {
   /** Keep only hostnames with the given visibility. `'public'` = externally reachable, `'private'` = LAN-only. */
   visibility?: 'public' | 'private'
-  /** Keep only hostnames whose metadata kind matches. A single kind or array of kinds. `'ip'` expands to `['ipv4','ipv6']`, `'domain'` matches both `'private-domain'` and `'public-domain'`. */
+  /** Keep only hostnames of the given kind — a single kind or an array; see {@link FilterKinds}. `'ip'` expands to `['ipv4','ipv6']`, `'domain'` matches both `'private-domain'` and `'public-domain'`. */
   kind?: FilterKinds | FilterKinds[]
-  /** Arbitrary predicate — hostnames for which this returns `false` are excluded. */
+  /** Escape hatch for a condition the declared fields cannot express — hostnames for which this returns `false` are excluded. */
   predicate?: (h: HostnameInfo) => boolean
   /** Keep only plugin hostnames provided by this package. Implies `kind: 'plugin'`. */
   pluginId?: PackageId
-  /** A nested filter whose matches are *removed* from the result (logical NOT). */
+  /**
+   * Drops every hostname matching **any** field of the nested filter, not only
+   * those matching all of them: `exclude: { kind: 'ipv4', visibility: 'public' }`
+   * removes every IPv4 *and* every public address. To subtract one combination,
+   * union its complements with {@link Filled.matchesAny} instead —
+   * `matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }])`.
+   */
   exclude?: Filter
 }
 
@@ -153,7 +161,7 @@ type FormatReturnTy<
  * matching subset of hostnames:
  *
  * ```ts
- * addresses.nonLocal                         // exclude localhost & link-local
+ * addresses.nonLocal                         // drop loopback, link-local & bridge
  * addresses.public                           // only publicly-reachable hostnames
  * addresses.filter({ kind: 'domain' })       // only domain-name hostnames
  * addresses.filter({ visibility: 'private' }) // only LAN-reachable hostnames
@@ -198,7 +206,7 @@ export type Filled<F extends Filter = {}> = {
     filters: [...NewFilters],
   ) => Filled<NewFilters[number] & F>
 
-  /** Shorthand filter that excludes `localhost` and IPv6 link-local addresses — keeps only network-reachable hostnames. */
+  /** Shorthand filter that excludes loopback, IPv6 link-local, and LXC bridge addresses — keeps what a client off the box can reach. */
   nonLocal: Filled<typeof nonLocalFilter & Filter>
   /** Shorthand filter that keeps only publicly-reachable hostnames (those with `public: true`). */
   public: Filled<typeof publicFilter & Filter>
@@ -207,7 +215,7 @@ export type Filled<F extends Filter = {}> = {
 }
 export type FilledAddressInfo = AddressInfo & Filled
 
-/** A {@link ServiceInterface} whose `addressInfo` is a {@link Filled} address — carrying the `filter`/`format`/`nonLocal`/`public`/`toUrl` helpers. */
+/** A {@link ServiceInterface} whose `addressInfo` is a {@link Filled} address — carrying its filter, format and URL helpers. */
 export type FilledServiceInterface = Omit<ServiceInterface, 'addressInfo'> & {
   addressInfo: FilledAddressInfo
 }
@@ -359,7 +367,7 @@ function enabledAddresses(addr: DerivedAddressInfo): HostnameInfo[] {
 }
 
 /**
- * Filters out localhost and IPv6 link-local hostnames from a list.
+ * Filters out loopback, IPv6 link-local, and LXC bridge hostnames from a list.
  * Equivalent to the `nonLocal` filter on `Filled` addresses.
  */
 export function filterNonLocal(hostnames: HostnameInfo[]): HostnameInfo[] {
@@ -439,7 +447,7 @@ export const filledAddress = (
 
 /**
  * Enrich a raw {@link Host} so each single-port binding's exported interfaces
- * carry a {@link Filled} address (`filter`/`format`/`nonLocal`/`public`/`toUrl`).
+ * carry a {@link Filled} address, with its filter, format and URL helpers.
  * Backs the object returned by `sdk.host.get`/`getOwn`. Port-range bindings are
  * left untouched — a `RangeServiceInterface` has no per-address `AddressInfo`.
  */


### PR DESCRIPTION
Source counterpart to [#3822](https://github.com/Start9Labs/start-technologies/pull/3822), which fixed the same two things in the guide. These are the comments an editor and an agent actually read, and both described behaviour the code does not have.

### `exclude`

Documented as "a nested filter whose matches are *removed* from the result (logical NOT)". It drops anything matching **any** field of the nested filter, so the reading that comment invites —

```ts
addresses.filter({ exclude: { kind: 'ipv4', visibility: 'public' } }) // "not a public IPv4"
```

— also removes every LAN IPv4 and every domain. Over a nine-address set covering both IP families, mDNS, a public domain and an onion, that returns 2 entries where 8 were intended. The comment now says what it does and points at the union-of-complements form that works.

### `nonLocal`

Documented as excluding "`localhost` and IPv6 link-local addresses". `nonLocalFilter` is `{ exclude: { kind: ['localhost', 'link-local', 'bridge'] } }` — it drops bridge addresses too, which is the difference between reaching a sibling container and not. The claim stood in three places: the shorthand's own comment, the `Filled` example block, and `filterNonLocal`.

### `kind`

Documented as matching "hostnames whose metadata kind matches", but `'localhost'` matches the hostname string (`localhost`/`127.0.0.1`/`::1`) and `'bridge'` matches `metadata.gateway === 'lxcbr0'`. It now points at `FilterKinds`, which enumerates each correctly.

### `predicate`

Ranked on the type itself so it reads as the escape hatch rather than a peer of the declared fields.

### `Filled` helper lists

`FilledServiceInterface` and `fillHost` each enumerate the helpers a `Filled` carries, and both lists predate `matchesAny` and `bridge`. They now point at the type rather than restating its members.

### Verification

Comment-only; `tsc --noEmit` and `prettier --check` are clean, and no generated bindings are involved. Behaviour was checked by running `filterRec` over a fixture covering both IP families, mDNS, a public domain, an onion, loopback, link-local and the bridge:

- `exclude: { kind: 'ipv4', visibility: 'public' }` keeps 3 of 10 — every IPv4 and every public address gone.
- `matchesAny([{ visibility: 'private' }, { exclude: { kind: 'ipv4' } }])` drops exactly the one public IPv4.
- `.nonLocal` and `filterNonLocal` return the same set, loopback / link-local / bridge removed.

### Not addressed here

`exclude`'s semantics still look like a bug rather than a design, and this PR documents them rather than changing them — every existing call site would move. Your call whether that is worth a follow-up; [lnd-startos#189](https://github.com/Start9Labs/lnd-startos/pull/189) is the only place I know of that wanted the other behaviour, and it uses `matchesAny`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
