### PR TITLE
docs(sdk): say where the start-cli installer puts the binary

### DIFF
--- a/projects/start-sdk/docs/src/environment-setup.md
+++ b/projects/start-sdk/docs/src/environment-setup.md
@@ -141,6 +141,8 @@ Install using the automated installer script:
 curl -fsSL https://start9.com/start-cli/install.sh | sh
 ```
 
+On Debian and its derivatives — Ubuntu, Raspberry Pi OS, Linux Mint — the script adds the Start9 apt repository and installs the `start-cli` package to `/usr/bin`, so `sudo apt update && sudo apt upgrade` picks up later releases. On macOS and every other Linux distribution it downloads the release binary into `~/.local/bin` and adds that directory to your `PATH`.
+
 ## Git
 
 [Git](https://git-scm.com/) is used by `start-cli s9pk init-workspace` to fetch the Start9 monorepo — the packaging guide, and the SDK and OS source behind it — and to keep it up to date afterward.


### PR DESCRIPTION
`https://start9.com/start-cli/install.sh` now installs the `start-cli` package from the Start9 apt repository on Debian and its derivatives, and falls back to the release binary in `~/.local/bin` everywhere else. The command in the guide is unchanged; where the binary lands, and how it is updated, is not.

Installer change: https://github.com/Start9Labs/start9.com/pull/66

`prettier --check` clean.
