### PR TITLE
fix(marketplace): scrolling notices, sticky category header, small-screen fixes, visible markdown links

### DIFF
--- a/projects/start-os/web/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
+++ b/projects/start-os/web/ui/src/app/routes/portal/routes/marketplace/marketplace.component.ts
@@ -43,7 +43,9 @@ import { MarketplaceControlsComponent } from './components/controls.component'
       display: flex;
       overflow: hidden;
       padding: 1px;
-      background: #1c1d26;
+      --tui-background-base: #1c1d26;
+
+      background: var(--tui-background-base);
     }
   `,
   imports: [

--- a/shared-libs/ts-modules/marketplace/src/components/marketplace.component.ts
+++ b/shared-libs/ts-modules/marketplace/src/components/marketplace.component.ts
@@ -103,74 +103,77 @@ const ICONS: Record<string, string> = {
       </footer>
     </aside>
     <div class="content">
-      @if (current()?.info?.description; as description) {
-        <div
-          tuiNotification
-          appearance="info"
-          class="g-markdown"
-          safeLinks
-          [innerHTML]="description | localize | markdown | dompurify"
-        ></div>
-      }
-      @if (warning(); as warning) {
-        <div tuiNotification appearance="warning">{{ warning | i18n }}</div>
-      }
-      <header tuiHeader="h4">
-        <hgroup tuiTitle>
-          <h2>
-            @if (current()) {
-              {{ name() | localize }}
-            }
-          </h2>
-        </hgroup>
-        <aside tuiAccessories>
-          <button
-            appearance="secondary-grayscale"
-            tuiButton
-            tuiButtonSelect
-            tuiChevron
-            [(ngModel)]="sortLabel"
-          >
-            {{ sortLabel }}
-            <tui-data-list *tuiDropdown>
-              @for (key of sortKeys; track key) {
-                <button tuiOption [value]="getLabel(key)">
-                  {{ getLabel(key) }}
-                </button>
-              }
-            </tui-data-list>
-          </button>
-        </aside>
-      </header>
       <tui-scrollbar>
-        <section>
-          @if (current()) {
-            @for ($implicit of packages(); track $index) {
-              <ng-container
-                *ngTemplateOutlet="template(); context: { $implicit }"
-              />
-            }
-          } @else {
-            @for (_ of '-'.repeat(6); track $index) {
-              <div tuiCardLarge="compact" [tuiSkeleton]="true">
-                <span tuiCell>
-                  <span tuiAvatar></span>
-                  <span tuiTitle>
-                    Loading
-                    <span tuiSubtitle>Loading</span>
-                  </span>
-                </span>
-                <span tuiDescription>Loading</span>
-              </div>
-            }
+        <div class="scroll">
+          @if (current()?.info?.description; as description) {
+            <div
+              tuiNotification
+              appearance="info"
+              class="g-markdown"
+              safeLinks
+              [innerHTML]="description | localize | markdown | dompurify"
+            ></div>
           }
-        </section>
+          @if (warning(); as warning) {
+            <div tuiNotification appearance="warning">{{ warning | i18n }}</div>
+          }
+          <header tuiHeader="h4">
+            <hgroup tuiTitle>
+              <h2>
+                @if (current()) {
+                  {{ name() | localize }}
+                }
+              </h2>
+            </hgroup>
+            <aside tuiAccessories>
+              <button
+                appearance="secondary-grayscale"
+                tuiButton
+                tuiButtonSelect
+                tuiChevron
+                [(ngModel)]="sortLabel"
+              >
+                {{ sortLabel }}
+                <tui-data-list *tuiDropdown>
+                  @for (key of sortKeys; track key) {
+                    <button tuiOption [value]="getLabel(key)">
+                      {{ getLabel(key) }}
+                    </button>
+                  }
+                </tui-data-list>
+              </button>
+            </aside>
+          </header>
+          <section>
+            @if (current()) {
+              @for ($implicit of packages(); track $index) {
+                <ng-container
+                  *ngTemplateOutlet="template(); context: { $implicit }"
+                />
+              }
+            } @else {
+              @for (_ of '-'.repeat(6); track $index) {
+                <div tuiCardLarge="compact" [tuiSkeleton]="true">
+                  <span tuiCell>
+                    <span tuiAvatar></span>
+                    <span tuiTitle>
+                      Loading
+                      <span tuiSubtitle>Loading</span>
+                    </span>
+                  </span>
+                  <span tuiDescription>Loading</span>
+                </div>
+              }
+            }
+          </section>
+        </div>
       </tui-scrollbar>
     </div>
   `,
   styles: `
     :host {
       --tui-theme-color: var(--tui-background-elevation-1);
+      --card-min: 20rem;
 
       display: flex;
       width: 100%;
@@ -210,24 +213,31 @@ const ICONS: Record<string, string> = {
       margin: 1rem 2rem 0;
     }
 
-    [tuiHeader] {
-      white-space: nowrap;
-      padding: 1rem 2rem 0;
+    .scroll {
+      min-inline-size: calc(var(--card-min) + 2 * 2rem);
     }
 
-    tui-scrollbar {
-      padding-block-start: 1rem;
-      mask: linear-gradient(transparent, black 1rem);
+    [tuiHeader] {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      white-space: nowrap;
+      padding: 1rem 2rem;
+      background: var(--tui-background-base);
     }
 
     section {
       padding: 0 2rem 1rem;
       display: grid;
       gap: 1rem;
-      grid-template-columns: repeat(auto-fill, minmax(17rem, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(var(--card-min), 1fr));
     }
 
     :host-context(tui-root._mobile) {
+      .scroll {
+        min-inline-size: calc(var(--card-min) + 2 * 1rem);
+      }
+
       :is([tuiHeader], section) {
         padding-inline: 1rem;
       }

--- a/shared-libs/ts-modules/marketplace/src/components/registry-select.component.ts
+++ b/shared-libs/ts-modules/marketplace/src/components/registry-select.component.ts
@@ -8,6 +8,7 @@ import {
   TaskService,
 } from '@start9labs/shared'
 import {
+  TUI_BREAKPOINT,
   TuiButton,
   TuiDataList,
   TuiDropdown,
@@ -32,8 +33,8 @@ import { StoreIconDirective } from './store-icon.directive'
     <button
       tuiButton
       tuiDropdown
-      tuiDropdownSided
       iconEnd="@tui.chevron-right"
+      [tuiDropdownSided]="breakpoint() !== 'mobile'"
       size="s"
       appearance="flat-grayscale"
       [(tuiDropdownOpen)]="open"
@@ -152,6 +153,7 @@ export class MarketplaceRegistrySelectComponent {
   private readonly router = inject(Router)
 
   protected open = false
+  protected readonly breakpoint = inject(TUI_BREAKPOINT)
 
   // The resolved current registry — used to label an arbitrary (deep-linked)
   // registry that isn't in the saved list yet.

--- a/shared-libs/ts-modules/shared/styles/shared.scss
+++ b/shared-libs/ts-modules/shared/styles/shared.scss
@@ -128,4 +128,14 @@ tui-dialog :not([tuiForm]) > [tuiNotification]:not(:last-child) {
     border: 1px solid var(--tui-border-normal);
     padding: 0.25rem 0.75rem;
   }
+
+  a {
+    color: var(--tui-text-action);
+    text-decoration: underline;
+    text-decoration-color: color-mix(in lch, currentColor, transparent);
+
+    &:hover {
+      text-decoration-color: currentColor;
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- **Links inside rendered markdown are visible.** `shared.scss` resets every `<a>` to `color: inherit; text-decoration: none`, and the `.g-markdown` rules that dress `| markdown | dompurify` output never restored either, so a link in a service's instructions, its release notes, or a registry's description was indistinguishable from the surrounding text in both the StartOS UI and the brochure marketplace. Anchors inside `.g-markdown` now take the action color with a translucent underline that turns solid on hover, mirroring Taiga's `tuiLink`.
- **The registry notices scroll with the grid.** The description and warning notices sat above the scroll view as fixed chrome, so the package grid scrolled underneath them. They now live inside the scroll view, and the category header with its sort selector is the one sticky element, pinning to the top once it reaches it. It paints on `--tui-background-base`; the StartOS marketplace route now sets that token instead of hard-coding the same color, so the header blends there too.
- **Narrow screens overflow as one block.** The scroll content keeps a minimum width of one card plus the gutters, so the notices, header and cards overflow together and scroll horizontally instead of crunching. The card minimum rises from 17rem to 20rem, held in one `--card-min` property.
- **The registry picker opens below its button on small screens.** The sided dropdown ran off the edge of a phone-width viewport. Below Taiga's mobile breakpoint (`TUI_BREAKPOINT`, under 768px) it opens beneath the button, where Taiga's positioning sizes it to its content, caps it at the viewport and shifts it to stay on screen. Sided above that.

Verified in the brochure marketplace against the live community-beta and beta registries, desktop and phone widths.

No changelog entry yet: 0.4.0.2 has been pulled from beta so the rebuilt alpha image can carry this; the entry lands with whichever OS version ships it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
