### PR TITLE
feat(registry): expand index subscriptions

### DIFF
--- a/projects/start-registry/ARCHITECTURE.md
+++ b/projects/start-registry/ARCHITECTURE.md
@@ -43,15 +43,22 @@ Defined in `shared-libs/crates/start-core/src/registry/mod.rs`:
 
 Subcommands (same module), each available over RPC and to the `start-registry` CLI via `with_call_remote`:
 
-| Command   | Module                | Purpose                                                                |
-| --------- | --------------------- | ---------------------------------------------------------------------- |
-| `index`   | `mod::get_full_index` | full combined index (name, icon, packages, OS, signers)                |
-| `info`    | `registry/info.rs`    | set/get registry info and categories                                   |
-| `os`      | `registry/os/`        | OS version index + asset (image) management                            |
-| `package` | `registry/package/`   | add/get/list packages, versions, assets                                |
-| `admin`   | `registry/admin.rs`   | manage admins and signers                                              |
-| `db`      | `registry/db.rs`      | dump/inspect the registry database; subscribe to package-index changes |
-| `metrics` | `registry/metrics.rs` | download/user metrics summaries (admin-only)                           |
+| Command   | Module                | Purpose                                                                  |
+| --------- | --------------------- | ------------------------------------------------------------------------ |
+| `index`   | `mod::get_full_index` | full combined index (name, icon, packages, OS, signers)                  |
+| `info`    | `registry/info.rs`    | set/get registry info and categories                                     |
+| `os`      | `registry/os/`        | OS version index + asset (image) management                              |
+| `package` | `registry/package/`   | add/get/list packages, versions, assets                                  |
+| `admin`   | `registry/admin.rs`   | manage admins and signers                                                |
+| `db`      | `registry/db.rs`      | dump/inspect the registry database; subscribe to `/index` or any subpath |
+| `metrics` | `registry/metrics.rs` | download/user metrics summaries (admin-only)                             |
+
+### Registry index subscriptions
+
+The public `db.subscribe` RPC accepts `{ "pointer": <JSON Pointer> }`. The pointer may select
+`/index` or any descendant; omitting it or passing `null` selects `/index`. The response contains
+an initial `{ id, value }` dump and a continuation `guid`. Connecting to `/ws/rpc/<guid>` streams
+revisions whose JSON Patch paths are relative to the selected subtree.
 
 ## Data model
 

--- a/projects/start-registry/CHANGELOG.md
+++ b/projects/start-registry/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to `start-registry` (the Start Registry server) are document
 
 ## [1.0.2]
 
-- **A client can follow the package index over a websocket instead of re-fetching it.** `db.subscribe`
-  returns the index as it stands plus a continuation id; connecting to `/ws/rpc/<id>` then streams a
-  JSON patch each time a package or version is added, removed, or recategorized. It is
-  unauthenticated and carries only the subtree `package.index` already serves.
+- **A client can follow the registry index over a websocket instead of re-fetching it.**
+  `db.subscribe` returns `/index` as it stands plus a continuation id; connecting to
+  `/ws/rpc/<id>` then streams its JSON patches. Callers can select `/index` or any subpath,
+  including the package or OS index, while the endpoint remains unauthenticated.
 
 - **An indexed package version now advertises which installed versions can migrate into it**, so a
   client asking for an upgrade path is offered a version it can actually install. Entries already

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -2169,6 +2169,14 @@ registry.context.unauthorized:
   fr_FR: "Non autorisé"
   pl_PL: "Brak autoryzacji"
 
+# registry/db.rs
+registry.db.pointer-outside-index:
+  en_US: "Subscription pointer must be at or below /index"
+  de_DE: "Der Abonnement-Zeiger muss auf oder unter /index liegen"
+  es_ES: "El puntero de suscripción debe estar en /index o por debajo"
+  fr_FR: "Le pointeur d'abonnement doit être situé au niveau ou en dessous de /index"
+  pl_PL: "Wskaźnik subskrypcji musi znajdować się w /index lub poniżej"
+
 # registry/os/asset/add.rs
 registry.os.asset.commitment-mismatch:
   en_US: "Commitment does not match"

