### PR TITLE
docs(start-os): host volumes path, and the checkbox that unlocks Preserve

### DIFF
--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -183,7 +183,7 @@ Anything else is a failure. **`BAD signature`** means the file is not what Start
 
 1. At the Select Drives dialog, select the disk(s) you want to use as your OS and data drives.
 
-1. If a previous StartOS install is detected, it will ask whether you want to Overwrite or Preserve the existing StartOS data. Select Overwrite to start fresh, or Preserve to flash the OS on the booted USB thumb drive over the old installation, while preserving your data. After install is complete, you will be prompted to Continue to Setup.
+1. If a previous StartOS install is detected, it will ask whether you want to Overwrite or Preserve the existing StartOS data. Select Overwrite to start fresh, or Preserve to flash the OS on the booted USB thumb drive over the old installation, while preserving your data. If that data is on an ext4 drive, it will be converted to btrfs, and Preserve stays greyed out until you check "I have a backup of my data". After install is complete, you will be prompted to Continue to Setup.
 
 ## Raspberry Pi
 

--- a/projects/start-os/docs/src/service-containers.md
+++ b/projects/start-os/docs/src/service-containers.md
@@ -55,3 +55,22 @@ lxc-attach <CONTAINER-ID>
 
 > [!WARNING]
 > This bypasses StartOS's managed access layer. Only use this if you have a specific reason that `start-cli package attach` cannot fulfill.
+
+## Service Data on the Host
+
+A service's volumes live on the host at:
+
+```
+/media/startos/data/package-data/volumes/<PACKAGE>/data/<VOLUME>
+```
+
+Inside the container, the same volume is mounted at `/media/startos/volumes/<VOLUME>`. That shorter path is the container's view of it and does not exist on the host.
+
+To see how much disk space each service is using, [SSH](ssh.md) in and run:
+
+```bash
+sudo du -h --max-depth=1 /media/startos/data/package-data/volumes/
+```
+
+> [!WARNING]
+> Do not modify files under this path while the service is running.

--- a/projects/start-os/docs/src/update-040.md
+++ b/projects/start-os/docs/src/update-040.md
@@ -95,7 +95,7 @@ Pick your method below. Everything above applies to both, and the two paths rejo
 1. Flash the 0.4.0 installer to a USB drive from any computer, following the [Download](installing-startos.md#download) and [Flash](installing-startos.md#flash) sections of the install guide. Your server can keep running while you do this.
 
    > [!NOTE]
-   > On a Raspberry Pi, there is no USB installer — flash the 0.4.0 Raspberry Pi image to the Pi's microSD card instead. Follow the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi) in place of the steps below, then continue with [Step 8](#step-8-wait-for-the-migration) — a Pi reaches the same migration progress screen.
+   > On a Raspberry Pi, there is no USB installer — flash the 0.4.0 Raspberry Pi image to the Pi's microSD card instead, following the [Raspberry Pi flashing instructions](installing-startos.md#raspberry-pi). Power the Pi on and rejoin the steps below at the language selection. The microSD card is already the OS drive, so you select a data drive only; everything after that is the same.
 
 1. Shut down your server through the StartOS UI.
 
@@ -111,7 +111,9 @@ Pick your method below. Everything above applies to both, and the two paths rejo
    > [!WARNING]
    > You must select the **same drive layout** you had on 0.3.5.1. If 0.3.5.1 (OS and data) lived on a single drive, select **that same drive for both** the OS drive and the data drive. If your 0.3.5.1 data was on a separate drive, select a different drive for the OS. Choosing a different layout than your existing install cannot preserve your data, and the installer will refuse rather than erase the drive.
 
-1. When prompted, select **Preserve** to keep your existing data.
+1. Selecting a data drive that holds StartOS data opens the **StartOS Data Detected** dialog. Choose **Preserve** to keep your existing data.
+
+   A 0.3.5.1 data drive is formatted ext4, which 0.4.0 converts to btrfs. Because of that conversion the dialog asks you to confirm you have a backup, and **Preserve** stays greyed out until you check **I have a backup of my data** — the backup you made in [Step 6](#step-6-create-a-full-system-backup).
 
    > [!WARNING]
    > If you do not select "Preserve", all data on the drive will be erased.


### PR DESCRIPTION
Two gaps surfaced by support conversations.

## Where service data lives on the host

A user asking how much disk each service was using was told to run `du` against `/media/startos/volumes/*`. That path is the *container's* view of a single volume (`persistent_container.rs` bind-mounts each one there inside the LXC rootfs) and does not exist on the host. The host path — `/media/startos/data/package-data/volumes/<pkg>/data/<volume>`, from `DATA_DIR` + `PKG_VOLUME_DIR` in `start-core` — appears in no book, so they found it by trial and error.

Documented on **Accessing Service Containers**, along with the container-vs-host distinction that produced the wrong advice, and the `du` invocation that answers the original question.

## The greyed-out Preserve button

`preserve-overwrite.dialog.ts` disables **Preserve** while `isExt4 && !backupAck` — the "StartOS Data Detected" dialog warns that the drive will be converted to btrfs and requires **I have a backup of my data** before it will let you keep the data. A 0.3.5.1 data drive is always ext4, so every flash update hits this, on every platform.

Unlike the `blockedReason` case, nothing on screen says the checkbox is what is holding the button, and the report we got read it as a Pi hardware or drive-detection fault and steered the user toward erasing and restoring instead. Both the 0.4.0 update guide and the install guide now name the checkbox.

While in the update guide: its Raspberry Pi note sent Pi users from the flashing instructions straight to the migration-progress step, skipping drive selection and Preserve entirely — the steps this user needed. A Pi boots the same wizard with the microSD card preset as the OS drive (`stateService.osDrive`), so it now rejoins at the language selection and picks a data drive only.

Both are corrections to already-published behavior, so they go to `live-docs`.
