### PR TITLE
chore(release): name the hardware in the OS download list

### DIFF
--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -153,20 +153,22 @@ deb_arch() {
     esac
 }
 
-os_platform_label() {
-    case "$1" in
-        x86_64-nonfree) echo "x86_64/AMD64" ;;
-        x86_64-nvidia) echo "x86_64/AMD64 + NVIDIA" ;;
-        x86_64) echo "x86_64/AMD64-slim (FOSS-only)" ;;
-        aarch64-nonfree) echo "aarch64/ARM64" ;;
-        aarch64-nvidia) echo "aarch64/ARM64 + NVIDIA" ;;
-        aarch64) echo "aarch64/ARM64-slim (FOSS-only)" ;;
-        raspberrypi) echo "Raspberry Pi (aarch64)" ;;
-        riscv64-nonfree) echo "RISCV64 (RVA23)" ;;
-        riscv64) echo "RISCV64 (RVA23)-slim (FOSS-only)" ;;
-        *) echo "$1" ;;
-    esac
-}
+# One row of the release notes' download table, in the order they are offered:
+# hardware | image | platform. A reader knows what they own, not which platform
+# tuple it is, so the hardware column leads and names the Start9 product where
+# there is one. release_notes fails on a platform with no row here, so a new
+# image variant cannot ship undescribed.
+OS_DOWNLOAD_ROWS=(
+    "**Server One**, and most other Intel and AMD desktops, laptops, and mini PCs|x86_64 (AMD64), standard|x86_64-nonfree"
+    "**Server Pure**, and other hardware that runs without proprietary firmware|x86_64 (AMD64), slim|x86_64"
+    "An Intel or AMD server with an NVIDIA GPU|x86_64 (AMD64), NVIDIA|x86_64-nvidia"
+    "ARM64 servers and single-board computers|aarch64 (ARM64), standard|aarch64-nonfree"
+    "ARM64 hardware that runs without proprietary firmware|aarch64 (ARM64), slim|aarch64"
+    "**NVIDIA DGX Spark**, and other ARM64 servers with an NVIDIA GPU|aarch64 (ARM64), NVIDIA|aarch64-nvidia"
+    "**Raspberry Pi 4** — flashed to a microSD card, not a USB drive|Raspberry Pi|raspberrypi"
+    "RISC-V servers and boards|RISC-V (RVA23), standard|riscv64-nonfree"
+    "RISC-V hardware that runs without proprietary firmware|RISC-V (RVA23), slim|riscv64"
+)
 
 # The image extensions a platform ships: squashfs everywhere, plus iso (most) or
 # a flashable img (raspberrypi).
@@ -1385,20 +1387,30 @@ release_notes() {
         os)
             echo "## Image Downloads"
             echo
-            local ext url
+            echo "| Hardware | Image | Download |"
+            echo "| --- | --- | --- |"
+            local ext url row hardware image described
             load_registry_index "$STARTOS_SOURCE_REGISTRY"
-            for platform in $OS_PLATFORMS; do
+            described=""
+            for row in "${OS_DOWNLOAD_ROWS[@]}"; do
+                IFS='|' read -r hardware image platform <<< "$row"
+                described="${described}${platform} "
                 for ext in $(os_image_exts "$platform"); do
                     # squashfs is the over-the-air update asset, not a download.
                     [ "$ext" != squashfs ] || continue
                     url=$(asset_url "$STARTOS_SOURCE_REGISTRY" "$ext" "$platform")
                     [ -n "$url" ] || continue
                     if [ "$ext" = img ]; then
-                        echo "- [$(os_platform_label "$platform")](${url}.gz \"gzip-compressed — Raspberry Pi Imager and balenaEtcher flash it without unpacking\")"
-                    else
-                        echo "- [$(os_platform_label "$platform")]($url)"
+                        url="${url}.gz \"gzip-compressed — Raspberry Pi Imager and balenaEtcher flash it without unpacking\""
                     fi
+                    echo "| ${hardware} | ${image} | [${ext^^}](${url}) |"
                 done
+            done
+            for platform in $OS_PLATFORMS; do
+                case "$described" in
+                    *"${platform} "*) ;;
+                    *) >&2 echo "No OS_DOWNLOAD_ROWS entry for ${platform} — it would be missing from the release notes" ; return 1 ;;
+                esac
             done
             echo
             local imgs


### PR DESCRIPTION
The `## Image Downloads` section of an OS release listed nine images as platform tuples and left the reader to work out which one their machine is:

```
- [x86_64/AMD64-slim (FOSS-only)](…_x86_64.iso)
- [x86_64/AMD64](…_x86_64-nonfree.iso)
- [x86_64/AMD64 + NVIDIA](…_x86_64-nvidia.iso)
- [aarch64/ARM64-slim (FOSS-only)](…_aarch64.iso)
…
```

Nobody owns an "x86_64/AMD64-slim (FOSS-only)". They own a Server One. And because the order came from `OS_PLATFORMS`, the *slim* build led every architecture — so the first x86_64 entry on the page is the one almost nobody should pick.

It is now a table led by the hardware, with the platform tuple kept in a second column for readers who want it:

| Hardware | Image | Download |
| --- | --- | --- |
| **Server One**, and most other Intel and AMD desktops, laptops, and mini PCs | x86_64 (AMD64), standard | [ISO](…) |
| **Server Pure**, and other hardware that runs without proprietary firmware | x86_64 (AMD64), slim | [ISO](…) |
| An Intel or AMD server with an NVIDIA GPU | x86_64 (AMD64), NVIDIA | [ISO](…) |
| ARM64 servers and single-board computers | aarch64 (ARM64), standard | [ISO](…) |
| ARM64 hardware that runs without proprietary firmware | aarch64 (ARM64), slim | [ISO](…) |
| **NVIDIA DGX Spark**, and other ARM64 servers with an NVIDIA GPU | aarch64 (ARM64), NVIDIA | [ISO](…) |
| **Raspberry Pi 4** — flashed to a microSD card, not a USB drive | Raspberry Pi | [IMG](…) |
| RISC-V servers and boards | RISC-V (RVA23), standard | [ISO](…) |
| RISC-V hardware that runs without proprietary firmware | RISC-V (RVA23), slim | [ISO](…) |

### How it's built

`os_platform_label()` is replaced by `OS_DOWNLOAD_ROWS`, an ordered `hardware|image|platform` table. Making it a list rather than a lookup is the point: display order now lives beside the labels instead of being inherited from `OS_PLATFORMS`, which is ordered to mirror the CI build matrix and has no business deciding what a reader sees first.

A platform in `OS_PLATFORMS` with no row aborts the notes rather than silently dropping out of the list, so a new image variant can't ship undescribed:

```
No OS_DOWNLOAD_ROWS entry for x86_64-newvariant — it would be missing from the release notes
```

The Raspberry Pi row keeps the existing `.img.gz` link title explaining that it flashes without unpacking.

### Verified

Rendered against the production registry index for 0.4.0.1 — all nine URLs match what the index publishes — and the missing-row guard exercised by adding a fake platform. `bash -n` clean. Nothing else calls `os_platform_label`.

### Context

This replaces #3847. The original plan put this table in the install guide pointing at the CDN, but with the checksums staying on GitHub the reader had to visit the release page anyway, so the links may as well be legible where they already are. #3846 separately rewrites the guide's verification steps, which is where the checksums and signatures get explained.

### Not included

A "Raspberry Pi 5 — coming soon" row. It reads well in the docs, but release notes are a per-version record that stays up forever, and a roadmap line frozen into every archived release ages badly. Happy to add it if you'd rather have it.
