### PR TITLE
Multi-line action result values

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -70,6 +70,11 @@ file tracks notable changes since the move to the monorepo.
   any browser pointed at this server. Narrow windows and phones always show the
   grid.
 
+- **An action can return a multi-line value** — a diagnostic report, a
+  generated config file, an exported key block. It appears as a read-only
+  monospace box that keeps its line breaks, and, where the service asks for it,
+  can be copied, shown as a QR code, or saved to a file.
+
 ### Changed
 
 - **Your server's name is now its `.local` address, without the `.local` on the

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-group.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-group.component.ts
@@ -1,39 +1,48 @@
 import { Component, Input } from '@angular/core'
 import { TuiAccordion, TuiFade } from '@taiga-ui/kit'
 import { ActionSuccessMemberComponent } from './action-success-member.component'
+import { ActionSuccessMultilineComponent } from './action-success-multiline.component'
 import { GroupResult } from './types'
 
 @Component({
   selector: 'app-action-success-group',
   template: `
     @for (member of group.value; track $index) {
-      <p>
-        @if (member.type === 'single') {
-          <app-action-success-member [member]="member" />
-        }
-        @if (member.type === 'group') {
-          <tui-accordion>
-            <button tuiAccordion>
-              <span tuiFade>{{ member.name }}</span>
-            </button>
-            <tui-expand>
-              <app-action-success-group [group]="member" />
-            </tui-expand>
-          </tui-accordion>
-        }
-      </p>
+      @if (member.type === 'single') {
+        <app-action-success-member [member]="member" />
+      }
+      @if (member.type === 'multiline') {
+        <app-action-success-multiline
+          [multiline]="member"
+          [name]="member.name"
+          [description]="member.description || ''"
+        />
+      }
+      @if (member.type === 'group') {
+        <tui-accordion>
+          <button tuiAccordion>
+            <span tuiFade>{{ member.name }}</span>
+          </button>
+          <tui-expand>
+            <app-action-success-group [group]="member" />
+          </tui-expand>
+        </tui-accordion>
+      }
     }
   `,
   styles: `
-    p:first-child {
-      margin-top: 0;
-    }
-
-    p:last-child {
-      margin-bottom: 0;
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
     }
   `,
-  imports: [ActionSuccessMemberComponent, TuiAccordion, TuiFade],
+  imports: [
+    ActionSuccessMemberComponent,
+    ActionSuccessMultilineComponent,
+    TuiAccordion,
+    TuiFade,
+  ],
 })
 export class ActionSuccessGroupComponent {
   @Input()

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-multiline.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-multiline.component.ts
@@ -1,0 +1,152 @@
+import {
+  Component,
+  computed,
+  inject,
+  input,
+  linkedSignal,
+  TemplateRef,
+} from '@angular/core'
+import { CopyService, DialogService, i18nPipe } from '@start9labs/shared'
+import { TuiButton, TuiTitle } from '@taiga-ui/core'
+import { TuiTextarea } from '@taiga-ui/kit'
+import { QRComponent } from 'src/app/routes/portal/components/qr.component'
+import { MultilineResult } from './types'
+
+@Component({
+  selector: 'app-action-success-multiline',
+  template: `
+    @if (name()) {
+      <span tuiTitle>
+        <strong>{{ name() }}</strong>
+        @if (description()) {
+          <span tuiSubtitle>{{ description() }}</span>
+        }
+      </span>
+    }
+    <tui-textfield>
+      <textarea
+        tuiTextarea
+        [max]="16"
+        [min]="3"
+        [readOnly]="true"
+        [style.filter]="masked() ? 'blur(0.5rem)' : null"
+        [value]="multiline().value"
+      ></textarea>
+      @if (multiline().masked) {
+        <button
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          type="button"
+          tabindex="-1"
+          [iconStart]="masked() ? '@tui.eye' : '@tui.eye-off'"
+          (pointerdown.stop)="(0)"
+          (click)="masked.set(!masked())"
+        >
+          {{ 'Reveal/Hide' | i18n }}
+        </button>
+      }
+      @if (multiline().copyable) {
+        <button
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          type="button"
+          tabindex="-1"
+          iconStart="@tui.copy"
+          (pointerdown.stop)="(0)"
+          (click)="copy.copy(multiline().value)"
+        >
+          {{ 'Copy' | i18n }}
+        </button>
+      }
+      @if (multiline().qr) {
+        <button
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          type="button"
+          tabindex="-1"
+          iconStart="@tui.qr-code"
+          (pointerdown.stop)="(0)"
+          (click)="show(qr)"
+        >
+          {{ 'Show QR' | i18n }}
+        </button>
+      }
+      @if (multiline().filename; as filename) {
+        <a
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          tabindex="-1"
+          iconStart="@tui.download"
+          [download]="filename"
+          [href]="href()"
+          (pointerdown.stop)="(0)"
+        >
+          {{ 'Download' | i18n }}
+        </a>
+      }
+    </tui-textfield>
+    <ng-template #qr>
+      <app-qr
+        [value]="multiline().value"
+        [style.filter]="masked() ? 'blur(0.5rem)' : null"
+      />
+      @if (masked()) {
+        <button
+          tuiIconButton
+          class="reveal"
+          iconStart="@tui.eye"
+          [style.border-radius.%]="100"
+          (click)="masked.set(false)"
+        >
+          {{ 'Reveal' | i18n }}
+        </button>
+      }
+    </ng-template>
+  `,
+  styles: `
+    @use '@taiga-ui/styles/utils' as taiga;
+
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    tui-textfield {
+      font-family: var(--tui-typography-family-code);
+    }
+
+    .reveal {
+      @include taiga.center-all();
+    }
+  `,
+  imports: [TuiButton, TuiTextarea, TuiTitle, QRComponent, i18nPipe],
+})
+export class ActionSuccessMultilineComponent {
+  private readonly dialog = inject(DialogService)
+  readonly copy = inject(CopyService)
+
+  readonly multiline = input.required<MultilineResult>()
+  readonly name = input('')
+  readonly description = input('')
+
+  protected readonly masked = linkedSignal(() => this.multiline().masked)
+  protected readonly href = computed(() =>
+    URL.createObjectURL(
+      new Blob([this.multiline().value], { type: 'application/octet-stream' }),
+    ),
+  )
+
+  protected show(template: TemplateRef<any>) {
+    const masked = this.masked()
+
+    this.masked.set(this.multiline().masked)
+    this.dialog
+      .openComponent(template, { label: 'Scan this QR', size: 's' })
+      .subscribe({ complete: () => this.masked.set(masked) })
+  }
+}

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success.page.ts
@@ -9,6 +9,7 @@ import { TuiDialogContext } from '@taiga-ui/core'
 import { NgDompurifyPipe } from '@taiga-ui/dompurify'
 import { injectContext } from '@taiga-ui/polymorpheus'
 import { ActionSuccessGroupComponent } from './action-success-group.component'
+import { ActionSuccessMultilineComponent } from './action-success-multiline.component'
 import { ActionSuccessSingleComponent } from './action-success-single.component'
 import { ActionResponse } from './types'
 
@@ -24,12 +25,23 @@ import { ActionResponse } from './types'
     @if (single) {
       <app-action-success-single [single]="single" />
     }
+    @if (multiline) {
+      <app-action-success-multiline [multiline]="multiline" />
+    }
     @if (group) {
       <app-action-success-group [group]="group" />
     }
   `,
+  styles: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+  `,
   imports: [
     ActionSuccessGroupComponent,
+    ActionSuccessMultilineComponent,
     ActionSuccessSingleComponent,
     NgDompurifyPipe,
     MarkdownPipe,
@@ -43,6 +55,8 @@ export class ActionSuccessPage {
   readonly message = this.data.message as i18nKey | null
   readonly single =
     this.data.result?.type === 'single' ? this.data.result : null
+  readonly multiline =
+    this.data.result?.type === 'multiline' ? this.data.result : null
   readonly group = this.data.result?.type === 'group' ? this.data.result : null
 
   readonly options = { breaks: true }

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/types.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/types.ts
@@ -3,4 +3,5 @@ import { ActionRes } from 'src/app/services/api/api.types'
 export type ActionResponse = NonNullable<ActionRes>
 type ActionResult = NonNullable<ActionResponse['result']>
 export type SingleResult = ActionResult & { type: 'single' }
+export type MultilineResult = ActionResult & { type: 'multiline' }
 export type GroupResult = ActionResult & { type: 'group' }

--- a/projects/start-os/web/ui/src/app/services/action.service.ts
+++ b/projects/start-os/web/ui/src/app/services/action.service.ts
@@ -1,5 +1,6 @@
 import { inject, Injectable } from '@angular/core'
 import { DialogService, getErrorMessage, i18nKey } from '@start9labs/shared'
+import { T } from '@start9labs/start-core'
 import { TuiNotificationMiddleService } from '@taiga-ui/kit'
 import { PolymorpheusComponent } from '@taiga-ui/polymorpheus'
 import { filter } from 'rxjs'
@@ -68,6 +69,7 @@ export class ActionService {
           .openComponent(new PolymorpheusComponent(ActionSuccessPage), {
             label: res.title as i18nKey,
             data: res,
+            size: res.result && hasMultiline(res.result) ? 'l' : 'm',
           })
           .subscribe()
       }
@@ -79,4 +81,10 @@ export class ActionService {
       loader.unsubscribe()
     }
   }
+}
+
+function hasMultiline(value: T.ActionResultValue): boolean {
+  return value.type === 'group'
+    ? value.value.some(hasMultiline)
+    : value.type === 'multiline'
 }

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -1648,6 +1648,114 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
     },
   }
 
