### PR TITLE
fix(sdk): drop the inert `type` option from mountDependency

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@
 - **Minimum StartOS version is now `0.4.0.2`**, which is what a package built
   with this SDK writes as its manifest `osVersion`
 
+- **Breaking — `mountDependency` no longer accepts `type`.** A dependency mount
+  has been a directory since StartOS 0.4.0-alpha.16 disabled file mounts on
+  dependencies, so the option was silently doing nothing; passing it is now a
+  compile error. To reach a single file, mount the directory holding it.
+  `mountVolume` and `mountAssets` still take `type`
+
 - `effects.getServicePortForward` resolves `null` instead of throwing when the
   binding does not exist. Prefer `sdk.host.getBridgeAddress` to reach a
   dependency; this is raw allocator metadata

--- a/projects/start-sdk/lib/mainFn/Mounts.ts
+++ b/projects/start-sdk/lib/mainFn/Mounts.ts
@@ -60,7 +60,7 @@ type DependencyOpts<Manifest extends T.SDKManifest> = {
   volumeId: Manifest['volumes'][number]
   /** Whether or not the resource should be readonly for this subcontainer */
   readonly: boolean
-} & SharedOptions
+} & Omit<SharedOptions, 'type'>
 
 /**
  * Immutable builder for declaring filesystem mounts into a subcontainer.
@@ -112,7 +112,10 @@ export class Mounts<Manifest extends T.SDKManifest> {
   }
 
   /**
-   * Add a mount from a dependency package's volume.
+   * Add a mount from a dependency package's volume. The mount is always a
+   * directory — StartOS does not bind a dependency's file. To reach a single
+   * file, mount the directory holding it.
+   *
    * @param options - Dependency ID, volume ID, mountpoint, readonly flag, and optional subpath
    * @returns A new Mounts instance with this dependency mount added
    */
@@ -178,7 +181,6 @@ export class Mounts<Manifest extends T.SDKManifest> {
             volumeId: d.volumeId,
             subpath: d.subpath,
             readonly: d.readonly,
-            filetype: d.type ?? 'directory',
             idmap: normalizeIdmap(d.idmap),
           },
         })),


### PR DESCRIPTION
`DependencyOpts` inherited `type` from `SharedOptions` and documented it as choosing between a file and a directory mount. For a dependency it has never done anything: `MountTarget.filetype` is `#[serde(skip_deserializing)]` and `SubContainer.mount` hardcodes `'directory'` for a pointer mount — both sides of the decision alpha.16 took when it disabled file mounts on dependencies.

So a package can ask for a file mount, typecheck, pack, install, and only then fail, with a bare `mount exited with exit status: 32` from the bind of a non-directory onto the directory that got created instead. Nothing in the types, the docs, or the error names the actual constraint. That is what packaging Stratum V2's Bitcoin Core IPC socket ran into — the socket is simply not mountable, and finding out why meant reading `dependency.rs`.

This makes it a compile error:

- `DependencyOpts` is now `& Omit<SharedOptions, 'type'>`.
- `build()` stops emitting `filetype` on a pointer, which `MountOptionsPointer` already (correctly) had no field for and the host discards anyway.
- `mountDependency`'s doc comment says the mount is always a directory, and to mount the directory holding a file you need to reach.

`mountVolume` and `mountAssets` are untouched — `type` still works there.

The workaround for a caller that was passing it: mount the parent directory. In the Stratum V2 case the JD Client's `data_dir` points at a directory on the package's own volume holding a symlink into the mounted one, which it needed regardless — upstream hardcodes the socket filename and bitcoind publishes a different one.
