### PR TITLE
docs: improve StartTunnel setup and StartOS SSH guidance

### DIFF
--- a/projects/start-os/docs/src/ssh.md
+++ b/projects/start-os/docs/src/ssh.md
@@ -1,6 +1,6 @@
 # SSH
 
-Secure Shell Protocol (SSH) opens a command-line session on your StartOS server from a terminal on your own computer. The `ssh` command starts on your computer; after it connects, the commands you enter run on your StartOS server.
+SSH opens a command-line session on your StartOS server from a terminal on your computer. Once connected, commands entered in that terminal run on the server.
 
 > [!WARNING]
 > Accessing your server via SSH is considered advanced. Please use caution, you can cause permanent damage to your server, potentially resulting in loss of data.
@@ -15,27 +15,7 @@ The SSH user is `start9`, not `root`. Root login is disabled. The `start9` user 
 
 ## Connect with your StartOS master password
 
-### Open a terminal
-
-{{#tabs global="platform"}}
-{{#tab name="Mac"}}
-
-Press Command + Space, type `Terminal`, and press Enter.
-
-{{#endtab}}
-{{#tab name="Windows"}}
-
-Press the Windows key, type `PowerShell`, and press Enter.
-
-{{#endtab}}
-{{#tab name="Linux"}}
-
-Open a terminal.
-
-{{#endtab}}
-{{#endtabs}}
-
-Run the following command in the terminal on your computer:
+Open Terminal on Mac or Linux, or PowerShell on Windows. Run:
 
 ```sh
 ssh start9@SERVER-HOSTNAME
@@ -52,85 +32,48 @@ This key is not known by any other names.
 Are you sure you want to continue connecting (yes/no/[fingerprint])?
 ```
 
-Confirm that the message names your StartOS server, then type `yes` and press Enter to trust the server's SSH public key.
+Confirm that the message names your server, then type `yes` and press Enter.
 
-When the terminal asks for `start9@...`'s password, enter the StartOS master password you use to sign in to the StartOS web interface. Do not enter your computer's login password. The terminal does not display characters, dots, or other feedback while you type the password. Press Enter when you finish.
+At the password prompt, enter the StartOS master password you use to sign in to the StartOS web interface, not your computer's login password. The terminal displays nothing while you type the password. Press Enter when finished.
 
-### Confirm that you are connected
+Once connected, the command prompt typically begins with `start9@` followed by your server's hostname.
 
-After authentication succeeds, the terminal displays a new command prompt, typically beginning with `start9@` followed by your server's hostname. Commands entered at this prompt run on your StartOS server.
-
-You can confirm the session with these commands:
-
-```sh
-whoami
-hostname
-```
-
-`whoami` should display `start9`, and `hostname` should display your server's hostname.
-
-### Troubleshoot a closed connection
-
-If `Connection closed` appears before the server's command prompt, the SSH session ended without opening a usable command line. Do not enter commands intended for StartOS at your computer's original prompt.
-
-Confirm that you entered the correct server hostname and that its StartOS web interface is reachable from the same computer, then try the SSH command again. If the connection closes again, copy the complete command and output and [contact Start9 support](https://start9.com/contact).
+If `Connection closed` appears before this prompt, you are not connected. Check the server hostname, confirm that its StartOS web interface is reachable from the same computer, and try again. If it continues, copy the complete command and output and [contact Start9 support](https://start9.com/contact).
 
 ## Connect with an SSH key
 
 ### Create an SSH key
 
-If you do not already have an SSH key pair on your computer, open a terminal as described above and run:
+If you do not already have an SSH key pair, open a terminal and run:
 
 ```sh
 ssh-keygen -t ed25519
 ```
 
-Press Enter to accept the default file location. You can optionally create a passphrase, which protects the private SSH key stored on your computer. This key passphrase is separate from both your StartOS master password and your computer's login password.
-
-Your public key is stored at `~/.ssh/id_ed25519.pub`.
+Press Enter to accept the default file location. You can optionally create a passphrase to protect the SSH key on your computer. This key passphrase is different from your StartOS master password.
 
 ### Add your key to StartOS
 
-Display your public key in the terminal:
+Display your public key:
 
-{{#tabs global="platform"}}
-{{#tab name="Mac"}}
+Mac or Linux:
 
 ```sh
 cat ~/.ssh/id_ed25519.pub
 ```
 
-{{#endtab}}
-{{#tab name="Windows"}}
+Windows PowerShell:
 
 ```powershell
 Get-Content $HOME\.ssh\id_ed25519.pub
 ```
 
-{{#endtab}}
-{{#tab name="Linux"}}
+Copy the complete key. In the StartOS web interface, go to `System > SSH`, select **Add Key**, paste the key, and select **Save**.
 
-```sh
-cat ~/.ssh/id_ed25519.pub
-```
-
-{{#endtab}}
-{{#endtabs}}
-
-Copy the complete key displayed in the terminal.
-
-In the StartOS web interface, go to `System > SSH`, select **Add Key**, paste the public key, and select **Save**.
-
-### Start the SSH connection
-
-Open a terminal on your computer and run:
+Open a terminal and connect:
 
 ```sh
 ssh start9@SERVER-HOSTNAME
 ```
 
-Replace `SERVER-HOSTNAME` with your server's `your-server-name.local` address.
-
-If the terminal asks for `Enter passphrase for key`, enter the passphrase you created for the SSH key. This prompt does not ask for your StartOS master password or your computer's login password.
-
-Use the checks under [Confirm that you are connected](#confirm-that-you-are-connected) to verify that commands will run on your StartOS server.
+If prompted for `Enter passphrase for key`, enter the SSH key passphrase, not your StartOS master password.

--- a/projects/start-os/docs/src/ssh.md
+++ b/projects/start-os/docs/src/ssh.md
@@ -1,6 +1,6 @@
 # SSH
 
-Like other Linux distributions, StartOS allows you to go "under-the-hood" via Secure Shell Protocol (SSH).
+Secure Shell Protocol (SSH) opens a command-line session on your StartOS server from a terminal on your own computer. The `ssh` command starts on your computer; after it connects, the commands you enter run on your StartOS server.
 
 > [!WARNING]
 > Accessing your server via SSH is considered advanced. Please use caution, you can cause permanent damage to your server, potentially resulting in loss of data.
@@ -13,53 +13,124 @@ Like other Linux distributions, StartOS allows you to go "under-the-hood" via Se
 
 The SSH user is `start9`, not `root`. Root login is disabled. The `start9` user has `sudo` privileges, so commands requiring root should use `sudo`. There is no need to run `sudo -i` or `sudo su`.
 
-## Using your StartOS Master Password
+## Connect with your StartOS master password
 
-1.  Open a terminal on your client device and enter:
+### Open a terminal
 
-        ssh start9@SERVER-HOSTNAME
+{{#tabs global="platform"}}
+{{#tab name="Mac"}}
 
-    Replace `SERVER-HOSTNAME` with your server's `your-server-name.local` address.
+Press Command + Space, type `Terminal`, and press Enter.
 
-1.  The first time you connect, you will see something like this:
+{{#endtab}}
+{{#tab name="Windows"}}
 
-    ```
-    The authenticity of host 'your-server-name.local (192.168.1.175)' can't be established.
-    ED25519 key fingerprint is SHA256:BgYhzyIDbshm3annI1cfySd8C4/lh6Gfk2Oi3FdIVAa.
-    This key is not known by any other names.
-    Are you sure you want to continue connecting (yes/no/[fingerprint])?
-    ```
+Press the Windows key, type `PowerShell`, and press Enter.
 
-    Type `yes` and hit Enter to start trusting the server's SSH public key.
+{{#endtab}}
+{{#tab name="Linux"}}
 
-1.  Enter your StartOS master password.
+Open a terminal.
 
-## Using SSH Keys
+{{#endtab}}
+{{#endtabs}}
+
+Run the following command in the terminal on your computer:
+
+```sh
+ssh start9@SERVER-HOSTNAME
+```
+
+Replace `SERVER-HOSTNAME` with your server's `your-server-name.local` address.
+
+The first time you connect, SSH displays a message like this:
+
+```
+The authenticity of host 'your-server-name.local (192.168.1.175)' can't be established.
+ED25519 key fingerprint is SHA256:BgYhzyIDbshm3annI1cfySd8C4/lh6Gfk2Oi3FdIVAa.
+This key is not known by any other names.
+Are you sure you want to continue connecting (yes/no/[fingerprint])?
+```
+
+Confirm that the message names your StartOS server, then type `yes` and press Enter to trust the server's SSH public key.
+
+When the terminal asks for `start9@...`'s password, enter the StartOS master password you use to sign in to the StartOS web interface. Do not enter your computer's login password. The terminal does not display characters, dots, or other feedback while you type the password. Press Enter when you finish.
+
+### Confirm that you are connected
+
+After authentication succeeds, the terminal displays a new command prompt, typically beginning with `start9@` followed by your server's hostname. Commands entered at this prompt run on your StartOS server.
+
+You can confirm the session with these commands:
+
+```sh
+whoami
+hostname
+```
+
+`whoami` should display `start9`, and `hostname` should display your server's hostname.
+
+### Troubleshoot a closed connection
+
+If `Connection closed` appears before the server's command prompt, the SSH session ended without opening a usable command line. Do not enter commands intended for StartOS at your computer's original prompt.
+
+Confirm that you entered the correct server hostname and that its StartOS web interface is reachable from the same computer, then try the SSH command again. If the connection closes again, copy the complete command and output and [contact Start9 support](https://start9.com/contact).
+
+## Connect with an SSH key
 
 ### Create an SSH key
 
-If you don't already have an SSH key pair on your laptop or desktop, open a terminal and run:
+If you do not already have an SSH key pair on your computer, open a terminal as described above and run:
 
-```bash
+```sh
 ssh-keygen -t ed25519
 ```
 
-Press Enter to accept the default file location, and optionally set a passphrase. Your public key will be at `~/.ssh/id_ed25519.pub`.
+Press Enter to accept the default file location. You can optionally create a passphrase, which protects the private SSH key stored on your computer. This key passphrase is separate from both your StartOS master password and your computer's login password.
+
+Your public key is stored at `~/.ssh/id_ed25519.pub`.
 
 ### Add your key to StartOS
 
-1.  Copy your public key to clipboard:
+Display your public key in the terminal:
 
-        cat ~/.ssh/id_ed25519.pub
+{{#tabs global="platform"}}
+{{#tab name="Mac"}}
 
-1.  In the StartOS UI, go to `System > SSH`
+```sh
+cat ~/.ssh/id_ed25519.pub
+```
 
-1.  Click `Add Key`, paste in your key and click `Save`
+{{#endtab}}
+{{#tab name="Windows"}}
 
-1.  Open a terminal on your client device and enter:
+```powershell
+Get-Content $HOME\.ssh\id_ed25519.pub
+```
 
-        ssh start9@SERVER-HOSTNAME
+{{#endtab}}
+{{#tab name="Linux"}}
 
-    Replace `SERVER-HOSTNAME` with your server's `your-server-name.local` address.
+```sh
+cat ~/.ssh/id_ed25519.pub
+```
 
-1.  Enter your key's passphrase (if any)
+{{#endtab}}
+{{#endtabs}}
+
+Copy the complete key displayed in the terminal.
+
+In the StartOS web interface, go to `System > SSH`, select **Add Key**, paste the public key, and select **Save**.
+
+### Start the SSH connection
+
+Open a terminal on your computer and run:
+
+```sh
+ssh start9@SERVER-HOSTNAME
+```
+
+Replace `SERVER-HOSTNAME` with your server's `your-server-name.local` address.
+
+If the terminal asks for `Enter passphrase for key`, enter the passphrase you created for the SSH key. This prompt does not ask for your StartOS master password or your computer's login password.
+
+Use the checks under [Confirm that you are connected](#confirm-that-you-are-connected) to verify that commands will run on your StartOS server.

--- a/projects/start-tunnel/docs/src/installing.md
+++ b/projects/start-tunnel/docs/src/installing.md
@@ -28,26 +28,22 @@ Rent a cheap VPS with a dedicated public IP. Minimum CPU, RAM, and disk are fine
 
 ### Network speed and monthly transfer
 
-A VPS plan may list both a network speed, such as 1 Gbps, and a monthly transfer allowance, such as 1 TB. Network speed limits throughput at any moment. The monthly allowance limits the total data the provider records during a billing period.
+Choose a network speed that supports the traffic you expect to send through StartTunnel. Monthly transfer rules vary by provider.
 
-StartTunnel relays data between two network legs: traffic enters the VPS from a public client or WireGuard peer and leaves toward the destination. This applies to published services, private connections between devices, and traffic sent through StartTunnel as an outbound gateway. Selecting StartTunnel as a StartOS system or per-service outbound gateway increases usage by sending that Internet traffic through the VPS; it does not create the two-leg behavior.
+Traffic routed through StartTunnel enters and leaves the VPS. Check how your provider counts transfer:
 
-Estimate the total uploads and downloads that StartTunnel will relay each month, then check how the VPS provider measures transfer:
+- If it counts only outbound transfer, plan for roughly your expected uploads plus downloads.
+- If it counts both inbound and outbound transfer, plan for roughly twice that amount.
 
-- If the provider counts only outbound transfer, it records approximately one copy of the relayed data.
-- If the provider adds inbound and outbound transfer together, it records approximately two copies.
+Leave extra capacity for network overhead. Selecting StartTunnel as a StartOS system or per-service [outbound gateway](/start-os/outbound-vpn.html) adds that Internet traffic to your estimate. Standard IPv4 device configurations leave unrelated Internet traffic on the device's normal connection.
 
-Leave additional capacity for WireGuard, IP, transport, and encryption overhead, acknowledgements, retransmissions, handshakes, and keepalives. The provider's dashboard is the authority for billable usage.
-
-Only traffic routed through StartTunnel belongs in this estimate. Standard StartTunnel IPv4 device configurations use split tunneling, so unrelated Internet traffic from those devices bypasses the VPS. A StartOS server sends Internet traffic through the VPS when StartTunnel is selected as its system or per-service [outbound gateway](/start-os/outbound-vpn.html). Devices with a [StartTunnel IPv6 address](ipv6.md#how-it-works) send all IPv6 traffic through the VPS.
-
-The provider's dashboard supplies the persistent monthly usage total and quota alerts. To compare current WireGuard activity by peer, connect to the VPS over SSH and run:
+Use your provider's dashboard to monitor monthly transfer. To compare current usage between WireGuard peers, connect to the VPS over SSH and run:
 
 ```sh
 wg show wg-start-tunnel
 ```
 
-The output has one peer section per device, identified by its WireGuard public key, with transfer received and sent from the VPS's perspective. These counters cover the WireGuard leg only and reset when the WireGuard interface is recreated. The provider calculates its total under its own ingress and egress policy and includes outer IP and UDP headers that these counters omit.
+The counters show data received and sent for each peer. They reset when the WireGuard interface is recreated, so they are not a monthly total.
 
 > [!IMPORTANT]
 > StartTunnel is designed to be the sole application on your VPS. The installer disables UFW and manages its own firewall rules via iptables. Do not run other Internet-facing services on the same VPS.

--- a/projects/start-tunnel/docs/src/installing.md
+++ b/projects/start-tunnel/docs/src/installing.md
@@ -18,13 +18,36 @@ Your public key will be at `~/.ssh/id_ed25519.pub`. You'll paste its contents in
 
 ## Get a VPS
 
-Rent a cheap VPS with a dedicated public IP. Minimum CPU/RAM/disk is fine. For bandwidth, no need to exceed your home Internet's upload speed.
+Rent a cheap VPS with a dedicated public IP. Minimum CPU, RAM, and disk are fine. Choose the network speed and monthly transfer allowance based on the traffic you expect StartTunnel to relay.
 
 ### Requirements
 
 - Debian 13
 - Root access
 - Dedicated public IPv4 address (required for publishing ports to the clearnet)
+
+### Network speed and monthly transfer
+
+A VPS plan may list both a network speed, such as 1 Gbps, and a monthly transfer allowance, such as 1 TB. Network speed limits throughput at any moment. The monthly allowance limits the total data the provider records during a billing period.
+
+StartTunnel relays data between two network legs: traffic enters the VPS from a public client or WireGuard peer and leaves toward the destination. This applies to published services, private connections between devices, and traffic sent through StartTunnel as an outbound gateway. Selecting StartTunnel as a StartOS system or per-service outbound gateway increases usage by sending that Internet traffic through the VPS; it does not create the two-leg behavior.
+
+Estimate the total uploads and downloads that StartTunnel will relay each month, then check how the VPS provider measures transfer:
+
+- If the provider counts only outbound transfer, it records approximately one copy of the relayed data.
+- If the provider adds inbound and outbound transfer together, it records approximately two copies.
+
+Leave additional capacity for WireGuard, IP, transport, and encryption overhead, acknowledgements, retransmissions, handshakes, and keepalives. The provider's dashboard is the authority for billable usage.
+
+Only traffic routed through StartTunnel belongs in this estimate. Standard StartTunnel IPv4 device configurations use split tunneling, so unrelated Internet traffic from those devices bypasses the VPS. A StartOS server sends Internet traffic through the VPS when StartTunnel is selected as its system or per-service [outbound gateway](/start-os/outbound-vpn.html). Devices with a [StartTunnel IPv6 address](ipv6.md#how-it-works) send all IPv6 traffic through the VPS.
+
+The provider's dashboard supplies the persistent monthly usage total and quota alerts. To compare current WireGuard activity by peer, connect to the VPS over SSH and run:
+
+```sh
+wg show wg-start-tunnel
+```
+
+The output has one peer section per device, identified by its WireGuard public key, with transfer received and sent from the VPS's perspective. These counters cover the WireGuard leg only and reset when the WireGuard interface is recreated. The provider calculates its total under its own ingress and egress policy and includes outer IP and UDP headers that these counters omit.
 
 > [!IMPORTANT]
 > StartTunnel is designed to be the sole application on your VPS. The installer disables UFW and manages its own firewall rules via iptables. Do not run other Internet-facing services on the same VPS.

--- a/projects/start-tunnel/docs/src/installing.md
+++ b/projects/start-tunnel/docs/src/installing.md
@@ -182,10 +182,10 @@ When prompted for a certificate, you have two choices:
 
 If you already have a StartOS server and have [trusted its Root CA](/start-os/trust-ca.html), you can sign the StartTunnel certificate with that same CA. This means your browser will trust the StartTunnel web UI automatically — no additional certificate to manage.
 
-1. On your StartOS server, generate a certificate for your StartTunnel's hostname or IP:
+1. On your StartOS server, generate a certificate for your VPS's public IP address:
 
    ```bash
-   start-cli net ssl generate-certificate <HOSTNAME_OR_IP>
+   start-cli net ssl generate-certificate <VPS_IP>
    ```
 
    This outputs a private key and certificate chain in PEM format.


### PR DESCRIPTION
## Summary

### StartTunnel

- identify the certificate subject as the VPS public IP address
- remove ambiguous hostname terminology from the setup step
- use the existing `<VPS_IP>` placeholder consistently
- distinguish VPS network speed from the monthly transfer allowance
- explain how provider ingress and egress policies affect transfer sizing across published, private, and outbound-gateway traffic
- document split-tunnel scope, provider-dashboard monitoring, and the limits of per-peer `wg show` counters

### StartOS

- explain where SSH commands run before and after connecting
- distinguish the StartOS master password, computer login password, and SSH-key passphrase
- show first-time users how to open a terminal, confirm a successful connection, and respond safely to `Connection closed`
- add the Windows command for displaying a generated public key

## Verification

- `cd projects/start-docs && ./build.sh`
- pinned Prettier check for both changed Markdown files