### PR TITLE
feat(core): add inbound WireGuard gateway marker

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -31,6 +31,11 @@ file tracks notable changes since the move to the monorepo.
   the gateway advertises), so the route comes up either way; PCP remains
   preferred when it gets through.
 
+- **WireGuard configs can declare inbound gateway support.** A config containing
+  `# inbound: yes` is classified as an inbound/outbound gateway when imported.
+  Existing StartTunnel configs remain recognizable by their StartTunnel header;
+  configs without either marker are classified as outbound-only.
+
 - **A service can permanently retire a network host or a port it no longer
   uses, and the port numbers it held become available again.** A service that
   reorganizes its interfaces across an update — renaming a host, dropping a

--- a/projects/start-os/docs/src/gateways.md
+++ b/projects/start-os/docs/src/gateways.md
@@ -30,8 +30,9 @@ Every gateway routes outbound traffic from your server to the Internet. Some gat
 1. Upload or paste a WireGuard configuration file from your VPN provider or StartTunnel instance.
 
    StartOS will automatically detect the gateway type:
-   - **StartTunnel** config files are recognized and marked as _inbound/outbound_ gateways.
-   - **All other** WireGuard configs are marked as _outbound-only_ gateways.
+   - Config files containing `# inbound: yes` are marked as _inbound/outbound_ gateways. StartTunnel adds this marker to the configs it generates.
+   - Older StartTunnel configs are also recognized by their StartTunnel header and marked as _inbound/outbound_ gateways.
+   - WireGuard configs without either marker are marked as _outbound-only_ gateways.
 
 ## Updating a Gateway's Config
 

--- a/projects/start-tunnel/CHANGELOG.md
+++ b/projects/start-tunnel/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the tunnel cannot bind the shared port's listener, instead of being
   acknowledged while routing nothing.
 
+- **Generated WireGuard configs identify their gateway as accepting inbound
+  connections.** Each config includes the `# inbound: yes` gateway marker while retaining its
+  StartTunnel header for compatibility with older StartOS versions.
+
 ### Fixed
 
 - **`start-tunnel` reaches a daemon that listens on a wildcard address.** With no

--- a/projects/start-tunnel/docs/src/devices.md
+++ b/projects/start-tunnel/docs/src/devices.md
@@ -20,7 +20,7 @@ Every device on a StartTunnel subnet gets its own WireGuard configuration. Devic
 1. Download the resulting `start-tunnel.conf` (or copy to your clipboard).
 
 1. Import the config into the appropriate app on the device:
