### PR TITLE
fix(scripts): resolve the personal signing key from the repo and overwrite partial signatures

### DIFF
--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -124,7 +124,7 @@ Everything rests on that fingerprint being the right one, so confirm it somewher
 > [!WARNING]
 > The download in the next step contains a copy of the key, as `start9.key.asc`. Do not use that one. A key that arrives alongside the signature it is checking proves nothing.
 
-**2. Download `signatures.tar.gz`** from the release page and unpack it, into the same folder as your image. It holds one signature per image, named after the image with `.start9.asc` on the end. A second signature from the person who cut the release is in there too — the `.start9.asc` one is the one to check.
+**2. Download `signatures.tar.gz`** from the release page and unpack it, into the same folder as your image. It holds one signature per image, named after the image with `.start9.asc` on the end. A second signature from the person who cut the release may be in there too — the `.start9.asc` one is the one to check.
 
 **3. Check your image.** Replace `FILENAME` with the name of the file you downloaded, in both places:
 

--- a/projects/start-os/docs/src/installing-startos.md
+++ b/projects/start-os/docs/src/installing-startos.md
@@ -124,7 +124,7 @@ Everything rests on that fingerprint being the right one, so confirm it somewher
 > [!WARNING]
 > The download in the next step contains a copy of the key, as `start9.key.asc`. Do not use that one. A key that arrives alongside the signature it is checking proves nothing.
 
