### PR TITLE
feat(registry): stream package-index changes over a websocket

### DIFF
--- a/projects/start-registry/ARCHITECTURE.md
+++ b/projects/start-registry/ARCHITECTURE.md
@@ -43,15 +43,15 @@ Defined in `shared-libs/crates/start-core/src/registry/mod.rs`:
 
 Subcommands (same module), each available over RPC and to the `start-registry` CLI via `with_call_remote`:
 
-| Command   | Module                | Purpose                                                 |
-| --------- | --------------------- | ------------------------------------------------------- |
-| `index`   | `mod::get_full_index` | full combined index (name, icon, packages, OS, signers) |
-| `info`    | `registry/info.rs`    | set/get registry info and categories                    |
-| `os`      | `registry/os/`        | OS version index + asset (image) management             |
-| `package` | `registry/package/`   | add/get/list packages, versions, assets                 |
-| `admin`   | `registry/admin.rs`   | manage admins and signers                               |
-| `db`      | `registry/db.rs`      | dump/inspect the registry database                      |
-| `metrics` | `registry/metrics.rs` | download/user metrics summaries (admin-only)            |
+| Command   | Module                | Purpose                                                                |
+| --------- | --------------------- | ---------------------------------------------------------------------- |
+| `index`   | `mod::get_full_index` | full combined index (name, icon, packages, OS, signers)                |
+| `info`    | `registry/info.rs`    | set/get registry info and categories                                   |
+| `os`      | `registry/os/`        | OS version index + asset (image) management                            |
+| `package` | `registry/package/`   | add/get/list packages, versions, assets                                |
+| `admin`   | `registry/admin.rs`   | manage admins and signers                                              |
+| `db`      | `registry/db.rs`      | dump/inspect the registry database; subscribe to package-index changes |
+| `metrics` | `registry/metrics.rs` | download/user metrics summaries (admin-only)                           |
 
 ## Data model
 

--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `start-registry` (the Start Registry server) are document
 
 ## [1.0.2]
 
+- **A client can follow the package index over a websocket instead of re-fetching it.** `db.subscribe`
+  returns the index as it stands plus a continuation id; connecting to `/ws/rpc/<id>` then streams a
+  JSON patch each time a package or version is added, removed, or recategorized. It is
+  unauthenticated and carries only the subtree `package.index` already serves.
+
 - **An indexed package version now advertises which installed versions can migrate into it**, so a
   client asking for an upgrade path is offered a version it can actually install. Entries already
   in an index keep their permissive value until that version is published again.

--- a/shared-libs/crates/start-core/src/registry/db.rs
+++ b/shared-libs/crates/start-core/src/registry/db.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
+use axum::extract::ws;
 use clap::Parser;
 use itertools::Itertools;
 use patch_db::Dump;
@@ -14,7 +16,13 @@ use crate::context::CliContext;
 use crate::prelude::*;
 use crate::registry::RegistryDatabase;
 use crate::registry::context::RegistryContext;
+use crate::rpc_continuations::{Guid, RpcContinuation};
 use crate::util::serde::{HandlerExtSerde, apply_expr};
