### PR TITLE
docs(start-os): give the download checks a result to read

### DIFF
--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -10,23 +10,141 @@ This guide is for flashing StartOS to a USB drive, then installing it onto a des
 
 1.  Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) to find the latest version of StartOS.
 
-1.  Under "ISO Downloads", select the ISO for your architecture. StartOS is available in x86_64 (AMD64), aarch64 (ARM64), and RISC-V (RVA23). For x86_64 and aarch64, two variants are available:
+1.  Under "Image Downloads", select the image for your hardware. StartOS is available in x86_64 (AMD64), aarch64 (ARM64), and RISC-V (RVA23). For x86_64 and aarch64, two variants are available:
     - **Standard**: Includes proprietary firmware and drivers for broader hardware compatibility, including display and wireless. Recommended for most users.
 
     - **Slim (FOSS-only)**: 100% open source, containing **no** proprietary firmware or drivers. Only compatible with certain hardware, such as the Start9 Server Pure.
 
-1.  Verify the SHA256 checksum against the one listed on GitHub (optional but recommended).
-    - **Mac**. Open a terminal and run:
+## Verify your download
 
-          openssl dgst -sha256 <filename>.iso
+Before you flash it, check that the file on your computer is exactly the file Start9 published — that nothing was damaged on the way down, and nothing was swapped for it. It takes about a minute, and it is worth doing before you erase a drive.
 
-    - **Linux**. Open a terminal and run:
+You do not need to understand what any of this means. Follow the three steps and read the one word at the end.
 
-          sha256sum <filename>.iso
+### 1. Find your file on the release page
 
-    - **Windows**. Open PowerShell and run:
+On the [release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1), scroll down to **OS Images Checksums**, then to the block under **SHA-256**. It holds one line per image: a long code, then the filename it belongs to.
 
