### PR TITLE
docs(start-wrt): point rpc-toolkit link at the in-repo crate

### DIFF
--- a/projects/start-wrt/backend/ARCHITECTURE.md
+++ b/projects/start-wrt/backend/ARCHITECTURE.md
@@ -4,7 +4,7 @@ Rust workspace powering the StartWRT router daemon and CLI. Three crates: `ctrl`
 
 ## Transport
 
-HTTP server on ports 80 (HTTP) and 443 (HTTPS, if TLS setup succeeds). JSON-RPC 2.0 at `POST /rpc/v1` via [rpc-toolkit](https://github.com/Start9Labs/rpc-toolkit). Session cookie authentication with rate limiting.
+HTTP server on ports 80 (HTTP) and 443 (HTTPS, if TLS setup succeeds). JSON-RPC 2.0 at `POST /rpc/v1` via [rpc-toolkit](../../../shared-libs/crates/rpc-toolkit). Session cookie authentication with rate limiting.
 
 Additional routes:
 


### PR DESCRIPTION
`projects/start-wrt/backend/ARCHITECTURE.md` linked `rpc-toolkit` to `github.com/Start9Labs/rpc-toolkit`. The crate lives in this repo at `shared-libs/crates/rpc-toolkit` and both backends consume it by path; the standalone repo is a stale copy we're looking at archiving. Repointed the link at the in-repo crate, matching how the other `projects/*` docs link into `shared-libs/crates/`.