### PR TITLE
feat(start-os): open an action result's link in a new tab

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -61,6 +61,10 @@ file tracks notable changes since the move to the monorepo.
   plaintext address, including the passwords typed into it. See
   [Gateways](https://docs.start9.com/start-os/gateways.html).
 
+- **An action result that hands you a link can be opened in a new tab.** Where a
+  service returns a URL — an authorization link, an admin panel — the result
+  shows an open-in-new-tab button beside it.
+
 ### Changed
 
 - **Your server's name is now its `.local` address, without the `.local` on the

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-member.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-member.component.ts
@@ -44,6 +44,21 @@ import { QRComponent } from 'src/app/routes/portal/components/qr.component'
           {{ 'Copy' | i18n }}
         </button>
       }
+      @if (member.launchable) {
+        <a
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          target="_blank"
+          rel="noreferrer"
+          tabindex="-1"
+          iconStart="@tui.external-link"
+          [href]="member.value"
+          [style.pointer-events]="'auto'"
+        >
+          {{ 'Open' | i18n }}
+        </a>
+      }
       @if (member.qr) {
         <button
           tuiIconButton
@@ -108,7 +123,7 @@ export class ActionSuccessMemberComponent {
   show(template: TemplateRef<any>) {
     const masked = this.masked
 
-    this.masked = this.member.masked
+    this.masked = !!this.member.masked
     this.dialog
       .openComponent(template, { label: 'Scan this QR', size: 's' })
       .subscribe({

--- a/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-single.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/services/modals/action-success/action-success-single.component.ts
@@ -47,6 +47,21 @@ import { SingleResult } from './types'
           {{ 'Copy' | i18n }}
         </button>
       }
+      @if (single.launchable) {
+        <a
+          tuiIconButton
+          appearance="icon"
+          size="s"
+          target="_blank"
+          rel="noreferrer"
+          tabindex="-1"
+          iconStart="@tui.external-link"
+          [href]="single.value"
+          [style.pointer-events]="'auto'"
+        >
+          {{ 'Open' | i18n }}
+        </a>
+      }
     </tui-textfield>
     <ng-template #qr>
       <app-qr

--- a/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
+++ b/projects/start-os/web/ui/src/app/services/api/api.fixures.ts
@@ -1641,6 +1641,7 @@ Full changelog: https://github.com/Kixunil/btc-rpc-proxy/blob/master/CHANGELOG.m
           copyable: false,
           qr: true,
           masked: false,
+          launchable: true,
           value: 'https://guessagain.com',
         },
       ],

--- a/projects/start-sdk/CHANGELOG.md
+++ b/projects/start-sdk/CHANGELOG.md
@@ -111,6 +111,12 @@
   accept `default: null`**, which renders the field unselected and holds the form
   unsubmittable until the user picks one
 
+- **`launchable` on a `single` action result opens the value in a new tab**, for
+  a result that hands the user a link — an authorization URL, an admin panel.
+  The value must be an `http(s)` URL. `copyable`, `qr` and `masked` are optional
+  alongside it and default to `false`. See
+  [Single Value](https://docs.start9.com/packaging/actions.html#single-value)
+
 ### Fixed
 
 - **Scaffolded package CI builds a draft PR when it becomes ready and rebuilds

--- a/projects/start-sdk/docs/src/actions.md
+++ b/projects/start-sdk/docs/src/actions.md
@@ -96,7 +96,7 @@ Actions return structured results that the StartOS UI renders for the user.
 
 `message` is prose shown under the title. It is rendered as **Markdown** — headings, lists, tables, code blocks, emphasis and links all work — and a single newline is kept as a line break, so text written as plain lines arrives as plain lines. Anything with its own line structure goes here.
 
-`result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR and masking, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
+`result` holds discrete values the user acts on: each one is a single-line field with optional copy, QR, masking and link-opening, so a newline in a `value` is not rendered. A multi-line report goes in `message`, not in a `value`.
 
 ```typescript
 return {
@@ -117,14 +117,28 @@ Restart the service once the rebuild finishes.`,
 ```typescript
 result: {
   type: 'single',
-  name: 'API Key',
-  description: null,
   value: 'abc123',
   masked: true,
   copyable: true,
   qr: false,
 }
 ```
+
+`copyable`, `qr`, `masked` and `launchable` are all optional and default to
+`false`. `launchable` puts an open-in-new-tab button beside the value, so a
+result that hands the user a link — an authorization URL, an admin panel — can
+be clicked straight through:
+
+```typescript
+result: {
+  type: 'single',
+  value: 'https://btcpay.example.com/api-keys/authorize?permissions=btcpay.store.cancreateinvoice',
+  copyable: true,
+  launchable: true,
+}
+```
+
+The value must be an `http(s)` URL for the button to go anywhere.
 
 ### Group of Values
 

--- a/shared-libs/crates/start-core/src/action.rs
+++ b/shared-libs/crates/start-core/src/action.rs
@@ -114,9 +114,10 @@ impl ActionResult {
                 message: Some(message),
                 result: value.map(|value| ActionResultValue::Single {
                     value,
-                    copyable,
-                    qr,
-                    masked: false,
+                    copyable: Some(copyable),
+                    qr: Some(qr),
+                    masked: None,
+                    launchable: None,
                 }),
             }),
             Self::V1(a) => Self::V1(a),
@@ -192,12 +193,18 @@ pub enum ActionResultValue {
         /// The actual string value to display. The UI renders it as a single-line field —
         /// multi-line text belongs in the result's `message`.
         value: String,
-        /// Whether or not to include a copy to clipboard icon to copy the value
-        copyable: bool,
-        /// Whether or not to also display the value as a QR code
-        qr: bool,
-        /// Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
-        masked: bool,
+        /// (optional) Whether or not to include a copy to clipboard icon to copy the value
+        #[ts(optional)]
+        copyable: Option<bool>,
+        /// (optional) Whether or not to also display the value as a QR code
+        #[ts(optional)]
+        qr: Option<bool>,
+        /// (optional) Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
+        #[ts(optional)]
+        masked: Option<bool>,
+        /// (optional) Whether or not to include an open in new tab icon to launch the value, which must be an http(s) URL
+        #[ts(optional)]
+        launchable: Option<bool>,
     },
     Group {
         /// An new group of nested values, experienced by the user as an accordion dropdown
@@ -212,7 +219,7 @@ impl ActionResultValue {
                     write!(f, "  ")?;
                 }
                 write!(f, "{value}")?;
-                if *qr {
+                if qr.unwrap_or_default() {
                     use qrcode::render::unicode;
                     writeln!(f)?;
                     for _ in 0..indent {

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultMember.ts
@@ -18,17 +18,21 @@ export type ActionResultMember = {
        */
       value: string
       /**
-       * Whether or not to include a copy to clipboard icon to copy the value
+       * (optional) Whether or not to include a copy to clipboard icon to copy the value
        */
-      copyable: boolean
+      copyable?: boolean
       /**
-       * Whether or not to also display the value as a QR code
+       * (optional) Whether or not to also display the value as a QR code
        */
-      qr: boolean
+      qr?: boolean
       /**
-       * Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
+       * (optional) Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
        */
-      masked: boolean
+      masked?: boolean
+      /**
+       * (optional) Whether or not to include an open in new tab icon to launch the value, which must be an http(s) URL
+       */
+      launchable?: boolean
     }
   | {
       type: 'group'

--- a/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
+++ b/shared-libs/ts-modules/start-core/lib/osBindings/ActionResultValue.ts
@@ -10,17 +10,21 @@ export type ActionResultValue =
        */
       value: string
       /**
-       * Whether or not to include a copy to clipboard icon to copy the value
+       * (optional) Whether or not to include a copy to clipboard icon to copy the value
        */
-      copyable: boolean
+      copyable?: boolean
       /**
-       * Whether or not to also display the value as a QR code
+       * (optional) Whether or not to also display the value as a QR code
        */
-      qr: boolean
+      qr?: boolean
       /**
-       * Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
+       * (optional) Whether or not to mask the value using ●●●●●●●, which is useful for password or other sensitive information
        */
-      masked: boolean
+      masked?: boolean
+      /**
+       * (optional) Whether or not to include an open in new tab icon to launch the value, which must be an http(s) URL
+       */
+      launchable?: boolean
     }
   | {
       type: 'group'


### PR DESCRIPTION
Closes #3218.

An action that returns a URL could only be copied — switch tab, paste, enter. For a link that points back at the same server, that is a detour around a browser the user already has open.

## What changed

`ActionResultValue::Single` gains **`launchable`**. When it is set, the action-result modal puts an open-in-new-tab button beside the value, using the same `@tui.external-link` icon the service controls use for "Open UI". It renders as an `<a target="_blank" rel="noreferrer">`, so Angular's URL sanitizer covers the value; the SDK docs state the value must be an `http(s)` URL.

Both renderers get it: `action-success-single` (a bare `single` result) and `action-success-member` (a `single` inside a group).

## Optionality

`copyable`, `qr` and `masked` were required. Adding `launchable` as a fourth required flag would mean editing every package in the fleet, so it is optional — and the three it sits beside are now optional too, defaulting to `false`. Existing packages are unaffected: they already send all three.

## Notes

- The generated bindings here are a hand-written prediction of what `make start-core-ts-bindings` emits — the regen does not fit on the machine this was written on. The `Generated Artifacts` gate is the check; if it drifts, the run's artifact replaces them.
- Conflicts textually with #3866, which adds a `multiline` variant carrying the same three flags. The conflict is textual only — `launchable` is for `single`, where the value is a URL, and does not belong on `multiline`.

Verified: `npm run check`, `ng build ui` (AOT, so the templates typecheck), container-runtime `tsc --noEmit`, `make start-core-format-check`.
