### PR TITLE
docs(start-sdk): say that Start9 reviews a submission as a PR on the fork

### DIFF
--- a/projects/start-sdk/docs/src/publishing.md
+++ b/projects/start-sdk/docs/src/publishing.md
@@ -20,8 +20,8 @@ The community registries, in promotion order:
 ### Initial Submission
 
 1. **Email <submissions@start9.com>** with a link to your public GitHub repository.
-2. Start9 **forks** your repo into the [Start9-Community GitHub organization](https://github.com/Start9-Community) and replies with any feedback.
-3. Address feedback by opening PRs **against the Start9-Community fork**, not your original repo. The fork becomes the upstream for the community pipeline from that point on.
+2. Start9 **forks** your repo into the [Start9-Community GitHub organization](https://github.com/Start9-Community) and reviews it against this guide — correctness, conformance, docs, localization, CI. The review lands as a pull request on the fork, so you see every change before it merges.
+3. **The fork is the upstream from that point on.** Anything left for you to fix, and every later version, is a PR against the fork — not your original repo.
 
 ### The Pipeline
 


### PR DESCRIPTION
`publishing.md` § Initial Submission described a feedback loop the submitter drives — Start9 replies with comments, the developer opens PRs to address them. Intake doesn't work that way. Start9 audits the fork and lands the conformance work itself as a pull request on the fork: README and `instructions.md` structure, i18n coverage across the full locale set, `manifest.packageRepo`, CI branch triggers, SDK version, and whatever the runtime audit turns up.

A submitter reading the old step 2 has no reason to expect a PR rewriting their package to appear on the fork days later. Step 2 now says the review lands as a PR they can read before it merges.

Step 3 kept only half of what a submitter needs — that the fork is the upstream — while framing the whole step around addressing feedback. It now leads with the fork being upstream and covers both cases that follow from it: anything left for the developer to fix, and every later version.

Targets `live-docs`: this corrects the published page, and nothing about it depends on unshipped software.