### PR TITLE
fix(start-sdk): drop undefined keys when writing an env file model

### DIFF
--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -117,6 +117,11 @@
   against every new base after retargeting.** Metadata edits preserve active
   builds and their conclusions
 
+- **`merge()` given a value of `undefined` removes the key from an `.env` file
+  model**, the way it already did for every other format. It wrote the literal
+  `KEY=undefined`, which a shape's `.catch()` then masked on read — so the file
+  the service actually parses held the word while the model reported the default
+
 - **`VersionGraph` reports a missing migration path in terms a service owner can
   act on**, rather than as an assertion about the version range the host handed
   it

--- a/projects/start-sdk/lib/test/fileHelper.merge.test.ts
+++ b/projects/start-sdk/lib/test/fileHelper.merge.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { FileHelper } from '../util/fileHelper'
+import { z } from '@start9labs/start-core/zExport'
+
+const shape = z.looseObject({ A: z.string(), K: z.string().optional() })
+const effects = {} as any
+
+const dir = mkdtempSync(join(tmpdir(), 'file-helper-'))
+
+const seeded = (name: string, contents: string) => {
+  const path = join(dir, name)
+  writeFileSync(path, contents)
+  return path
+}
+
+describe('FileHelper.merge', () => {
+  // Every format drops a key merged as `undefined`; the env writer used to
+  // render it through a template literal and emit the word instead.
+  test.each([
+    ['env', 'A=keep\nK=old\n', 'A=keep'],
+    ['ini', 'A=keep\nK=old\n', 'A=keep'],
+    ['json', '{"A":"keep","K":"old"}', '{\n  "A": "keep"\n}'],
+    ['yaml', 'A: keep\nK: old\n', 'A: keep'],
+    ['toml', 'A = "keep"\nK = "old"\n', 'A = "keep"'],
+  ])('%s removes a key merged as undefined', async (kind, before, after) => {
+    const path = seeded(`undefined.${kind}`, before)
+    const file = (FileHelper as any)[kind](path, shape)
+
+    await file.merge(effects, { K: undefined })
+
+    expect(readFileSync(path, 'utf-8').trim()).toBe(after)
+  })
+
+  test.each(['env', 'ini', 'json', 'yaml', 'toml'])(
+    '%s leaves a key the merge does not name',
+    async kind => {
+      const before = {
+        env: 'A=keep\nK=old\n',
+        ini: 'A=keep\nK=old\n',
+        json: '{"A":"keep","K":"old"}',
+        yaml: 'A: keep\nK: old\n',
+        toml: 'A = "keep"\nK = "old"\n',
+      }[kind]!
+      const path = seeded(`absent.${kind}`, before)
+      const file = (FileHelper as any)[kind](path, shape)
+
+      await file.merge(effects, {})
+
+      expect(readFileSync(path, 'utf-8')).toContain('old')
+    },
+  )
+})

--- a/projects/start-sdk/lib/util/fileHelper.ts
+++ b/projects/start-sdk/lib/util/fileHelper.ts
@@ -226,11 +226,17 @@ class FileHelperImpl<A> implements FileHelper<A> {
     return null
   }
 
+  /** Renders to the file format. A key whose value is `undefined` is dropped, so
+   * merging `undefined` removes it rather than serializing the word. */
+  private serialize(data: A): string {
+    return this.writeData(filterUndefined(data))
+  }
+
   /**
    * Accepts structured data and overwrites the existing file on disk.
    */
   private async writeFile(data: A): Promise<null> {
-    return await this.writeFileRaw(this.writeData(data))
+    return await this.writeFileRaw(this.serialize(data))
   }
 
   private async readFileRaw(): Promise<string | null> {
@@ -408,7 +414,7 @@ class FileHelperImpl<A> implements FileHelper<A> {
       fileData = this.validate(fileData)
     } catch (_) {}
     const mergeData = this.validate(fileMerge({}, fileData, data))
-    const toWrite = this.writeData(mergeData)
+    const toWrite = this.serialize(mergeData)
     if (toWrite !== fileDataRaw) {
       await this.writeFile(mergeData)
       if (!options.allowWriteAfterConst && effects.constRetry) {
@@ -655,7 +661,7 @@ export const FileHelper: FileHelperStatic = {
   ): FileHelper<A> {
     return rawTransformed<A, Record<string, unknown>, Transformed>(
       path,
-      inData => INI.stringify(filterUndefined(inData), options),
+      inData => INI.stringify(inData, options),
       inString => INI.parse(inString, options),
       deepLooseParse(shape),
       transformers,


### PR DESCRIPTION
`merge(effects, { KEY: undefined })` removes the key from a file model — except on `FileHelper.env`, which writes the literal `KEY=undefined`.

## What's happening

`fileMerge` leaves the key present with an undefined value, and `z.deepLoose(shape).parse` keeps it, so whether it survives to disk has been up to each writer:

| writer | drops an undefined-valued key? |
| --- | --- |
| `json` | yes — `JSON.stringify` omits it |
| `yaml` / `toml` / `xml` | yes — their serializers omit it |
| `ini` | yes — `INI.stringify(filterUndefined(inData))`, explicitly |
| **`env`** | **no** — `Object.entries(inData).map(([k, v]) => \`${k}=${v}\`)` stringifies it to the word |

Same shape, same file, `merge(effects, { K: undefined })` on 2.0.9:

```
json  -> {"A":"keep"}                 removed
ini   -> A=keep                       removed
yaml  -> A: keep                      removed
toml  -> A = "keep"                   removed
xml   -> <root><A>keep</A></root>     removed
env   -> A=keep\nK=undefined          NOT removed
```

A key simply absent from the merge object is a correct no-op in all six.

## The fix

Filter in the one place `write` and `merge` both render through, rather than per writer — the contract then holds for every format instead of five of six by accident, and `merge`'s dirty-check compares the same bytes it goes on to write. The `ini` writer's own `filterUndefined` call becomes redundant and is removed.

## Why it matters

`FileHelper.env` is rare in the fleet — three packages across both registries — which is why this held up unnoticed. One of them hits it: `bitcoin-explorer-startos` writes

```ts
BTCEXP_REDIS_URL: input.redis ? redisUrl : undefined
```

so turning Redis off in its Configure action writes `BTCEXP_REDIS_URL=undefined`. btc-rpc-explorer then gets a Redis URL of `"undefined"`, while the shape's `.catch(redisUrl)` masks the bad value on read — so the package's own guard still reports Redis as enabled and the setting silently doesn't take. Filed as an issue on that repo.

## Tests

`lib/test/fileHelper.merge.test.ts` covers both directions across the five text formats — a key merged as `undefined` is removed, a key the merge doesn't name is left alone. Verified it fails on the env case without the fix (`1 failed, 9 passed`) and passes with it.

Full suite on this branch: `9 passed, 117 tests`.
