### PR TITLE
docs(start-sdk): the address filters do not narrow the hostname type

### DIFF
--- a/projects/start-sdk/docs/src/main.md
+++ b/projects/start-sdk/docs/src/main.md
@@ -166,7 +166,7 @@ addresses.nonLocal.filter({ kind: 'domain' }) // domains, off-box only
 addresses.matchesAny([{ kind: 'mdns' }, { kind: 'domain' }]) // either one
 ```
 
-`predicate` is the escape hatch for what those cannot express; it is opaque to the type narrowing the declared forms give you.
+`predicate` is the escape hatch for what those cannot express; it hides its condition in a function body, where the declared forms state theirs inline.
 
 **`exclude` drops anything matching _any_ field of the nested filter**, so `exclude: { kind: 'ipv4', visibility: 'public' }` removes every IPv4 _and_ every public address, not just the public IPv4s. Union the complements instead:
 


### PR DESCRIPTION
Targets `live-docs`: the sentence is published. Source counterpart is [#3823](https://github.com/Start9Labs/start-technologies/pull/3823), which drops the same rationale from `Filter.predicate`'s doc comment.

### The claim

§ Narrowing the set ranks `predicate` last on the grounds that "it is opaque to the type narrowing the declared forms give you". No filter form narrows anything.

`Filled<F>`'s `F` is a phantom parameter — `hostnames` is declared `HostnameInfo[]`, and `format` resolves `FormatReturnTy<{}, Format>`, `{}` rather than `F`, so `FilterReturnTy` is only ever instantiated at the empty filter. Both lines read the same way in the `.d.ts` built under `projects/start-sdk/dist/`. A tsc probe, which compiles clean:

```ts
const domainsOnly = a.filter({ kind: 'domain' }).hostnames
const probe: (typeof domainsOnly)[number]['metadata']['kind'] = 'ipv4'
```

The same alias rejects a bogus kind, so the probe is not vacuous — it resolves to the full `'ipv4' | 'ipv6' | 'mdns' | 'private-domain' | 'public-domain' | 'plugin'` union after the filter. A type-guard `predicate` and `format('hostname-info')` behave identically.

`FilterReturnTy` even carries a branch for a type-guard `predicate`, so the claim is backwards in both directions: nothing narrows, and were the machinery wired up a predicate would narrow alongside `kind` and `visibility`.

### The fix

Ranking `predicate` last is still right, so this keeps the ranking on a reason that holds — a declared field states its condition inline, a predicate hides it in a function body. Nothing else in the section changes; the `.nonLocal` row and the `exclude` paragraph were verified by running `filterRec` over a fixture and are correct as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
