### PR TITLE
docs: correct the Bitcoin flavors table for the Knots registry move

### DIFF
--- a/projects/start-docs/bitcoin-guides/src/README.md
+++ b/projects/start-docs/bitcoin-guides/src/README.md
@@ -32,12 +32,12 @@ StartOS supports multiple Bitcoin and Lightning node implementations. You are no
 
 The Bitcoin service on StartOS is available in multiple flavors (implementations). The service is called **Bitcoin** regardless of which flavor you install — the flavor determines the underlying software.
 
-| Flavor            | Description                                                                                      |
-| ----------------- | ------------------------------------------------------------------------------------------------ |
-| **Bitcoin Core**  | The reference implementation — validates blocks, relays transactions, serves wallet data via RPC |
-| **Bitcoin Knots** | A Bitcoin Core derivative with additional configuration options and policy controls              |
+| Flavor                       | Registry           | Description                                                                                                                              |
+| ---------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bitcoin Core**             | Start9 Registry    | The reference implementation — validates blocks, relays transactions, serves wallet data via RPC                                         |
+| **Bitcoin Knots (pre-RDTS)** | Community Registry | A Bitcoin Core derivative with additional configuration options and policy controls, pinned to its last release before the RDTS softfork |
 
-Both flavors provide the same RPC interface used by wallets and Electrum servers.
+Both follow the same blockchain and expose the same RPC interface used by wallets and Electrum servers, so switching between them keeps the chain you have already synced. Both registries ship with StartOS — click "Switch" beneath the current registry title in the Marketplace sidebar to move between them. Community Registry services are [not maintained, recommended, or supported by Start9](/start-os/default-registries.html).
 
 ### Lightning Nodes
 


### PR DESCRIPTION
The Bitcoin Guides landing page still described Bitcoin Knots as a Marketplace flavor sitting alongside Core. Two things about that are no longer true.

**Where it lives.** The Start9 Registry now serves Bitcoin Core alone:

```
Start9 Registry      31.1:15                = Bitcoin Core
Community Registry   #knotsprerdts:29.3:27  = Bitcoin Knots (pre-RDTS)
```

A reader following this page looked for Knots where it no longer is. The table gains a Registry column, and the page now says both registries ship with StartOS and how to switch between them, linking the [Community Registry's support status](/start-os/default-registries.html) rather than restating it.

**What it is called.** The package is titled *Bitcoin Knots (pre-RDTS)*. The description says what the suffix means — pinned to its last release before the RDTS softfork — so the name here matches the name in the Marketplace.

The closing line also leads with the chain rather than the RPC interface, since "does it follow the same chain" is the property someone switching flavors actually cares about, and it is what makes switching keep an already-synced chain.

---

Targets `live-docs` because it only corrects already-published text; `docs-backport.yml` carries it to master. Touches one file under `projects/start-docs/`, so `live-docs-guard` is satisfied. `./build.sh` passes, and the cross-book link resolves through the deploy's generated nginx `book_versions.conf`, which maps `/<book>/<rest>` onto the current version directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)