### PR TITLE
fix(marketplace): match search anywhere, rank by closeness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "deep-equality-data-structures": "1.5.1",
         "dompurify": "3.4.0",
         "fast-json-patch": "^3.1.1",
-        "fuse.js": "^6.4.6",
         "jose": "^4.9.0",
         "js-yaml": "^4.1.0",
         "marked": "^4.0.0",
@@ -8618,13 +8617,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "deep-equality-data-structures": "1.5.1",
     "dompurify": "3.4.0",
     "fast-json-patch": "^3.1.1",
-    "fuse.js": "^6.4.6",
     "jose": "^4.9.0",
     "js-yaml": "^4.1.0",
     "marked": "^4.0.0",

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -71,6 +71,10 @@ file tracks notable changes since the move to the monorepo.
 
 - Trim whitespace on form inputs.
 
+- **Marketplace search matches anywhere in a package's name, ID or
+  description, and ranks results by how closely they match.** Searching
+  `cloud` finds Nextcloud.
+
 - **Restoring a service from a backup is many times faster.** A restore reads
   the service's whole package out of the backup, and the encrypted backup
   filesystem stores file contents as sealed 1 MiB blocks that it fetches and

--- a/shared-libs/ts-modules/marketplace/package.json
+++ b/shared-libs/ts-modules/marketplace/package.json
@@ -17,7 +17,6 @@
     "@taiga-ui/dompurify": ">=5.0.0",
     "@taiga-ui/kit": ">=5.0.0",
     "@taiga-ui/layout": ">=5.0.0",