--- a/shared-libs/crates/start-core/src/registry/db.rs
+++ b/shared-libs/crates/start-core/src/registry/db.rs
@@ -21,8 +21,7 @@ use crate::rpc_continuations::{Guid, RpcContinuation};
 use crate::util::serde::{HandlerExtSerde, apply_expr};
 
 lazy_static::lazy_static! {
-    /// Must stay within what `package.index` already serves unauthenticated.
-    static ref PACKAGE_INDEX: JsonPointer = "/index/package".parse().unwrap();
+    static ref INDEX: JsonPointer = "/index".parse().unwrap();
 }
 
 pub fn db_api<C: Context>() -> ParentHandler<C> {
@@ -111,8 +110,29 @@ pub async fn dump(ctx: RegistryContext, DumpParams { pointer }: DumpParams) -> R
         .await)
 }
 
-pub async fn subscribe(ctx: RegistryContext) -> Result<SubscribeRes, Error> {
-    let (dump, mut sub) = ctx.db.dump_and_sub(PACKAGE_INDEX.clone()).await;
+#[derive(Deserialize, Serialize, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct SubscribeParams {
+    #[ts(type = "string | null")]
+    pointer: Option<JsonPointer>,
+}
+
+fn subscription_pointer(pointer: Option<JsonPointer>) -> Result<JsonPointer, Error> {
+    let pointer = pointer.unwrap_or_else(|| INDEX.clone());
+    ensure_code!(
+        pointer.starts_with(&*INDEX),
+        ErrorKind::InvalidRequest,
+        "{}",
+        rust_i18n::t!("registry.db.pointer-outside-index")
+    );
+    Ok(pointer)
+}
+
+pub async fn subscribe(
+    ctx: RegistryContext,
+    SubscribeParams { pointer }: SubscribeParams,
+) -> Result<SubscribeRes, Error> {
+    let (dump, mut sub) = ctx.db.dump_and_sub(subscription_pointer(pointer)?).await;
     let guid = Guid::new();
     ctx.rpc_continuations
         .add(
@@ -156,6 +176,46 @@ pub async fn subscribe(ctx: RegistryContext) -> Result<SubscribeRes, Error> {
         .await;
 
     Ok(SubscribeRes { dump, guid })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn subscribe_params_allow_an_omitted_or_null_pointer() {
+        for params in [
+            serde_json::json!({}),
+            serde_json::json!({ "pointer": null }),
+        ] {
+            let params: SubscribeParams = serde_json::from_value(params).unwrap();
+            assert!(params.pointer.is_none());
+        }
+    }
+
+    #[test]
+    fn subscription_pointer_defaults_to_index() {
+        assert_eq!(subscription_pointer(None).unwrap(), INDEX.clone());
+    }
+
+    #[test]
+    fn subscription_pointer_accepts_index_descendants() {
+        for pointer in ["/index", "/index/package", "/index/os/versions"] {
+            let pointer: JsonPointer = pointer.parse().unwrap();
+            assert_eq!(
+                subscription_pointer(Some(pointer.clone())).unwrap(),
+                pointer
+            );
+        }
+    }
+
+    #[test]
+    fn subscription_pointer_rejects_paths_outside_index() {
+        for pointer in ["", "/", "/admins", "/indexing"] {
+            let err = subscription_pointer(Some(pointer.parse().unwrap())).unwrap_err();
+            assert!(matches!(err.kind, ErrorKind::InvalidRequest));
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize, Parser)]


### PR DESCRIPTION
## Summary
- default unauthenticated `db.subscribe` calls to `/index`
- allow callers to select any JSON Pointer at or below `/index`
- reject pointers outside the public index and document the request/stream contract

## Verification
- `cargo test -p start-core registry --features=test` (67 passed)
- `cargo check -p start-registry`
- `make start-core-format-check`
- `make start-registry-format-check`
- pinned Prettier check for changed Markdown/YAML
- `git diff --check`

## Note
- `cargo clippy -p start-core` is currently blocked by pre-existing Rust 1.94 lints denied in `shared-libs/crates/patch-db/json-patch/src/lib.rs` (`type_complexity` and `borrow_deref_ref`).