-   - **StartOS server**: Navigate to `System > Gateways`, click "Add", name the gateway (e.g. "StartTunnel"), upload or paste the config, and click "Save". StartOS will now see the VPS as a gateway, and each service interface will automatically acquire new addresses corresponding to it.
+   - **StartOS server**: Navigate to `System > Gateways`, click "Add", name the gateway (e.g. "StartTunnel"), upload or paste the config, and click "Save". The config's `# inbound: yes` marker lets StartOS identify it as an inbound/outbound gateway, and each service interface automatically acquires new addresses corresponding to it.
    - **Phone or tablet**: Scan the QR code shown in StartTunnel using the [WireGuard app](https://www.wireguard.com/install/).
    - **Laptop or desktop**: Download the config and import it into the [WireGuard app](https://www.wireguard.com/install/).
 

--- a/shared-libs/crates/start-core/src/net/tunnel.rs
+++ b/shared-libs/crates/start-core/src/net/tunnel.rs
@@ -15,6 +15,8 @@ use crate::db::model::public::{
 use crate::net::host::all_hosts;
 use crate::prelude::*;
 
+pub(crate) const INBOUND_GATEWAY_MARKER: &str = "# inbound: yes";
+
 pub fn tunnel_api<C: Context>() -> ParentHandler<C> {
     ParentHandler::new()
         .subcommand(
@@ -64,17 +66,7 @@ pub async fn add_tunnel(
         set_as_default_outbound,
     }: AddTunnelParams,
 ) -> Result<GatewayId, Error> {
-    // Caller may declare the type; fall back to auto-detection only when absent.
-    // StartTunnel configs carry a marker => inbound/outbound; anything else
-    // (e.g. a commercial VPN like Mullvad) => outbound-only.
-    let gateway_type = gateway_type.unwrap_or_else(|| {
-        let marker = crate::tunnel::wg::START_TUNNEL_MARKER.to_lowercase();
-        if config.to_lowercase().contains(&marker) {
-            GatewayType::InboundOutbound
-        } else {
-            GatewayType::OutboundOnly
-        }
-    });
+    let gateway_type = gateway_type.unwrap_or_else(|| gateway_type_from_config(&config));
 
     let ifaces = ctx.net_controller.net_iface.watcher.subscribe();
     let mut iface = GatewayId::from(InternedString::intern("wg0"));
@@ -164,6 +156,18 @@ pub async fn add_tunnel(
     }
 
     Ok(iface)
+}
+
+fn gateway_type_from_config(config: &str) -> GatewayType {
+    let has_inbound_marker = config
+        .lines()
+        .any(|line| line.trim() == INBOUND_GATEWAY_MARKER);
+    let legacy_marker = crate::tunnel::wg::START_TUNNEL_MARKER.to_ascii_lowercase();
+    if has_inbound_marker || config.to_ascii_lowercase().contains(&legacy_marker) {
+        GatewayType::InboundOutbound
+    } else {
+        GatewayType::OutboundOnly
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Parser, TS)]
@@ -326,4 +330,45 @@ pub async fn update_tunnel(
     // and if the handler is cancelled, the gateway is simply left on its old (or
     // new) config, never in a half-deleted state.
     crate::net::gateway::update_wireguard_config(id.as_str(), &config).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inbound_marker_selects_inbound_outbound() {
+        assert_eq!(
+            gateway_type_from_config("[Interface]\n# inbound: yes\n"),
+            GatewayType::InboundOutbound
+        );
+    }
+
+    #[test]
+    fn start_tunnel_marker_remains_inbound_outbound() {
+        assert_eq!(
+            gateway_type_from_config("# starttunnel config for server\n"),
+            GatewayType::InboundOutbound
+        );
+    }
+
+    #[test]
+    fn inbound_marker_requires_a_complete_line() {
+        assert_eq!(
+            gateway_type_from_config("# inbound: yesterday\n"),
+            GatewayType::OutboundOnly
+        );
+        assert_eq!(
+            gateway_type_from_config("# Remove # inbound: yes unless supported\n"),
+            GatewayType::OutboundOnly
+        );
+    }
+
+    #[test]
+    fn unmarked_config_is_outbound_only() {
+        assert_eq!(
+            gateway_type_from_config("[Interface]\nAddress = 192.0.2.2/32\n"),
+            GatewayType::OutboundOnly
+        );
+    }
 }

--- a/shared-libs/crates/start-core/src/tunnel/client.conf.template
+++ b/shared-libs/crates/start-core/src/tunnel/client.conf.template
@@ -1,4 +1,5 @@
 # {marker} config for {name}
+{inbound_marker}
 
 [Interface]
 Address = {addr}

--- a/shared-libs/crates/start-core/src/tunnel/wg.rs
+++ b/shared-libs/crates/start-core/src/tunnel/wg.rs
@@ -21,14 +21,7 @@ pub fn current_ifindex() -> u32 {
     nix::net::if_::if_nametoindex(WIREGUARD_INTERFACE_NAME).unwrap_or(0)
 }
 
-/// Brand token written into every StartTunnel client config's header (see
-/// client.conf.template, rendered as `# StartTunnel config for <name>`).
-/// `add_tunnel` looks for this token (case-insensitively) to classify a pasted
-/// config as an inbound/outbound StartTunnel gateway — vs outbound-only for
-/// plain WireGuard configs like Mullvad. Matching just the brand token keeps
-/// detection working across StartTunnel/StartOS version skew and any future
-/// rewording of the surrounding header, and stays backwards-compatible with
-/// configs generated before this check existed.
+/// Legacy marker retained for StartOS gateway auto-detection.
 pub const START_TUNNEL_MARKER: &str = "StartTunnel";
 
 #[derive(Deserialize, Serialize, HasModel, TS)]
@@ -352,6 +345,7 @@ impl std::fmt::Display for ClientConfig {
             f,
             include_str!("./client.conf.template"),
             marker = START_TUNNEL_MARKER,
+            inbound_marker = crate::net::tunnel::INBOUND_GATEWAY_MARKER,
             name = self.client_config.name,
             privkey = self.client_config.key.to_padded_string(),
             psk = self.client_config.psk.to_padded_string(),
@@ -384,6 +378,8 @@ mod tests {
                 None,
             )
             .to_string();
+        assert!(cfg.contains("# StartTunnel config for phone"));
+        assert!(cfg.contains(crate::net::tunnel::INBOUND_GATEWAY_MARKER));
         assert!(cfg.contains("Address = 10.59.0.2/24"));
         assert!(cfg.contains("DNS = 10.59.0.1"));
         assert!(cfg.contains("AllowedIPs = 10.59.0.0/24"));


### PR DESCRIPTION
## Summary

- recognize an exact `# inbound: yes` line when StartOS auto-classifies imported WireGuard gateways
- keep the legacy case-insensitive StartTunnel marker for compatibility
- include both markers in StartTunnel-generated client configs and document the behavior

## Testing

- `cargo test -p start-core net::tunnel::tests --features=test`
- `cargo test -p start-core tunnel::wg::tests::client_config_without_ipv6_is_v4_only --features=test`
- `make start-core-format-check`
- `npm run build:deps`
- `make projects/start-tunnel/web/dist/static/start-tunnel/index.html`
- `cargo check -p start-tunnel`
- `npx --no-install prettier --check projects/start-os/CHANGELOG.md projects/start-os/docs/src/gateways.md projects/start-tunnel/CHANGELOG.md projects/start-tunnel/docs/src/devices.md`
- `cd projects/start-docs && ./build.sh`
