### PR TITLE
fix(sdk): re-check a package PR when its draft or base moves

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -90,6 +90,10 @@
 
 ### Fixed
 
+- **Scaffolded package CI builds a draft PR when it becomes ready and rebuilds
+  against every new base after retargeting.** Metadata edits preserve active
+  builds and their conclusions
+
 - **`VersionGraph` reports a missing migration path in terms a service owner can
   act on**, rather than as an assertion about the version range the host handed
   it

--- a/projects/start-sdk/docs/package-template/.github/workflows/build.yml
+++ b/projects/start-sdk/docs/package-template/.github/workflows/build.yml
@@ -3,15 +3,20 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
-    paths-ignore: ['*.md']
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ['master']
+    paths-ignore: ['*.md']
+
+permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: package-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
     uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
     # No DEV_KEY — a PR build doesn't publish, so it doesn't need the signing key.

--- a/projects/start-sdk/docs/package-template/.github/workflows/pr-retarget.yml
+++ b/projects/start-sdk/docs/package-template/.github/workflows/pr-retarget.yml
@@ -1,0 +1,18 @@
+name: Retarget Build
+
+on:
+  pull_request:
+    types: [edited]
+
+permissions: {}
+
+concurrency:
+  group: package-build-${{ github.event.changes.base && github.event.pull_request.number || format('metadata-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.changes.base && github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    uses: Start9Labs/start-technologies/.github/workflows/build.yml@master

--- a/projects/start-sdk/docs/src/project-structure.md
+++ b/projects/start-sdk/docs/src/project-structure.md
@@ -11,6 +11,7 @@ my-service-startos/
 ├── .github/
 │   └── workflows/
 │       ├── build.yml          # CI build on PR
+│       ├── pr-retarget.yml    # CI rebuild when a PR's base changes
 │       ├── tagAndRelease.yml  # Version check, tag, and release on merge
 │       ├── release.yml        # Release on manual tag push
 │       └── syncNext.yml       # Carry the base branch onto `next` on merge
@@ -90,12 +91,13 @@ These files typically require minimal modification:
 
 ### .github/workflows/
 
-Every package should include four GitHub Actions workflows that delegate to the reusable CI workflows in this monorepo (`.github/workflows/`). The CI pipeline has two automatic stages, plus an optional manual path, and a branch-hygiene job that runs alongside them:
+Every package should include five GitHub Actions workflows that delegate to the reusable CI workflows in this monorepo (`.github/workflows/`). The CI pipeline has two automatic stages, plus an optional manual path, a retarget build, and a branch-hygiene job:
 
 ```
-PR opened/updated ──> Build
+PR opened/updated/marked ready ──> Build
+PR base changed ──> Retarget Build
 PR merged to master ──> Version check ──> Tag ──> Build ──> Release ──> Publish
-                   └─> Sync next
+                    └─> Sync next
 Manual tag push ──> Build ──> Release ──> Publish (bypasses version check)
 ```
 
@@ -109,19 +111,57 @@ name: Build
 on:
   workflow_dispatch:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ['master']
     paths-ignore: ['*.md']
 
+permissions: {}
+
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: package-build-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
     uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
     # No DEV_KEY — a PR build doesn't publish, so it doesn't need the signing key.
 ```
+
+GitHub's default `pull_request` activities cover opened, updated, and reopened PRs.
+`ready_for_review` is listed explicitly so a draft's first ready state runs the build.
+The job gate keeps subsequent draft updates out of the build matrix.
+
+**pr-retarget.yml** -- rebuilds the `.s9pk` against a PR's new base:
+
+```yaml
+name: Retarget Build
+
+on:
+  pull_request:
+    types: [edited]
+
+permissions: {}
+
+concurrency:
+  group: package-build-${{ github.event.changes.base && github.event.pull_request.number || format('metadata-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    if: github.event.changes.base && github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
+```
+
+A base change is an `edited` event. The unfiltered listener receives it even when the new
+base or changed paths fall outside `build.yml`'s trigger filters. Base changes share the
+ordinary build's `package-build-<PR>` concurrency group, so the newest run replaces work
+against an obsolete base. Title and body edits use a separate metadata group and leave an
+active build alone.
 
 A PR build only compiles and packs; it never publishes. The reusable workflow falls back to
 `start-cli init-key` when no signing key is present, so passing `DEV_KEY` here would put the
@@ -143,7 +183,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  tag-and-release:
+  tag:
     uses: Start9Labs/start-technologies/.github/workflows/tagAndRelease.yml@master
     with:
       REFERENCE_REGISTRY: ${{ vars.REFERENCE_REGISTRY }}


### PR DESCRIPTION
The package template's PR build skipped two state changes that require fresh validation: a draft becoming ready and a pull request moving to another base.

## `ready_for_review`

A package PR opened as a draft records a skipped `build` check. GitHub's default `pull_request` activity set does not include `ready_for_review`, so the template now lists it explicitly and runs the build when the PR first becomes ready.

This gap has occurred in practice: `Start9Labs/gitea-startos#34` was marked ready and merged without another commit; its head carried only the skipped build from its draft state.

## Base changes

The build validates GitHub's generated merge ref, so changing the base changes the input even though the head SHA stays fixed. The template now includes an unfiltered `pr-retarget.yml` listener that calls the same reusable build for every non-draft base change.

This follows the final design from #3836 rather than adding `edited` directly to `build.yml`:

- normal and retarget builds share `package-build-<PR>`, so newer work cancels a build against an obsolete head or base;
- title and body edits use `package-build-metadata-<PR>`, so they cannot cancel an active build or replace its substantive conclusions;
- trigger-level branch and path filters remain on ordinary builds but cannot hide a retarget event;
- both callers grant only `contents: read`, and neither exposes `DEV_KEY` to PR-authored code.

## Documentation

The packaging guide documents the five-workflow scaffold and mirrors both build callers. The change also corrects the guide's stale `tagAndRelease.yml` job id and records the behavior under the unreleased SDK changelog.

## Verification

- `actionlint` on both changed template workflows
- `.github/scripts/check-pr-retarget-workflows.py`
- package-template/documented-workflow mirror assertions
- `projects/start-docs/build.sh`
- Prettier 3.8.3
- `git diff --check`