-    "fuse.js": "^6.4.6",
     "rxjs": ">=7.0.0"
   },
   "dependencies": {

--- a/shared-libs/ts-modules/marketplace/src/pipes/filter-packages.pipe.ts
+++ b/shared-libs/ts-modules/marketplace/src/pipes/filter-packages.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform } from '@angular/core'
-import Fuse from 'fuse.js'
+import { T } from '@start9labs/start-core'
+
 import { MarketplacePkg } from '../types'
 
 @Pipe({
@@ -9,70 +10,47 @@ export class FilterPackagesPipe implements PipeTransform {
   transform = filterPackages
 }
 
+const EXACT = 1
+const PREFIX = 0.8
+const WORD = 0.6
+const INFIX = 0.4
+
+const flatten = (value: T.LocaleString) =>
+  typeof value === 'string' ? value : Object.values(value).join(' ')
+
+const FIELDS = [
+  { get: (pkg: MarketplacePkg) => pkg.title, weight: 1, min: INFIX },
+  { get: (pkg: MarketplacePkg) => pkg.id, weight: 0.8, min: INFIX },
+  {
+    get: (pkg: MarketplacePkg) => flatten(pkg.description.short),
+    weight: 0.4,
+    min: WORD,
+  },
+  {
+    get: (pkg: MarketplacePkg) => flatten(pkg.description.long),
+    weight: 0.2,
+    min: WORD,
+  },
+]
+
 export function filterPackages(
   packages: MarketplacePkg[],
   query: string | null = '',
   category: string | null = '',
   sort: string | null = '',
 ): MarketplacePkg[] {
-  query = query?.trim() || ''
+  const search = query?.trim().toLowerCase() || ''
 
-  // query
-  if (query) {
-    let options: Fuse.IFuseOptions<MarketplacePkg> = {
-      includeScore: true,
-      includeMatches: true,
-    }
-
-    if (query.length < 4) {
-      options = {
-        ...options,
-        threshold: 0.2,
-        location: 0,
-        distance: 16,
-        keys: [
-          {
-            name: 'title',
-            weight: 1,
-          },
-          {
-            name: 'id',
-            weight: 0.5,
-          },
-        ],
-      }
-    } else {
-      options = {
-        ...options,
-        ignoreLocation: true,
-        useExtendedSearch: true,
-        keys: [
-          {
-            name: 'title',
-            weight: 1,
-          },
-          {
-            name: 'id',
-            weight: 0.5,
-          },
-          {
-            name: 'description.short',
-            weight: 0.4,
-          },
-          {
-            name: 'description.long',
-            weight: 0.1,
-          },
-        ],
-      }
-      query = `'${query}`
-    }
-
-    const fuse = new Fuse(packages, options)
-    return fuse.search(query).map(p => p.item)
+  if (search) {
+    return packages
+      .map(pkg => ({ pkg, score: score(pkg, search) }))
+      .filter(match => match.score > 0)
+      .sort(
+        (a, b) => b.score - a.score || a.pkg.title.localeCompare(b.pkg.title),
+      )
+      .map(match => match.pkg)
   }
 
-  // category
   return packages
     .filter(p => category === 'all' || p.categories.includes(category!))
     .sort((a, b) => {
@@ -89,4 +67,44 @@ export function filterPackages(
       }
     })
     .map(a => ({ ...a }))
+}
+
+function score(pkg: MarketplacePkg, search: string): number {
+  const words = search.split(/\s+/).map(word => best(pkg, word))
+
+  if (words.includes(0)) return 0
+
+  return Math.max(
+    best(pkg, search),
+    words.reduce((sum, word) => sum + word) / words.length,
+  )
+}
+
+function best(pkg: MarketplacePkg, search: string): number {
+  return FIELDS.reduce((max, { get, weight, min }) => {
+    const match = quality(get(pkg), search)
+
+    return match < min ? max : Math.max(max, weight * match)
+  }, 0)
+}
+
+function quality(text: string, search: string): number {
+  const lower = text.toLowerCase()
+
+  if (lower === search) return EXACT
+  if (lower.startsWith(search)) return PREFIX
+
+  let found = 0
+
+  for (
+    let i = lower.indexOf(search);
+    i !== -1;
+    i = lower.indexOf(search, i + 1)
+  ) {
+    if (!/[a-z0-9]/.test(lower.charAt(i - 1))) return WORD
+
+    found = INFIX
+  }
+
+  return found
 }


### PR DESCRIPTION
Searching the marketplace for `re`, `red` or `RED` did not find Node-RED, while `re` did find Firefly and `node` found Node-RED.

## Cause

`filterPackages` ran two different Fuse.js configurations. Queries under four characters used a bitap window — `location: 0`, `distance: 16`, `threshold: 0.2` — which adds `proximity / distance` to the match score, so a hit more than ~3 characters into the field can never clear the threshold no matter how exact it is. `re` sits at index 2 of "Firefly" and passes; `red` sits at index 5 of "Node-RED" and does not. Queries of four characters or more took the other branch (`useExtendedSearch` with a `'` exact-include prefix), which has no such window, so `node` worked.

## Change

One code path for every query length, no Fuse:

- The query is matched as a substring of `title`, `id`, `description.short` and `description.long`.
- Each field's hit is graded by where it lands — whole field, field prefix, word start, anywhere else — and scaled by a field weight. The weights keep the title decisive: the best a description can score ties the weakest title match.
- Titles and ids match on any substring (so `cloud` finds Nextcloud); descriptions match only from a word start, which is what keeps `red` off every description containing "required".
- A multi-word query must match every word somewhere, and scores as the better of the whole-phrase match and the mean of its words.
- Results are ordered by score, ties alphabetically.

Both `ui` and `brochure-marketplace` render the shared `<marketplace>` component, so both inherit it. `fuse.js` had no other consumer and is dropped.

## Result

Measured over the live Start9 and community registry indexes, localized to `en_US` and expanded per flavor the way `fetchPackages$` does — 123 entries — across 60 queries:

| query | before | after |
| --- | --- | --- |
| `red` / `RED` | no results | Cloudflare Tunnel, Bitcoin Knots (RDTS), Buzz Relay |
| `vpn` | no results | WireGuard VPN |
| `dns` | no results | Holesail, Namecoin Core, Payment Name |
| `fin` | no results | Jellyfin, +7 |
| `lnd` | LND, LNDg | LND, LNDg, Charge LND, +6 |
| `git` | Gitea, Gitea Runner | Gitea, Gitea Runner, Forgejo, +1 |
| `bitcoin core` | Bitcoin Core, +35 | Bitcoin Core, Bitcoin Knots (RDTS), Namecoin Core |
| `media server` | Audiobookshelf, Bisq, MeTube, +4 | Audiobookshelf, Jellyfin, MeTube |
| `ward` | Vaultwarden, Datum Gateway, P2Pool, LND | Vaultwarden |

Node-RED and Firefly III are in neither registry yet; added to the corpus by hand, `red` puts Node-RED 1st of 4 and `re` puts it 4th with Firefly 14th.

Flavors sharing an id stay separable: `bitcoin core` returns Bitcoin Core first, `bitcoin knots` returns only the two Knots rows, and `bitcoind` returns all three.

Two-word queries shrink because the old extended-search pattern only exact-matched the first word and fuzzy-matched the rest — `bitcoin core` matched 36 packages, `media server` reached Bisq and AxeOS Monitor.

The word-start rule on descriptions has a cost worth naming: `cloud` no longer reaches MeTube through "SoundCloud", and `flare` no longer reaches MySpeed through "Cloudflare". That is the same rule that stops `ward` returning LND for "forwarding", and in both cases the package the user was after still matches on its title.