### PR TITLE
docs(start-os): document reading and downloading logs in the UI

### DIFF
--- a/projects/start-os/docs/src/README.md
+++ b/projects/start-os/docs/src/README.md
@@ -52,6 +52,7 @@ StartOS is a sovereign computing platform that makes it easy to run a personal s
 
 ## System
 
+- [Logs](logs.md)
 - [Server Name](server-name.md)
 - [SSH](ssh.md)
 - [SMTP](smtp.md)

--- a/projects/start-os/docs/src/SUMMARY.md
+++ b/projects/start-os/docs/src/SUMMARY.md
@@ -67,6 +67,7 @@
 
 # System
 
+- [Logs](logs.md)
 - [Server Name](server-name.md)
 - [SSH](ssh.md)
 - [SMTP](smtp.md)

--- a/projects/start-os/docs/src/cli-reference.md
+++ b/projects/start-os/docs/src/cli-reference.md
@@ -70,7 +70,7 @@ Update the server firmware.
 
 ### `start-cli server logs`
 
-Display StartOS system logs.
+Display StartOS system logs. These are also readable and downloadable in the web interface under **System** — see [Logs](logs.md).
 
 - `-l, --limit <N>` — Max entries
 - `-f, --follow` — Stream in real-time
@@ -236,7 +236,7 @@ Remove a package and its data.
 
 ### `start-cli package logs <ID>`
 
-Display logs from a service.
+Display logs from a service. These are also readable and downloadable on the service's **Logs** tab in the web interface — see [Logs](logs.md).
 
 - `-l, --limit <N>` — Max entries
 - `-f, --follow` — Stream in real-time

--- a/projects/start-os/docs/src/faq.md
+++ b/projects/start-os/docs/src/faq.md
@@ -101,4 +101,4 @@ If time sync still fails, please [contact support](https://start9.com/contact).
 
 ## Issue with a particular service
 
-If a service is misbehaving or crashing, check the logs for that service. Look for any errors that might explain the problem. Often, the solution is to restart the service by clicking "Restart". If the issue persist, [contact support](https://start9.com/contact).
+If a service is misbehaving or crashing, check the [logs](logs.md) for that service — open the service and select its **Logs** tab. Look for any errors that might explain the problem. Often, the solution is to restart the service by clicking "Restart". If the issue persist, [contact support](https://start9.com/contact).

--- a/projects/start-os/docs/src/logs.md
+++ b/projects/start-os/docs/src/logs.md
@@ -1,0 +1,38 @@
+# Logs
+
+Every service, and StartOS itself, streams its logs live in the web interface. You can read them there, scroll back through older entries, and download a copy to keep or send to support. Nothing needs to be installed, and you do not need [SSH](ssh.md) or the command line.
+
+## Service Logs
+
+Open the service from the dashboard and select the **Logs** tab. New lines appear as the service writes them.
+
+This is where a misbehaving service explains itself: a failed [health check](health-checks.md), a backend it cannot reach, a setting it rejected, or a crash on startup.
+
+## OS and Kernel Logs
+
+Go to **System**:
+
+- **OS Logs** — StartOS itself: the daemon, service supervision, networking, and updates.
+- **Kernel Logs** — the Linux kernel: hardware, disks, drivers, and out-of-memory events.
+
+## Reading a Log
+
+The view follows the end of the log, so new lines appear as they are written. Scroll up to read older entries — more are loaded as you reach the top. **Scroll to bottom** returns to the end and resumes following.
+
+## Downloading Logs
+
+**Download**, at the bottom of any log view, saves the most recent 10,000 entries as an HTML file that opens in any browser, colored the same as it appears onscreen. The file is named for what it came from — `<service-id>-logs.html`, `os-logs.html`, or `kernel-logs.html`.
+
+Attach that file when you [contact support](https://start9.com/contact). It carries far more than the last error onscreen, and it is the fastest way to get an answer.
+
+## From the Command Line
+
+The web interface is the primary way to read logs. [`start-cli`](cli-reference.md) covers the cases it cannot reach — a server that will not boot far enough to serve the UI, or a log you want to pipe into another tool:
+
+```bash
+start-cli package logs <ID>
+start-cli server logs
+start-cli server kernel-logs
+```
+
+In **Diagnostic Mode**, where StartOS has failed to start normally, the diagnostic page offers **View logs**. There is no download button there, so `start-cli diagnostic logs` is how to capture those. See the [FAQ](faq.md#startos-boots-into-diagnostic-mode).

--- a/projects/start-os/docs/src/service-containers.md
+++ b/projects/start-os/docs/src/service-containers.md
@@ -10,7 +10,7 @@ Every service on StartOS runs inside its own isolated LXC container. Within each
 There are several reasons you might want a shell inside a running service container:
 
 - **Running CLI tools** — Many services ship their own command-line utilities (e.g., `bitcoin-cli`, `lncli`) that can be invoked directly inside the container.
-- **Debugging** — Inspect logs, running processes, or file state when a service is misbehaving.
+- **Debugging** — Inspect running processes or file state when a service is misbehaving. Logs do not require a shell; they are on the service's [Logs](logs.md) tab in the UI.
 - **Querying a database** — Run ad-hoc queries against a service's database (e.g., `sqlite3`, `psql`, `redis-cli`) that aren't exposed through the UI.
 - **Inspecting configuration** — View the generated config files or environment variables a service is actually running with.
 - **Advanced recovery** — In rare cases, manually repair data or state that cannot be fixed through the StartOS UI.


### PR DESCRIPTION
## Problem

StartOS's docs never mentioned the log viewer. Search the book for logs and the only page describing how to obtain them is `cli-reference.md` — `start-cli package logs <ID>` and `start-cli server logs`.

That is what everyone retrieves, Dux included. A customer whose service was throwing a 500 was told to SSH in and run `start-cli package logs open-webui` to produce a file that the web interface hands over in one click. StartWRT's docs already document its log viewer and download button; StartOS's did not.

## Change

New `logs.md`, in the System section and on the landing index:

- **Service Logs** — the service's **Logs** tab.
- **OS and Kernel Logs** — **System > OS Logs / Kernel Logs**.
- **Reading a Log** — live tail, scrollback loading at the top, **Scroll to bottom**.
- **Downloading Logs** — **Download** writes the last 10,000 entries as an HTML file (`<service-id>-logs.html`, `os-logs.html`, `kernel-logs.html`), and that is the file to attach to a support request.
- **From the Command Line** — `start-cli` last, scoped to what the UI cannot reach: a server in Diagnostic Mode (whose **View logs** page has no download button), or piping into another tool.

Cross-links, so the pages people actually land on route back to the UI:

- Both `start-cli` log subcommands in `cli-reference.md`.
- The FAQ's "Issue with a particular service" answer.
- `service-containers.md`, whose **Debugging** bullet listed "inspect logs" as a reason to open a shell inside a container.

Targets `live-docs` — the log viewer and its Download button ship in 0.4.0, so this corrects what is already published rather than describing something unreleased.