### PR TITLE
fix(start-os): restore hostname collision check after integration

### DIFF
--- a/shared-libs/crates/start-core/src/hostname.rs
+++ b/shared-libs/crates/start-core/src/hostname.rs
@@ -216,12 +216,10 @@ pub async fn set_hostname_rpc(
     let hostname = ServerHostname::new_from_input(hostname)?;
     ctx.db
         .mutate(|db| {
-            if let Some(hostname) = &hostname {
-                let reserved = hostname.local_domain_name();
-                for host in all_hosts(db) {
-                    if host?.as_private_domains().contains_key(&reserved)? {
-                        hostname.reject_private_domain(&reserved)?;
-                    }
+            let reserved = hostname.local_domain_name();
+            for host in all_hosts(db) {
+                if host?.as_private_domains().contains_key(&reserved)? {
+                    hostname.reject_private_domain(&reserved)?;
                 }
             }
             let server_info = db.as_public_mut().as_server_info_mut();


### PR DESCRIPTION
## Summary

- adapt the private-domain collision check to the now-required server hostname
- restore `start-core` compilation after #3785 and #3791 merged together

## Verification

- `cargo check -p start-core --all-targets`
- `cargo test -p start-core hostname:: -- --nocapture` (18 passed)
- `cargo fmt --all --check`
- `git diff --check`