+  const DOCTOR_REPORT = `Vikunja Doctor
+==============
+
+Checked against https://vikunja.embassy at 2026-08-28T14:02:11Z
+
+Component          Status    Detail
+-----------------  --------  ---------------------------------------
+Database           ok        postgres 16.3, 41 tables, 0 pending
+Typesense index    degraded  4812 of 5104 tasks indexed
+Attachment store   ok        1.2 GiB across 318 files
+Mailer             skipped   no SMTP credentials configured
+Public URL         ok        resolves to 10.0.1.24:3456
+
+2 warnings
+  - The search index is behind. Run "Reindex" to rebuild it.
+  - The mailer is unconfigured, so reminders and invitations are
+    silently dropped.`
+
+  const DEVICE_CONFIG = `[Interface]
+PrivateKey = qNSHDgIkG9Bo0dnjBRAmvIBaU0MI/ADoWfDaCu9uWFo=
+Address = 10.13.13.4/32
+DNS = 10.13.13.1
+
+[Peer]
+PublicKey = HIgo9xNzJMWLKASShiTqIybxZ0U3wGLiUeJ1PKf8ykw=
+PresharedKey = uUYtV+HDNU9kZ0eDDBTBQfLuIJfHIPRSRfBWMWFBAgk=
+Endpoint = tunnel.start9.com:51820
+AllowedIPs = 0.0.0.0/0, ::/0
+PersistentKeepalive = 25`
+
+  export const ActionResMultiline: ActionRes = {
+    version: '1',
+    title: 'Diagnostics',
+    message: 'Send this report along if you open a support ticket.',
+    result: {
+      type: 'multiline',
+      copyable: true,
+      qr: false,
+      masked: false,
+      filename: 'vikunja-doctor.txt',
+      value: DOCTOR_REPORT,
+    },
+  }
+
+  export const ActionResMultilineSecret: ActionRes = {
+    version: '1',
+    title: 'Device Added',
+    message: 'Scan this from the WireGuard app, or save it as a file.',
+    result: {
+      type: 'multiline',
+      copyable: true,
+      qr: true,
+      masked: true,
+      filename: 'start-tunnel.conf',
+      value: DEVICE_CONFIG,
+    },
+  }
+
+  export const ActionResMultilineGroup: ActionRes = {
+    version: '1',
+    title: 'Service Information',
+    message: 'Everything StartOS could collect about this service.',
+    result: {
+      type: 'group',
+      value: [
+        {
+          type: 'single',
+          name: 'Version',
+          description: null,
+          copyable: false,
+          qr: false,
+          masked: false,
+          value: '0.24.6',
+        },
+        {
+          type: 'multiline',
+          name: 'Doctor Report',
+          description: 'The full output of `vikunja doctor`.',
+          copyable: true,
+          qr: false,
+          masked: false,
+          filename: 'vikunja-doctor.txt',
+          value: DOCTOR_REPORT,
+        },
+        {
+          type: 'multiline',
+          name: 'Device Config',
+          description: 'The WireGuard config for the device you just added.',
+          copyable: true,
+          qr: true,
+          masked: true,
+          filename: 'start-tunnel.conf',
+          value: DEVICE_CONFIG,
+        },
+        {
+          type: 'multiline',
+          name: 'Recovery Phrase',
+          description: 'Write this down. It is shown only once.',
+          copyable: true,
+          qr: false,
+          masked: true,
+          value:
+            'shrug cinnamon plunge oyster\nharbor velvet timber acorn\nglisten fossil marble rooster',
+        },
+      ],
+    },
+  }
+
   export const getCreateOnionServiceSpec = async (): Promise<IST.InputSpec> =>
     configBuilderToSpec(
       ISB.InputSpec.of({

--- a/projects/start-os/web/ui/src/app/services/api/embassy-mock-api.service.ts
+++ b/projects/start-os/web/ui/src/app/services/api/embassy-mock-api.service.ts
@@ -1312,6 +1312,11 @@ export class MockApiService extends ApiService {
     // return Mock.ActionResSingle
     if (params.actionId === 'big-qr') return Mock.ActionResBigQr
     if (params.actionId === 'unencodable-qr') return Mock.ActionResUnencodableQr
+    if (params.actionId === 'multiline') return Mock.ActionResMultiline
+    if (params.actionId === 'multiline-secret')
+      return Mock.ActionResMultilineSecret
+    if (params.actionId === 'multiline-group')
+      return Mock.ActionResMultilineGroup
     return Mock.ActionResMessage
   }
 

--- a/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
+++ b/projects/start-os/web/ui/src/app/services/api/mock-patch.ts
@@ -521,6 +521,36 @@ export const mockPatchData: DataModel = {
           hasInput: false,
           group: null,
         },
+        multiline: {
+          name: 'Show Report',
+          description:
+            'Returns a multi-line value with a copy button and a download',
+          warning: null,
+          visibility: 'enabled',
+          allowedStatuses: 'any',
+          hasInput: false,
+          group: null,
+        },
+        'multiline-secret': {
+          name: 'Show Device Config',
+          description:
+            'Returns a masked multi-line value that can also be shown as a QR code',
+          warning: null,
+          visibility: 'enabled',
+          allowedStatuses: 'any',
+          hasInput: false,
+          group: null,
+        },
+        'multiline-group': {
+          name: 'Show Mixed Group',
+          description:
+            'Returns a group whose members mix single-line and multi-line values',
+          warning: null,
+          visibility: 'enabled',
+          allowedStatuses: 'any',
+          hasInput: false,
+          group: null,
+        },
         test: {
           name: 'Do Another Thing',
           description:

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -117,6 +117,12 @@
   alongside it and default to `false`. See
   [Single Value](https://docs.start9.com/packaging/actions.html#single-value)
 
+- **An action result can be a `multiline` value**: a read-only monospace box
+  that keeps its line breaks, taking the same optional `copyable` / `qr` /
+  `masked` flags as `single`, plus an optional `filename` that offers it as a
+  download. A `single` value is one line, and a newline in one is not rendered.
+  See [Result Types](https://docs.start9.com/packaging/actions.html#result-types)
+
 ### Fixed
 
 - **Scaffolded package CI builds a draft PR when it becomes ready and rebuilds

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -94,9 +94,7 @@ export const actions = sdk.Actions.of().addAction(setAdminPassword)
 
 Actions return structured results that the StartOS UI renders for the user.
 
-`message` is prose shown under the title. It is rendered as **Markdown** — headings, lists, tables, code blocks, emphasis and links all work — and a single newline is kept as a line break, so text written as plain lines arrives as plain lines. Anything with its own line structure goes here.
-
-`result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR, masking and link-opening, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
+`message` is prose shown under the title. It is rendered as **Markdown** — headings, lists, tables, code blocks, emphasis and links all work — and a single newline is kept as a line break, so text written as plain lines arrives as plain lines. Guidance and next steps go here.
 
 ```typescript
 return {
@@ -111,6 +109,16 @@ Restart the service once the rebuild finishes.`,
   result: null,
 }
 ```
+
+`result` holds the values the user acts on — copies, scans, or saves. It takes one of three types:
+
+| `type`      | Renders as                                                         | Takes                                                           |
+| ----------- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
+| `single`    | a one-line field                                                   | `value`, plus optional `copyable`, `qr`, `masked`, `launchable` |
+| `multiline` | a read-only monospace box that keeps its line breaks               | `value`, plus optional `copyable`, `qr`, `masked`, `filename`   |
+| `group`     | an accordion of named members, each of which is any of these three | `value`, the array of members                                   |
+
+A newline in a `single` value is not rendered — the browser strips it from the field — so anything with its own line structure is a `multiline` value. `filename` is what separates "here is some text" from "here is a file": set it and the value is also offered as a download under that name; omit it for no download button.
 
 ### Single Value
 
@@ -140,7 +148,20 @@ result: {
 
 The value must be an `http(s)` URL for the button to go anywhere.
 
+### Multi-line Value
+
+```typescript
+result: {
+  type: 'multiline',
+  value: report,
+  copyable: true,
+  filename: 'vikunja-doctor.txt',
+}
+```
+
 ### Group of Values
+
+A member carries a `name`, and an optional `description`, on top of whatever its own type takes:
 
 ```typescript
 result: {
@@ -148,6 +169,7 @@ result: {
   value: [
     { type: 'single', name: 'Username', description: null, value: 'admin', masked: false, copyable: true, qr: false },
     { type: 'single', name: 'Password', description: null, value: 'secret', masked: true, copyable: true, qr: false },
+    { type: 'multiline', name: 'Device Config', description: null, value: config, masked: true, copyable: true, qr: true, filename: 'start-tunnel.conf' },
   ],
 }
 ```

--- a/shared-libs/crates/start-core/src/action.rs
+++ b/shared-libs/crates/start-core/src/action.rs
@@ -191,7 +191,7 @@ pub struct ActionResultMember {
 pub enum ActionResultValue {
     Single {
         /// The actual string value to display. The UI renders it as a single-line field —
-        /// multi-line text belongs in the result's `message`.
+        /// multi-line text belongs in a `multiline` value.
         value: String,
         /// (optional) Whether or not to include a copy to clipboard icon to copy the value
         #[ts(optional)]
@@ -206,6 +206,22 @@ pub enum ActionResultValue {
         #[ts(optional)]
         launchable: Option<bool>,
     },
+    Multiline {
+        /// The actual string value to display. The UI renders it verbatim in a read-only monospace field that keeps its line breaks
+        value: String,
+        /// (optional) Whether or not to include a copy to clipboard icon to copy the value
+        #[ts(optional)]
+        copyable: Option<bool>,
+        /// (optional) Whether or not to also display the value as a QR code
+        #[ts(optional)]
+        qr: Option<bool>,
+        /// (optional) Whether or not to blur the value until the user reveals it, which is useful for a private key or other sensitive information
+        #[ts(optional)]
+        masked: Option<bool>,
+        /// (optional) Also offer the value as a download under this file name, such as "diagnostics.txt"
+        #[ts(optional)]
+        filename: Option<String>,
+    },
     Group {
         /// An new group of nested values, experienced by the user as an accordion dropdown
         value: Vec<ActionResultMember>,
@@ -214,11 +230,16 @@ pub enum ActionResultValue {
 impl ActionResultValue {
     fn fmt_rec(&self, f: &mut fmt::Formatter<'_>, indent: usize) -> fmt::Result {
         match self {
-            Self::Single { value, qr, .. } => {
-                for _ in 0..indent {
-                    write!(f, "  ")?;
+            Self::Single { value, qr, .. } | Self::Multiline { value, qr, .. } => {
+                for (i, line) in value.lines().enumerate() {
+                    if i > 0 {
+                        writeln!(f)?;
+                    }
+                    for _ in 0..indent {
+                        write!(f, "  ")?;
+                    }
+                    write!(f, "{line}")?;
                 }
-                write!(f, "{value}")?;
                 if qr.unwrap_or_default() {
                     use qrcode::render::unicode;
                     writeln!(f)?;

--- a/shared-libs/ts-modules/shared/styles/taiga.scss
+++ b/shared-libs/ts-modules/shared/styles/taiga.scss
@@ -166,6 +166,7 @@ tui-textfield [tuiTooltip] {
 :root {
   --tui-typography-family-text: 'Hanken Grotesk', system-ui;
   --tui-typography-family-display: 'Hanken Grotesk', system-ui;
+  --tui-typography-family-code: ui-monospace, monospace;
 }
 
 tui-notification-middle {

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
@@ -14,7 +14,7 @@ export type ActionResultMember = {
       type: 'single'
       /**
        * The actual string value to display. The UI renders it as a single-line field —
-       * multi-line text belongs in the result's `message`.
+       * multi-line text belongs in a `multiline` value.
        */
       value: string
       /**
@@ -33,6 +33,29 @@ export type ActionResultMember = {
        * (optional) Whether or not to include an open in new tab icon to launch the value, which must be an http(s) URL
        */
       launchable?: boolean
+    }
+  | {
+      type: 'multiline'
+      /**
+       * The actual string value to display. The UI renders it verbatim in a read-only monospace field that keeps its line breaks
+       */
+      value: string
+      /**
+       * (optional) Whether or not to include a copy to clipboard icon to copy the value
+       */
+      copyable?: boolean
+      /**
+       * (optional) Whether or not to also display the value as a QR code
+       */
+      qr?: boolean
+      /**
+       * (optional) Whether or not to blur the value until the user reveals it, which is useful for a private key or other sensitive information
+       */
+      masked?: boolean
+      /**
+       * (optional) Also offer the value as a download under this file name, such as "diagnostics.txt"
+       */
+      filename?: string
     }
   | {
       type: 'group'

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
@@ -6,7 +6,7 @@ export type ActionResultValue =
       type: 'single'
       /**
        * The actual string value to display. The UI renders it as a single-line field —
-       * multi-line text belongs in the result's `message`.
+       * multi-line text belongs in a `multiline` value.
        */
       value: string
       /**
@@ -25,6 +25,29 @@ export type ActionResultValue =
        * (optional) Whether or not to include an open in new tab icon to launch the value, which must be an http(s) URL
        */
       launchable?: boolean
+    }
+  | {
+      type: 'multiline'
+      /**
+       * The actual string value to display. The UI renders it verbatim in a read-only monospace field that keeps its line breaks
+       */
+      value: string
+      /**
+       * (optional) Whether or not to include a copy to clipboard icon to copy the value
+       */
+      copyable?: boolean
+      /**
+       * (optional) Whether or not to also display the value as a QR code
+       */
+      qr?: boolean
+      /**
+       * (optional) Whether or not to blur the value until the user reveals it, which is useful for a private key or other sensitive information
+       */
+      masked?: boolean
+      /**
+       * (optional) Also offer the value as a download under this file name, such as "diagnostics.txt"
+       */
+      filename?: string
     }
   | {
       type: 'group'


### PR DESCRIPTION
Closes #3810.

## The gap

`ActionResultValue` had two variants and neither could carry multi-line text. `Single` renders as an `<input>`, and HTML's value-sanitization algorithm strips CR/LF from a text input's value, so a multi-line `value` arrived with its lines concatenated. That left `message` as the only home for a diagnostic report, a generated config file or an exported key block — prose under the title, with no name, no copy affordance, no QR and no download. Action *inputs* have had `ValueSpecTextarea` since the start; results had no counterpart, and packagers worked around it by returning the same report twice (Start9-Community/vikunja-startos#6).

## The variant

```rust
Multiline {
    value: String,
    copyable: Option<bool>,
    qr: Option<bool>,
    masked: Option<bool>,
    filename: Option<String>,
}
```

A third variant rather than `Single { multiline: bool }`: the widget differs, the sizing differs, and the flags mean different things per widget — one component branching across two layouts is the shape that produced the group-copy bug in #3792. It also keeps `Single`'s contract, and its doc comments, true.

Every flag is optional and defaults to `false`, the contract #3878 set for `single`'s flags; `launchable` stays on `single`, where the value is a URL. `filename` is what separates "here is some text" from "here is a file". Set it and the value is offered as a download under that name; omit it and it is text on the screen.

## The widget

StartTunnel's device-config dialog minus its help infrastructure: a read-only `textarea tuiTextarea` inside a `tui-textfield`, sized to content between 3 and 16 rows, monospace so aligned columns survive, masked by blur with a reveal button, and a QR opened through the same dialog `action-success-member` already used. Name and description sit above the field as a `tuiTitle` / `tuiSubtitle` pair, the way `about.component.ts` groups a modal item with its caption.

Two things the tall textarea exposed that a one-line input had been hiding:

- **Focus stealing.** `TuiTextfieldComponent` projects everything that isn't the input or label into a `<span class="t-content" (pointerdown)="input()?.nativeElement?.focus()">`. That handler has no `.self`, so clicking any in-field icon focuses the input — imperceptible for an `<input>`, a jarring scroll for a 16-row textarea below the fold. Every in-field control now carries `(pointerdown.stop)`. Copy also moved from `tuiCopy` to `CopyService`, since `tuiCopy` copies by calling `.select()` on the native element, which scrolls for the same reason; `CopyService` is what both sibling components and the About modal already use.
- **Width.** The result dialog opens at size `l` when the result carries a multiline value at any depth, so a report's columns don't wrap mid-row.

## Elsewhere

- `fmt_rec`'s `Single` and `Multiline` arms are one or-pattern that indents every line of a value, so `start-cli` prints the new variant the way it prints the old one.
- `--tui-typography-family-code` is defined in the theme sheet alongside the existing family overrides. Taiga's default resolves to `'JetBrains Mono'`, which this app doesn't load, so it would have silently fallen back to the sans stack and defeated the aligned columns.
- Mock fixtures for all three shapes, on Bitcoin Core: **Show Report** (copy + download), **Show Device Config** (QR + masked + download), **Show Mixed Group** (a group mixing `single` and three `multiline` members).
- `actions.md` § Result Types now documents all three variants and what each takes; changelog entries in `0.4.0.2` and SDK `2.0.10`. No new i18n keys — `Show QR`, `Scan this QR`, `Reveal`, `Reveal/Hide` and `Download` all already existed.

## One thing to check

**The two regenerated bindings are hand-written.** `make start-core-ts-bindings` compiles start-core at `opt-level = 3` with full debuginfo, which does not fit in this machine's docker budget. `ActionResultValue.ts` and `ActionResultMember.ts` were written by hand from the existing generated output, including #3878's optional-field form. The `Generated Artifacts` job uploads what it regenerates, so if `start-core-ts-bindings-check` fails, the run's artifact replaces them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