+
+lazy_static::lazy_static! {
+    /// Must stay within what `package.index` already serves unauthenticated.
+    static ref PACKAGE_INDEX: JsonPointer = "/index/package".parse().unwrap();
+}
 
 pub fn db_api<C: Context>() -> ParentHandler<C> {
     ParentHandler::new()
@@ -28,6 +36,12 @@ pub fn db_api<C: Context>() -> ParentHandler<C> {
             "dump",
             from_fn_async(dump)
                 .with_metadata("admin", Value::Bool(true))
+                .no_cli(),
+        )
+        .subcommand(
+            "subscribe",
+            from_fn_async(subscribe)
+                .with_metadata("authenticated", Value::Bool(false))
                 .no_cli(),
         )
         .subcommand(
@@ -94,6 +108,61 @@ pub async fn dump(ctx: RegistryContext, DumpParams { pointer }: DumpParams) -> R
         .db
         .dump(&pointer.as_ref().map_or(ROOT, |p| p.borrowed()))
         .await)
+}
+
+#[derive(Deserialize, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeRes {
+    #[ts(type = "{ id: number; value: unknown }")]
+    pub dump: Dump,
+    pub guid: Guid,
+}
+
+pub async fn subscribe(ctx: RegistryContext) -> Result<SubscribeRes, Error> {
+    let (dump, mut sub) = ctx.db.dump_and_sub(PACKAGE_INDEX.clone()).await;
+    let guid = Guid::new();
+    ctx.rpc_continuations
+        .add(
+            guid.clone(),
+            RpcContinuation::ws(
+                |mut ws| async move {
+                    if let Err(e) = async {
+                        loop {
+                            tokio::select! {
+                                rev = sub.recv() => {
+                                    let Some(rev) = rev else {
+                                        return ws.normal_close("complete").await;
+                                    };
+                                    ws.send(ws::Message::Text(
+                                        serde_json::to_string(&rev)
+                                            .with_kind(ErrorKind::Serialization)?
+                                            .into(),
+                                    ))
+                                    .await
+                                    .with_kind(ErrorKind::Network)?;
+                                }
+                                msg = ws.recv() => {
+                                    if msg.transpose().with_kind(ErrorKind::Network)?.is_none() {
+                                        return Ok(())
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    .await
+                    {
+                        if !crate::util::net::is_ws_reset_without_close(&e) {
+                            tracing::error!("Error in registry db websocket: {e}");
+                            tracing::debug!("{e:?}");
+                        }
+                    }
+                },
+                Duration::from_secs(30),
+            ),
+        )
+        .await;
+
+    Ok(SubscribeRes { dump, guid })
 }
 
 #[derive(Deserialize, Serialize, Parser)]

--- a/shared-libs/crates/start-core/src/registry/db.rs
+++ b/shared-libs/crates/start-core/src/registry/db.rs
@@ -13,6 +13,7 @@ use tracing::instrument;
 use ts_rs::TS;
 
 use crate::context::CliContext;
+use crate::db::SubscribeRes;
 use crate::prelude::*;
 use crate::registry::RegistryDatabase;
 use crate::registry::context::RegistryContext;
@@ -108,14 +109,6 @@ pub async fn dump(ctx: RegistryContext, DumpParams { pointer }: DumpParams) -> R
         .db
         .dump(&pointer.as_ref().map_or(ROOT, |p| p.borrowed()))
         .await)
-}
-
-#[derive(Deserialize, Serialize, TS)]
-#[serde(rename_all = "camelCase")]
-pub struct SubscribeRes {
-    #[ts(type = "{ id: number; value: unknown }")]
-    pub dump: Dump,
-    pub guid: Guid,
 }
 
 pub async fn subscribe(ctx: RegistryContext) -> Result<SubscribeRes, Error> {


### PR DESCRIPTION
Adds `db.subscribe` to the registry RPC surface, so a client can follow the package index instead of re-fetching it.

`POST …/rpc/registry/db/subscribe` returns `{ dump, guid }`; connecting to `GET …/ws/rpc/<guid>` then streams a `Revision` (`{ id, patch }`) each time the index changes.

## Why

Nothing on a registry pushes. A consumer that wants to react when a package or a version lands has to poll `package.get` or `package.index`, and those responses are large and uncacheable — measured against production, with `otherVersions: "none"` and no ETag or gzip on any of them:

| registry | bytes |
| --- | --- |
| `registry.start9.com` | 1.9 MB |
| `beta-registry.start9.com` | 2.0 MB |
| `community-registry.start9.com` | 8.6 MB |
| `community-beta-registry.start9.com` | 21.3 MB |

That is ~34 MB per sweep across the fleet, for a signal that fires a few times a week.

## Shape

The registry already carried the machinery: `RegistryContext` holds a `TypedPatchDb<RegistryDatabase>` and `RpcContinuations`, and `registry_router` mounts `/ws/rpc/{*path}`. No registry method had ever called `rpc_continuations.add`, so no GUID was ever issued and that route was unreachable — this is the first thing to use it.

The handler mirrors `db::subscribe` in `src/db/mod.rs`, minus the `sync_db` merge, which has no registry equivalent.

## Scope and auth

Pinned to `/index/package`, not a caller-supplied pointer, and tagged `authenticated: false`.

`package.index` already returns that whole subtree unauthenticated (`get_package_index`, `authenticated: false`), so the stream carries nothing a client could not already fetch. A caller-supplied pointer would reach `/admins` and `/index/signers` on a public handler, which is why the pointer is fixed. patch-db scopes a subscriber's patches to its pointer (`ScopedSender::send` → `Revision::for_path`), so patches arrive relative to `/index/package` and revisions that do not touch it are dropped rather than delivered empty — a consumer must not assume contiguous revision ids.

No CLI surface (`no_cli`), so no manpage change; no `#[ts(export)]`, so no bindings regeneration.

## Consumer

support-server will hold one subscription per registry (alpha, beta, prod, community-beta, community-prod) and diff successive states to announce new packages and new versions to Matrix and X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)