### PR TITLE
fix(core): Let's Encrypt issuance no longer aborts on a 409 conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "async-acme"
 version = "0.6.0"
-source = "git+https://github.com/Start9Labs/async-acme.git?rev=4f71d55304e77650bbbedd33fe0acb5d26d3883f#4f71d55304e77650bbbedd33fe0acb5d26d3883f"
+source = "git+https://github.com/Start9Labs/async-acme.git?rev=45c8a56379c5f8afb6b9dd6511e0c7e1ce70ccf5#45c8a56379c5f8afb6b9dd6511e0c7e1ce70ccf5"
 dependencies = [
  "async-trait",
  "base64 0.22.1",

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -183,6 +183,16 @@ file tracks notable changes since the move to the monorepo.
   starts many of them built them up without limit, and only a restart cleared
   them. The container's first process now collects them as they finish.
 
+- **A Let's Encrypt certificate is issued even when the authority takes longer
+  than a second to check your domain.** StartOS asked Let's Encrypt to run the
+  check and then, one second later, asked it to run the check again — which
+  Let's Encrypt refuses, because the one it was already running had not
+  finished. The whole request failed there, and the retry a minute later failed
+  the same way, so a domain could sit without a certificate indefinitely. Let's
+  Encrypt validates from several vantage points around the world and routinely
+  takes longer than a second, so this affected almost every domain. StartOS now
+  waits for the answer instead of asking again.
+
 - **A Let's Encrypt domain works on an interface served on a port other than
   `443`** — an Electrum server on `50002`, a TURN server on `5349`. Let's
   Encrypt proves you control a name by connecting to it on port `443` whatever

--- a/shared-libs/crates/start-core/Cargo.toml
+++ b/shared-libs/crates/start-core/Cargo.toml
@@ -32,7 +32,7 @@ unstable = ["backtrace-on-stack-overflow"]
 
 [dependencies]
 aes = "0.9.1"
-async-acme = { version = "0.6.0", git = "https://github.com/Start9Labs/async-acme.git", rev = "4f71d55304e77650bbbedd33fe0acb5d26d3883f", features = [
+async-acme = { version = "0.6.0", git = "https://github.com/Start9Labs/async-acme.git", rev = "45c8a56379c5f8afb6b9dd6511e0c7e1ce70ccf5", features = [
   "use_rustls",
   "use_tokio",
 ] }


### PR DESCRIPTION
TLS-ALPN-01 issuance fails for anyone whose validation takes longer than a second — since July 2026, essentially everyone. The fault was in the pinned `async-acme` fork, in `rustls_helper::authorize`: it triggered the challenge, then re-POSTed it on every poll that still saw the authorization as `pending`.

Per RFC 8555 §7.1.6 an authorization stays `pending` for exactly as long as its challenge is `processing`, and `Auth` could not represent that — it mirrors the authorization resource, and the fork's `Challenge` carried no `status` field either. So the loop could not tell "not yet triggered" from "validation in flight" and always re-POSTed. Boulder used to start a second validation on such a re-POST and drop whichever attempt finished last, so the loop was non-conformant but worked; since letsencrypt/boulder#8838 (merged 2026-07-23) it rejects a POST to an authorization already being validated with 409 `urn:ietf:params:acme:error:conflict`, `?` turns that into a hard `OrderError`, and the whole order is abandoned. The first re-POST lands one `sleep(1s)` after the trigger, and Let's Encrypt validates from several perspectives, so it is now the normal case, not an edge:

    01:07:37.51  performing ACME auth challenge
    01:07:38.05  performing ACME auth challenge
    01:07:38.86  .../acme/chall/... HTTP 409 {"type":"...:error:conflict"}
                 ACME order failed: acme error: HTTP Status 409
                 ACME order for {...} backing off for 60s

RFC 8555 §7.5.1 has the client trigger once and then poll the authorization, so the fix drops the re-trigger and polls the authorization instead. It is merged as Start9Labs/async-acme#4 (45c8a56), verified against live Let's Encrypt before merge: two orders, one challenge trigger each, no 409, certificates in 5.9 s and 4.9 s. This bumps the pin from 4f71d55 to that merge commit; the crate's dependency set is unchanged, so only the lockfile's source line moves.

Claude-Session: https://claude.ai/code/session_017q6ATEuNzjQfayBiLsEwtC