-**2. Download `signatures.tar.gz`** from the release page and unpack it, into the same folder as your image. It holds one signature per image, named after the image with `.start9.asc` on the end. A second signature from the person who cut the release may be in there too — the `.start9.asc` one is the one to check.
+**2. Download `signatures.tar.gz`** from the release page and unpack it, into the same folder as your image. It holds one signature per image, named after the image with `.start9.asc` on the end. Additional maintainer signatures may be included — the `.start9.asc` one is the one to check.
 
 **3. Check your image.** Replace `FILENAME` with the name of the file you downloaded, in both places:
 

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -313,7 +313,8 @@ release_files() {
 
 resolve_gh_user() {
     GH_USER=${GH_USER:-$(gh api user -q .login 2>/dev/null || true)}
-    GH_GPG_KEY=$(git config user.signingkey 2>/dev/null || true)
+    GH_GPG_KEY=$(git -C "$REPO_ROOT" config user.signingkey 2>/dev/null || true)
+    [ "$(git -C "$REPO_ROOT" config gpg.format 2>/dev/null)" != ssh ] || GH_GPG_KEY=
 }
 
 require_kind() {
@@ -1328,9 +1329,9 @@ cmd_sign() {
     mapfile -t files < <(release_files)
     mkdir -p signatures
     for file in "${files[@]}"; do
-        gpg -u $START9_GPG_KEY --detach-sign --armor -o "signatures/${file}.start9.asc" "$file"
+        gpg -u $START9_GPG_KEY --yes --detach-sign --armor -o "signatures/${file}.start9.asc" "$file"
         if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
-            gpg -u "$GH_GPG_KEY" --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+            gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
         fi
     done
 
@@ -1366,7 +1367,7 @@ cmd_cosign() {
     local files file
     mapfile -t files < <(release_files)
     for file in "${files[@]}"; do
-        gpg -u "$GH_GPG_KEY" --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+        gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
     done
     gpg --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
 

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -313,6 +313,10 @@ release_files() {
 
 resolve_gh_user() {
     GH_USER=${GH_USER:-$(gh api user -q .login 2>/dev/null || true)}
+    if [ "${GH_USER,,}" = start9 ]; then
+        >&2 echo "Error: GitHub user '$GH_USER' is reserved for Start9 signatures"
+        exit 1
+    fi
     GH_GPG_KEY=$(git -C "$REPO_ROOT" config user.signingkey 2>/dev/null || true)
     case "$(git -C "$REPO_ROOT" config gpg.format 2>/dev/null)" in
         '' | openpgp) ;;

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -318,9 +318,6 @@ resolve_gh_user() {
         '' | openpgp) ;;
         *) GH_GPG_KEY= ;;
     esac
-    GH_GPG=$(git -C "$REPO_ROOT" config gpg.openpgp.program 2>/dev/null \
-        || git -C "$REPO_ROOT" config gpg.program 2>/dev/null \
-        || echo gpg)
 }
 
 require_kind() {
@@ -1334,16 +1331,17 @@ cmd_sign() {
     local files file
     mapfile -t files < <(release_files)
     mkdir -p signatures
+    [ -z "$GH_USER" ] || rm -f "signatures/"*".${GH_USER}.asc" "signatures/${GH_USER}.key.asc"
     for file in "${files[@]}"; do
         gpg -u $START9_GPG_KEY --yes --detach-sign --armor -o "signatures/${file}.start9.asc" "$file"
         if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
-            "$GH_GPG" -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+            gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
         fi
     done
 
     gpg --export -a $START9_GPG_KEY > signatures/start9.key.asc
     if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
-        "$GH_GPG" --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
+        gpg --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
     else
         >&2 echo 'Warning: could not determine GitHub user or GPG signing key, skipping personal signature'
     fi
@@ -1360,7 +1358,7 @@ cmd_cosign() {
 
     if [ -z "$GH_USER" ] || [ -z "$GH_GPG_KEY" ]; then
         >&2 echo 'Error: could not determine GitHub user or GPG signing key'
-        >&2 echo "Set GH_USER and/or configure git user.signingkey"
+        >&2 echo "Set GH_USER and/or configure an OpenPGP git user.signingkey"
         exit 1
     fi
 
@@ -1373,9 +1371,9 @@ cmd_cosign() {
     local files file
     mapfile -t files < <(release_files)
     for file in "${files[@]}"; do
-        "$GH_GPG" -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+        gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
     done
-    "$GH_GPG" --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
+    gpg --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
 
     tar -czf signatures.tar.gz -C signatures .
     gh release upload -R "$REPO" "$TAG" signatures.tar.gz --clobber

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -314,7 +314,13 @@ release_files() {
 resolve_gh_user() {
     GH_USER=${GH_USER:-$(gh api user -q .login 2>/dev/null || true)}
     GH_GPG_KEY=$(git -C "$REPO_ROOT" config user.signingkey 2>/dev/null || true)
-    [ "$(git -C "$REPO_ROOT" config gpg.format 2>/dev/null)" != ssh ] || GH_GPG_KEY=
+    case "$(git -C "$REPO_ROOT" config gpg.format 2>/dev/null)" in
+        '' | openpgp) ;;
+        *) GH_GPG_KEY= ;;
+    esac
+    GH_GPG=$(git -C "$REPO_ROOT" config gpg.openpgp.program 2>/dev/null \
+        || git -C "$REPO_ROOT" config gpg.program 2>/dev/null \
+        || echo gpg)
 }
 
 require_kind() {
@@ -1331,13 +1337,13 @@ cmd_sign() {
     for file in "${files[@]}"; do
         gpg -u $START9_GPG_KEY --yes --detach-sign --armor -o "signatures/${file}.start9.asc" "$file"
         if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
-            gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+            "$GH_GPG" -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
         fi
     done
 
     gpg --export -a $START9_GPG_KEY > signatures/start9.key.asc
     if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
-        gpg --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
+        "$GH_GPG" --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
     else
         >&2 echo 'Warning: could not determine GitHub user or GPG signing key, skipping personal signature'
     fi
@@ -1367,9 +1373,9 @@ cmd_cosign() {
     local files file
     mapfile -t files < <(release_files)
     for file in "${files[@]}"; do
-        gpg -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
+        "$GH_GPG" -u "$GH_GPG_KEY" --yes --detach-sign --armor -o "signatures/${file}.${GH_USER}.asc" "$file"
     done
-    gpg --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
+    "$GH_GPG" --export -a "$GH_GPG_KEY" > "signatures/${GH_USER}.key.asc"
 
     tar -czf signatures.tar.gz -C signatures .
     gh release upload -R "$REPO" "$TAG" signatures.tar.gz --clobber

--- a/scripts/manage-release.sh
+++ b/scripts/manage-release.sh
@@ -318,6 +318,7 @@ resolve_gh_user() {
         '' | openpgp) ;;
         *) GH_GPG_KEY= ;;
     esac
+    [ -z "$GH_GPG_KEY" ] || gpg --list-secret-keys "$GH_GPG_KEY" >/dev/null 2>&1 || GH_GPG_KEY=
 }
 
 require_kind() {
@@ -1330,8 +1331,8 @@ cmd_sign() {
 
     local files file
     mapfile -t files < <(release_files)
-    mkdir -p signatures
-    [ -z "$GH_USER" ] || rm -f "signatures/"*".${GH_USER}.asc" "signatures/${GH_USER}.key.asc"
+    rm -rf signatures
+    mkdir signatures
     for file in "${files[@]}"; do
         gpg -u $START9_GPG_KEY --yes --detach-sign --armor -o "signatures/${file}.start9.asc" "$file"
         if [ -n "$GH_USER" ] && [ -n "$GH_GPG_KEY" ]; then
@@ -1364,8 +1365,10 @@ cmd_cosign() {
 
     echo "Downloading existing signatures..."
     gh release download -R "$REPO" "$TAG" -p "signatures.tar.gz" -D "$(pwd)" --clobber
-    mkdir -p signatures
+    rm -rf signatures
+    mkdir signatures
     tar -xzf signatures.tar.gz -C signatures
+    rm -f "signatures/"*".${GH_USER}.asc" "signatures/${GH_USER}.key.asc"
 
     echo "Adding personal signatures as $GH_USER..."
     local files file


### PR DESCRIPTION
## Summary

- `cmd_sign` and `cmd_cosign` resolve `user.signingkey` after `enter_release_dir` has `cd`'d into the release staging directory, so the repo-local key is never seen and the global one is used. With a global SSH signing key that is a `.pub` path, and gpg aborts with `No secret key` after writing the first Start9 signature. This happened cutting start-cli 2.0.0.
- Read the key from `$REPO_ROOT`, and keep the personal signature only when the repo's `gpg.format` is unset or `openpgp` **and** `gpg --list-secret-keys` on PATH knows the key. Otherwise `sign` skips it with the existing warning and `cosign` fails before downloading anything. Signing stays on `gpg` from PATH, the contract the Start9 key, the apt suite signature and pre-check already rely on; Git's `gpg.program` is deliberately not consulted, since Git guarantees only its `-bsau`/`--verify` interface for it and resolves a relative path from the worktree.
- `sign` rebuilds `signatures/` from empty on every run. `cosign` extracts the release's current archive into an empty directory and removes the current user's entries before regenerating them, so other maintainers' signatures actually present in the archive survive and nothing left in the staging directory from an earlier run is republished. The `start9` signer name is reserved for the organizational signature files.
- Pass `--yes` to the detach-sign calls so re-running `sign` or `cosign` after a partial failure overwrites the half-written `signatures/*.asc` instead of stopping at gpg's overwrite prompt.
- The install guide says additional maintainer signatures may be included in `signatures.tar.gz`, without asserting who they belong to.

Verified by signing start-cli 2.0.0, start-tunnel 1.3.0 and start-registry 1.1.0 with the patched script.

