### PR TITLE
docs(start-os): per-service outbound gateway overrides the system-wide default

### DIFF
--- a/projects/start-os/docs/src/cli-reference.md
+++ b/projects/start-os/docs/src/cli-reference.md
@@ -276,7 +276,7 @@ Cancel a pending install or download.
 
 ### `start-cli package set-outbound-gateway <PACKAGE> [GATEWAY]`
 
-Override the outbound gateway for a specific service.
+Override the outbound gateway for a specific service, taking precedence over the system-wide default.
 
 ### `start-cli package action run <PACKAGE_ID> <ACTION_ID> <INPUT>`
 
@@ -411,7 +411,7 @@ Rename a gateway.
 
 ### `start-cli net gateway set-default-outbound <GATEWAY>`
 
-Set the default outbound gateway for all services.
+Set the system-wide default outbound gateway, used by every service without its own override.
 
 ### `start-cli net gateway set-secure <GATEWAY> [SECURE]`
 

--- a/projects/start-os/docs/src/outbound-vpn.md
+++ b/projects/start-os/docs/src/outbound-vpn.md
@@ -22,16 +22,16 @@ Both options hide your home IP address, and in both cases the provider knows who
 
 ## Set System-Wide Default Gateway
 
-By default, StartOS dynamically selects which gateway to use for outbound traffic for optimal performance ("Auto" mode). You can override this under `System > Gateways > Outbound Traffic` by switching from "Auto" to a specific gateway. This forces _all_ outbound traffic for everything on the server through the selected gateway.
+By default, StartOS dynamically selects which gateway to use for outbound traffic for optimal performance ("Auto" mode). You can override this under `System > Gateways > Outbound Traffic` by switching from "Auto" to a specific gateway. This sets the system-wide default: every service uses it, except services with their own [per-service override](#route-individual-services-through-vpn), which keep their own gateway.
 
 ## IPv6 leak prevention
 
-StartOS treats IPv6 outbound routing the same way as IPv4: the default gateway is chosen by route metric, and you can pin all traffic to a specific gateway under `System > Gateways > Outbound Traffic`.
+StartOS treats IPv6 outbound routing the same way as IPv4: the default gateway is chosen by route metric, and you can set the system-wide default under `System > Gateways > Outbound Traffic`.
 
 If the gateway you select for outbound traffic can't carry IPv6 — for example a commercial VPN whose WireGuard config has no IPv6 address — StartOS **drops** the server's outbound IPv6 rather than letting it fall back to your ISP connection, so your real IPv6 address never leaks around the VPN. (The drop is a blackhole in that gateway's own routing table.) A gateway that does provide IPv6 (such as a StartTunnel with a [delegated prefix](/start-tunnel/ipv6.html)) carries IPv6 normally; on a server with no native ISP IPv6, such a tunnel can also become your IPv6 default before you pin it, so select an outbound gateway explicitly if you want to control which one.
 
 ## Route Individual Services Through VPN
 
-You can override the system default on a per-service basis by navigating to a service and going to **Actions > Set Outbound Gateway**. This lets you route individual services through different VPNs while leaving others on the default.
+A service's own setting always takes precedence over the system-wide default — whether that default is Auto or a pinned gateway. To set one, navigate to a service and go to **Actions > Set Outbound Gateway**. This lets you route individual services through different VPNs while leaving others on the default; choose "System default" in that dialog to clear the override and follow the system-wide setting again.
 
-For example, you could route your Bitcoin node through Mullvad for privacy while leaving Nextcloud on the default gateway for better performance.
+For example, you could route your Bitcoin node through Mullvad for privacy while leaving Nextcloud on the default gateway for better performance — even with Mullvad also pinned as the system-wide default.

--- a/projects/start-os/docs/src/outbound-vpn.md
+++ b/projects/start-os/docs/src/outbound-vpn.md
@@ -22,7 +22,7 @@ Both options hide your home IP address, and in both cases the provider knows who
 
 ## Set System-Wide Default Gateway
 
-By default, StartOS dynamically selects which gateway to use for outbound traffic for optimal performance ("Auto" mode). You can override this under `System > Gateways > Outbound Traffic` by switching from "Auto" to a specific gateway. This sets the system-wide default: every service uses it, except services with their own [per-service override](#route-individual-services-through-vpn), which keep their own gateway.
+By default, StartOS dynamically selects which gateway to use for outbound traffic for optimal performance ("Auto" mode). You can override this under `System > Gateways > Outbound Traffic` by switching from "Auto" to a specific gateway. This sets the system-wide default: it covers everything on the server — every service, and the OS itself (registry connections, package downloads) — except services with their own [per-service override](#route-individual-services-through-vpn), which keep their own gateway.
 
 ## IPv6 leak prevention
 


### PR DESCRIPTION
## Summary

The StartOS user book claimed that pinning a system-wide outbound gateway "forces _all_ outbound traffic for everything on the server" — which contradicts the per-service **Set Outbound Gateway** override documented on the same page. This PR makes the intended precedence explicit everywhere it's described:

- `outbound-vpn.md`: pinning a gateway sets a *default*; services with their own override keep their own gateway. The per-service section now states outright that the service's setting always takes precedence over the system-wide default (Auto or pinned), and how to clear an override ("System default" in the dialog).
- `cli-reference.md`: `package set-outbound-gateway` says it takes precedence over the system-wide default; `net gateway set-default-outbound` says it's a default used by services without their own override.

Docs-only change (`projects/start-os/docs/`); no code touched.

## Follow-up worth flagging

While verifying before writing this, I checked the actual routing and **the code currently does not implement this precedence** when a global gateway is *pinned*:

- Per-package overrides install `ip rule add from <service-ip> lookup <table> priority 100` (`net_controller.rs`).
- A pinned global default installs a selector-less catch-all at `priority 75` (`gateway.rs` `apply_default_outbound`).

Linux evaluates policy rules in ascending priority order, so the catch-all at 75 matches first and its table lookup succeeds — the priority-100 rule is never reached. Verified empirically on a VM: with rules `75: from all lookup 2001` and `100: from 203.0.113.10 lookup 2002`, `ip route get` from the package IP resolves via table 2001, not the package's table. In Auto mode (no pin) there is no 75 rule, so per-service overrides work as documented.

Happy to take the routing fix (e.g. installing per-package rules below 75) as a follow-up if you want it.