### PR TITLE
fix(sdk): let a select or union render with no option preselected

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -107,6 +107,10 @@
   one canonical origin. See
   [Nominating an Address to Open](https://docs.start9.com/packaging/interfaces.html#nominating-an-address-to-open).
 
+- **`Value.select`, `Value.dynamicSelect`, `Value.union` and `Value.dynamicUnion`
+  accept `default: null`**, which renders the field unselected and holds the form
+  unsubmittable until the user picks one
+
 ### Fixed
 
 - **Scaffolded package CI builds a draft PR when it becomes ready and rebuilds

--- a/shared-libs/ts-modules/start-core/lib/actions/input/builder/value.ts
+++ b/shared-libs/ts-modules/start-core/lib/actions/input/builder/value.ts
@@ -885,12 +885,12 @@ export class Value<
     /** Supplementary text rendered persistently beneath the field. */
     footnote?: string | null
     /**
-     * @description Determines if the field is required. If so, optionally provide a default value from the list of values.
+     * @description The option to preselect. `null` leaves the field unselected; a selection is required either way.
      * @type { (keyof Values & string) | null }
      * @example default: null
      * @example default: 'radio1'
      */
-    default: keyof Values & string
+    default: (keyof Values & string) | null
     /**
      * @description A mapping of unique radio options to their human readable display format.
      * @example
@@ -937,7 +937,7 @@ export class Value<
         description?: string | null
         warning?: string | null
         footnote?: string | null
-        default: string
+        default: string | null
         values: Values
         disabled?: false | string | string[]
       },
@@ -1223,11 +1223,12 @@ export class Value<
     warning?: string | null
     variants: Variants<VariantValues>
     /**
-     * @description Provide a default value from the list of variants.
-     * @type { string }
+     * @description The variant to preselect. `null` leaves the field unselected; a selection is required either way.
+     * @type { (keyof VariantValues & string) | null }
+     * @example default: null
      * @example default: 'variant1'
      */
-    default: keyof VariantValues & string
+    default: (keyof VariantValues & string) | null
     /**
      * @description Once set, the value can never be changed.
      * @default false
@@ -1269,7 +1270,7 @@ export class Value<
         description?: string | null
         warning?: string | null
         variants: Variants<VariantValues>
-        default: keyof VariantValues & string
+        default: (keyof VariantValues & string) | null
         disabled: string[] | false | string
       },
       OuterType
@@ -1292,7 +1293,7 @@ export class Value<
         description?: string | null
         warning?: string | null
         variants: Variants<VariantValues>
-        default: keyof VariantValues & string
+        default: (keyof VariantValues & string) | null
         disabled: string[] | false | string
       },
       OuterType
@@ -1318,7 +1319,7 @@ export class Value<
         description?: string | null
         warning?: string | null
         variants: Variants<VariantValues>
-        default: keyof VariantValues & string
+        default: (keyof VariantValues & string) | null
         disabled: string[] | false | string
       },
       OuterType


### PR DESCRIPTION
`Value.select` and `Value.union` typed `default` as a required, non-nullable key, so a packager could not express "the user must choose" — every such field had to name a winner up front.

Everything downstream already supported the null case:

- `ValueSpecSelect.default` and `ValueSpecUnion.default` are already `string | null` (`inputSpecTypes.ts`)
- the UI builds a select as `formBuilder.control(spec.default, [Validators.required])` (`form.service.ts`), so a null default renders **unselected and blocks submission** until the user picks; `getUnionObject` falls through to an empty sub-form
- the builder's own doc comment already documented `@type { (keyof Values & string) | null }` and `@example default: null`

Only the public signature disagreed. This widens it on `select`, `dynamicSelect`, `union` and all three `dynamicUnion` overloads, and corrects the two doc comments that described the old contract.

Packages already need this and are casting around it — `lnbits-startos/startos/actions/lightningImplementation.ts` writes `default: undefined as any` to get an unselected Lightning-backend picker.

Every other builder — `text`, `textarea`, `number`, `color`, `datetime`, `triState` — already accepts a null default. `select` and `union` were the outliers; `toggle` and `multiselect` are correct as-is (binary, and an empty array already means "nothing selected").

### Verification

`npm run check` clean across all projects; `make web-format-check` clean.