-          Get-FileHash <filename>.iso
+```text
+37b63c86197150866809d34b5824ae22c5fc705d4f8dc9e9750b8fa23485441a  startos-0.4.0.1-fdb27c7_x86_64-nonfree.iso
+```
+
+Rather than reading down the list, press **Ctrl + F** (**Command + F** on a Mac), paste the name of the file you downloaded, and press Enter. Your browser jumps straight to its line.
+
+### 2. Check your file against that line
+
+{{#tabs global="platform"}}
+{{#tab name="Mac"}}
+
+Select and copy that **whole line** — the long code, the spaces, and the filename together.
+
+Open Terminal: press Command + Space, type `Terminal`, and press Enter.
+
+Type this and press Enter. It points Terminal at your downloads folder:
+
+```sh
+cd ~/Downloads
+```
+
+Now type this, replacing the words `PASTE THE WHOLE LINE HERE` with what you copied — keep the quotation marks — and press Enter:
+
+```sh
+echo "PASTE THE WHOLE LINE HERE" | shasum -a 256 -c
+```
+
+{{#endtab}}
+{{#tab name="Windows"}}
+
+From that line you need its two halves separately: the long code, and the filename.
+
+Open PowerShell: press the Windows key, type `PowerShell`, and press Enter.
+
+Type this, replacing `FILENAME` with the name of the file you downloaded and `LONG CODE` with the long code from the release page — keep the quotation marks — and press Enter:
+
+```powershell
+(Get-FileHash "$HOME\Downloads\FILENAME").Hash -eq "LONG CODE"
+```
+
+{{#endtab}}
+{{#tab name="Linux"}}
+
+Select and copy that **whole line** — the long code, the spaces, and the filename together.
+
+Open a terminal, type this, and press Enter. It points the terminal at your downloads folder:
+
+```sh
+cd ~/Downloads
+```
+
+Now type this, replacing the words `PASTE THE WHOLE LINE HERE` with what you copied — keep the quotation marks — and press Enter:
+
+```sh
+echo "PASTE THE WHOLE LINE HERE" | sha256sum -c
+```
+
+{{#endtab}}
+{{#endtabs}}
+
+If your browser saved the file somewhere else, use that folder's name in place of `Downloads`.
+
+### 3. Read the answer
+
+On **Mac** and **Linux**, your file is good if the reply ends in `OK`:
+
+```text
+startos-0.4.0.1-fdb27c7_x86_64-nonfree.iso: OK
+```
+
+On **Windows**, your file is good if the reply is `True`.
+
+> [!WARNING]
+> A reply of `FAILED` or `False` means the file on your computer is **not** the one Start9 published. Do not flash it. Delete it, download it again, and check it again. If it fails a second time, stop here and ask on the [Community Hub](https://community.start9.com) before going any further.
+
+Two other replies mean the command went wrong rather than your download. Your file is neither confirmed nor rejected, so correct the command and run it again:
+
+- **`No such file or directory`**, or on Windows a red error above `False` — the command looked somewhere that does not hold your file. Check the folder name and the filename, including its ending (`.iso`, or `.img.gz` for Raspberry Pi).
+- **`no properly formatted SHA checksum lines found`** — the line was not pasted whole. Copy it again from the release page, from the first character of the long code through the last character of the filename, and make sure the spaces between them come along.
+
+### Going further: check the signature
+
+The check above proves your file matches what the release page says. A signature proves the file came from Start9 — signed with a key that sits on no Start9 server and never touches the build system, but on a maintainer's own computer. It is the check that still means something if Start9's GitHub account or web hosting were taken over.
+
+It takes longer than the checksum and needs GPG installed: [Gpg4win](https://gpg4win.org) on Windows, [GPG Suite](https://gpgtools.org) on Mac. On Linux you almost certainly have it already.
+
+**1. Get Start9's key from somewhere that is not Start9.**
+
+```sh
+gpg --keyserver hkps://keys.openpgp.org --recv-keys 5456DBFF1B9DF905041FA7765259ADFC2D63C217
+```
+
+Everything rests on that fingerprint being the right one, so confirm it somewhere else as well. The same key is published at <https://start9.com/start9.gpg>, in the [security policy](https://github.com/Start9Labs/start-technologies/blob/master/SECURITY.md), and in the Debian repository keyring on any machine already running StartOS. The more of those agree, the more sure you can be.
+
+> [!WARNING]
+> The download in the next step contains a copy of the key, as `start9.key.asc`. Do not use that one. A key that arrives alongside the signature it is checking proves nothing.
+
+**2. Download `signatures.tar.gz`** from the release page and unpack it, into the same folder as your image. It holds one signature per image, named after the image with `.start9.asc` on the end. A second signature from the person who cut the release is in there too — the `.start9.asc` one is the one to check.
+
+**3. Check your image.** Replace `FILENAME` with the name of the file you downloaded, in both places:
+
+```sh
+gpg --verify FILENAME.start9.asc FILENAME
+```
+
+**4. Read the answer.** Two things have to be true — the signature is Start9's, and the key it names is the one you confirmed in step 1:
+
+```text
+gpg: Good signature from "Start9 <security@start9.com>" [unknown]
+gpg: WARNING: This key is not certified with a trusted signature!
+gpg:          There is no indication that the signature belongs to the owner.
+Primary key fingerprint: 5456 DBFF 1B9D F905 041F  A776 5259 ADFC 2D63 C217
+```
+
+- The reply says **`Good signature from "Start9 <security@start9.com>"`**, and
+- the **`Primary key fingerprint`** line matches the fingerprint in step 1, character for character.
+
+Those two lines are the answer. The `WARNING` between them is normal and appears every time — it only means you have never personally vouched for the key, which you have no reason to have done.
+
+Anything else is a failure. **`BAD signature`** means the file is not what Start9 signed: do not flash it, delete it, and download it again. If it fails a second time, stop and ask on the [Community Hub](https://community.start9.com). **`Can't check signature: No public key`** means step 1 did not finish — run it again before drawing any conclusion about the file.
 
 ## Flash
 
@@ -76,7 +194,7 @@ A Raspberry Pi does not use the USB installer above. Instead, you flash the Star
 
 1. Visit the [Github release page](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0.1) and, from the downloads list, download the **Raspberry Pi `.img.gz`** file.
 
-1. Verify the SHA256 checksum against the one listed on GitHub (optional but recommended) — see [Download](#download) for the command for your computer. The release lists checksums for both the compressed `.img.gz` you downloaded and the `.img` inside it.
+1. Check it against the release page, exactly as in [Verify your download](#verify-your-download). The release lists a checksum for the `.img` inside the archive as well — the line you want is the one ending in `.img.gz`, because that is the file you downloaded.
 
 1. Insert your Raspberry Pi's microSD card into your computer, using a microSD card reader if needed.
 


### PR DESCRIPTION
The install guide told the reader to run `openssl dgst -sha256 <filename>.iso` and stopped. It never said what to compare the output against, where to find that, or what to do if it didn't match — so a reader who followed it exactly learned nothing about their download. These are not technical people, and 64 hex characters is not something to eyeball.

It is now its own `## Verify your download` section, three steps ending in one word:

1. Find your file's line under **OS Images Checksums → SHA-256** on the release page. Ctrl+F / Command+F the filename rather than scrolling — the block runs to ~20 lines.
2. Run the command for your OS (`Mac` / `Windows` / `Linux` tabs, `global="platform"`).
3. `OK` on Mac/Linux, `True` on Windows. Anything else and you don't flash it.

**Mac and Linux copy the whole line** — code, spaces, filename — and pipe it into `shasum -a 256 -c` / `sha256sum -c`. The release notes' SHA-256 block is already emitted in exactly the format those tools check (`checksum_block` shells out to `sha256sum`), so pasting the line intact makes the tool do the comparison instead of the reader's eyes. That is deliberate: `shasum` rejects a single space between hash and filename with `no properly formatted SHA checksum lines found`, and asking a non-technical reader to retype that spacing is a trap.

**Windows** has no `-c` equivalent, so it compares in PowerShell: `(Get-FileHash "…\FILENAME").Hash -eq "LONG CODE"` → `True` / `False`. PowerShell's `-eq` is case-insensitive for strings, so the page's lowercase code matches `Get-FileHash`'s uppercase output without the reader noticing a difference.

A failed check now carries a `[!WARNING]` telling them not to flash it, to re-download, and to stop and ask on the Community Hub if it fails twice. The two replies that mean *the command* was wrong rather than the download — wrong folder, line not pasted whole — are named separately, so neither is read as a verdict on the file.

## Signature verification

Every OS release already ships `signatures.tar.gz` — a detached, armored signature per image from the Start9 key, plus one from the maintainer who cut the release. Nothing in the docs mentioned it existed, so the strongest check we publish went unused. It is now a `### Going further: check the signature` subsection, below the checksum steps.

**Why it is worth more than the checksum.** `docs.start9.com` is deployed *by* GitHub Actions using `WEBSITE_DEPLOY_KEY`, so an attacker holding the GitHub org holds the release page and the docs alike. The signing key is in neither: `cmd_sign` runs `gpg` locally and `pre-check` requires `2D63C217` in the operator's own keyring, so the private key never enters CI or any Start9 server.

**That only holds if the key is fetched independently**, which is the part worth reviewing:

- Step 1 fetches from `hkps://keys.openpgp.org` — a third party outside Start9's control — and names three further corroboration points (`start9.com/start9.gpg`, `SECURITY.md`, and the apt keyring on any machine already running StartOS).
- The copy bundled inside `signatures.tar.gz` as `start9.key.asc` is called out in a `[!WARNING]` as the one *not* to use. It is sitting right there in the archive and is the obvious wrong move.

**Interpretation is the other trap.** `gpg --verify` prints `WARNING: This key is not certified with a trusted signature!` on a perfectly good signature, every time. The section shows the real output verbatim, says which two lines are the answer (`Good signature from "Start9 <security@start9.com>"` and the `Primary key fingerprint` line), and states plainly that the WARNING between them is expected. `BAD signature` and `Can't check signature: No public key` are distinguished, since only the first is a verdict on the file.

## Also

`Under "ISO Downloads"` → `Under "Image Downloads"`. That section has been called Image Downloads since the release notes started listing the Raspberry Pi `.img.gz`.

## Verified, not assumed

- `shasum -a 256 -c` and `sha256sum -c` exercised against a matching file, a tampered one, and a missing one; confirmed `shasum` hard-fails on single-space input and both accept an uppercase hash.
- Fetched the Start9 key from both keys.openpgp.org and start9.com and confirmed both match `5456 DBFF 1B9D F905 041F A776 5259 ADFC 2D63 C217`; ran `--recv-keys` in a throwaway `GNUPGHOME`.
- Reproduced the exact `gpg --verify` output against a live Start9 signature (the `stable` apt suite's `InRelease`, signed by the same key), so the block in the docs is transcribed rather than invented.
- Unpacked `signatures.tar.gz` from `start-os/v0.4.0.1` to confirm the `.start9.asc` naming.
- Book builds clean; all three tabs render.

## Branch

`live-docs` — the old text is wrong on the published site today, not just on master. The change deliberately leaves the version-pinned release link on line 11 alone and only replaces the verify step, so the backport onto master should apply without touching master's unreleased NVIDIA paragraph.

An earlier revision of this PR also moved the download links themselves into the guide, pointing at the CDN. That was dropped: keeping the checksums on GitHub while the links lived here meant the reader still had to visit GitHub, which defeated the point. The images stay on the release page, and #3850 makes that page's download list legible instead.