### PR TITLE
ci: drop the runner's Microsoft apt sources before apt-get update

### DIFF
--- a/.github/actions/publish-apt/action.yml
+++ b/.github/actions/publish-apt/action.yml
@@ -42,6 +42,8 @@ runs:
     - name: Install apt publishing tools
       shell: bash
       run: |
+        # The runner image's Microsoft apt sources 403 intermittently, and one failing source fails the whole update.
+        grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
         sudo apt-get update -qq
         sudo apt-get install -y -qq s3cmd dpkg-dev apt-utils
 

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -10,7 +10,8 @@ runs:
 
     - name: Install dependencies
       run: |
-        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+        # The runner image's Microsoft apt sources 403 intermittently, and one failing source fails the whole update.
+        grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
         sudo apt-get update
         sudo apt-get install -y --no-install-recommends \
           build-essential \

--- a/.github/workflows/start-wrt.yaml
+++ b/.github/workflows/start-wrt.yaml
@@ -153,6 +153,8 @@ jobs:
       # every product, so this install lives here instead).
       - name: Install OpenWrt build dependencies
         run: |
+          # The runner image's Microsoft apt sources 403 intermittently, and one failing source fails the whole update.
+          grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
           sudo apt-get update
           sudo apt-get install -y \
             build-essential clang flex bison g++ gawk gcc-multilib \


### PR DESCRIPTION
`apt-get update` fetches metadata for every configured source and exits 100 if any one of them fails. The step shell runs with `-e`, so a single unreachable third-party source aborts the job before `apt-get install` runs — even when nothing we install comes from that source.

The GitHub runner image ships an azure-cli source on `packages.microsoft.com` that intermittently answers 403. It took down the x86 half of a `cln-startos` release build today ([run](https://github.com/Start9Labs/cln-startos/actions/runs/33003013715)), skipping `Publish` and leaving the version unreleased:

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/repos/azure-cli noble InRelease' is no longer signed.
##[error]Process completed with exit code 100.
```

Every package repo in both registries calls `setup-build-env`, so this is a fleet-wide flake, not a cln one. arm passed on the same commit, so it is intermittent rather than a hard break.

## The change

`setup-build-env` already removed `microsoft-prod.list`, but azure-cli is a **separate file**, so the hardcoded filename missed it. Matching on the host instead covers every Microsoft source whatever it is named and whether it is a `.list` or a deb822 `.sources`:

```bash
grep -rl 'packages\.microsoft\.com' /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f || true
```

Two properties worth stating, since both are easy to get wrong here:

- **It cannot remove the Ubuntu mirror.** A filename glob such as `*azure*` would match `azure.archive.ubuntu.com` config and break every build. Matching the Microsoft host cannot. (On these runners the Ubuntu mirrors come from `/etc/apt/apt-mirrors.txt`, not `sources.list.d`, but the host match is what makes that irrelevant.)
- **A no-match run still exits 0.** `grep` returns 1 when it finds nothing, which under `-o pipefail` would fail the pipeline and abort the step — the trailing `|| true` is what keeps a runner image with no Microsoft source from failing. Verified under the exact step shell (`bash --noprofile --norc -e -o pipefail`).

## Scope

Applied to the three places that run `apt-get update` on the runner itself: `setup-build-env`, `publish-apt`, and start-wrt's OpenWrt host-deps step.

Left alone: `start-registry.yaml` and `startos-iso.yaml` both run `apt-get update` inside a container whose `sources.list.d` carries no Microsoft repo.
