### PR TITLE
docs(start-sdk): put store.json on its own startos volume

### DIFF
--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -332,7 +332,7 @@ const shape = z.object({
   smtp: smtpShape,
 })
 
-export const storeJson = FileHelper.json({ base: sdk.volumes.main, subpath: './store.json' }, shape)
+export const storeJson = FileHelper.json({ base: sdk.volumes.startos, subpath: 'store.json' }, shape)
 ```
 
 ### 2. Create the manageSmtp Action

--- a/projects/start-sdk/docs/src/file-models.md
+++ b/projects/start-sdk/docs/src/file-models.md
@@ -30,7 +30,9 @@ When done correctly, the shape itself eliminates the need for separate default c
 
 ### store.json.ts (Common Pattern)
 
-The most common file model is `store.json`, used to persist internal service state:
+`store.json` holds StartOS-side state that the upstream service's own configuration has no place for — a generated database password, a secret key, a backend the user selected, a flag an action toggles. Where the service does read a config file of its own, model that file directly instead: see [Prefer Direct FileModel Over store.json](#prefer-direct-filemodel-over-storejson--environment-variables).
+
+**It belongs on a volume of its own, named `startos`, that no subcontainer mounts.** Nothing inside the container reads it, and keeping it off the data volume keeps package-generated credentials out of a directory the application can read.
 
 ```typescript
 import { FileHelper, z } from '@start9labs/start-sdk'
@@ -43,8 +45,11 @@ const shape = z.object({
   someFlag: z.boolean().catch(false),
 })
 
-export const storeJson = FileHelper.json({ base: sdk.volumes.main, subpath: './store.json' }, shape)
+export const storeJson = FileHelper.json({ base: sdk.volumes.startos, subpath: 'store.json' }, shape)
 ```
+
+- **Declare the volume** in the manifest — `volumes: ['main', 'startos']` — and give it no mountpoint.
+- **Back it up.** `sdk.Backups.ofVolumes('main', 'startos')`. Restoring the data volume alone brings back an install whose generated secrets are gone; where one of them is an encryption key, the restored data is unreadable.
 
 ### YAML Configuration
 
@@ -498,7 +503,7 @@ When an upstream service reads a config file (TOML, YAML, JSON, XML, etc.), mode
 - **Simpler main.ts**: Mount the config file from the volume into the subcontainer. No need to read and regenerate it.
 - **Easy user configuration**: Exposing config options via Actions is as simple as `configToml.merge(effects, { key: newValue })`.
 
-Use `store.json` only for internal package state that has no upstream config file equivalent (e.g., a generated PostgreSQL password that the upstream service doesn't read from its own config file).
+Use `store.json` only for internal package state that has no upstream config file equivalent (e.g., a generated PostgreSQL password that the upstream service doesn't read from its own config file) — on [its own `startos` volume](#storejsonts-common-pattern), not the data volume.
 
 ```typescript
 // GOOD: Model the upstream config directly


### PR DESCRIPTION
The `store.json` section of `file-models.md` showed the model based on the data volume, and `actions.md`’s SMTP example copied it. The convention the fleet actually follows — a dedicated `startos` volume that no subcontainer mounts, declared in the manifest and included in the backup set — was stated only in `service-to-service.md`, inside the alternative-backends recipe, where it reads as specific to that recipe rather than as the general rule.

Twelve packages already do it that way (immich, jellyfin, ghost, discourse, ntfy, open-webui, albyhub, cal-diy, spliit, firefly-iii, mempool, tor); the ones on `main` predate it. A packager working from the canonical page gets the older shape, which puts package-generated credentials inside a directory the application can read — and, for anything that runs user-supplied code, its users can read.

This states the placement where `store.json` is introduced, pairs it with the decision it belongs to (bind the upstream config file directly when the service has one; reach for `store.json` only when it does not), and fixes the one example that contradicted it.

Targets `live-docs`: it corrects guidance that is already wrong on the published site, and no code accompanies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)