### PR TITLE
fix(start-cli): say when the workspace's start-technologies checkout is off live-docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7703,7 +7703,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "start-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "start-core",
  "tracing",

--- a/projects/start-cli/CHANGELOG.md
+++ b/projects/start-cli/CHANGELOG.md
@@ -9,6 +9,19 @@ Because `start-cli` is a thin client over `start-core`, most user-visible CLI ch
 in `start-core`; record here anything that changes this crate's entrypoint, features, packaging,
 or the CLI's externally observable behavior.
 
+## [2.0.1]
+
+### Added
+
+- **`s9pk init-workspace` and `s9pk init-package` say when the workspace's `start-technologies`
+  checkout is on a branch other than `live-docs`.** The notice names the checkout and the branch
+  and says how to replace it.
+
+### Fixed
+
+- **The notice that `start-cli` is behind the published release is given only when the workspace's
+  `start-technologies` checkout is on `live-docs`.**
+
 ## [2.0.0]
 
 ### Added

--- a/projects/start-cli/Cargo.toml
+++ b/projects/start-cli/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 license = "MIT"
 name = "start-cli"
 repository = "https://github.com/Start9Labs/start-technologies"
-version = "2.0.0"                                               # VERSION_BUMP
+version = "2.0.1"                                               # VERSION_BUMP
 
 [[bin]]
 name = "start-cli"

--- a/projects/start-cli/man/start-cli.1
+++ b/projects/start-cli/man/start-cli.1
@@ -1,6 +1,6 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH start-cli 1  "start-cli 2.0.0"
+.TH start-cli 1  "start-cli 2.0.1"
 .SH NAME
 start\-cli
 .SH SYNOPSIS
@@ -120,4 +120,4 @@ Command for calculating the blake3 hash of a file
 start\-cli\-wifi(1)
 Commands related to wifi networks i.e. add, connect, delete
 .SH VERSION
-v2.0.0
+v2.0.1

--- a/projects/start-sdk/docs/src/environment-setup.md
+++ b/projects/start-sdk/docs/src/environment-setup.md
@@ -307,6 +307,6 @@ git -C start-technologies pull --ff-only
 
 `live-docs` only ever moves forward, so this is always a fast-forward. It brings in two things: corrections to already-published pages, as soon as they go live on docs.start9.com, and — when a product is released — that product's whole tree at the release.
 
-There's no separate update command — re-running `init-workspace` on an existing workspace just fills in anything missing, and your `AGENTS.local.md` is never touched.
+There's no separate update command — re-running `init-workspace` on an existing workspace just fills in anything missing, and your `AGENTS.local.md` is never touched. If `start-technologies` has ended up on another branch, `init-workspace` and `init-package` say so; move it out of the workspace and rerun `init-workspace` to get a fresh checkout on `live-docs`.
 
 Your environment is ready. Continue to [Quick Start](./quick-start.md) to scaffold and build your first package inside the workspace.

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -169,6 +169,20 @@ s9pk.init.cloning-guide:
   fr_FR: "Clonage du monorepo Start9 (guide d'empaquetage, sources du SDK et de l'OS)…"
   pl_PL: "Klonowanie monorepo Start9 (przewodnik pakowania, kod źródłowy SDK i OS)…"
 
+s9pk.init.guide-linked-off-branch:
+  en_US: "%{path} links to %{target}, which is on branch `%{branch}`, not `%{expected}`: its guide and package template may describe an `@start9labs/start-sdk` that npm cannot resolve. Rather than switching that checkout, remove the link and %{next} to give the workspace a checkout of its own."
+  de_DE: "%{path} verweist auf %{target}, das auf dem Branch `%{branch}` steht, nicht `%{expected}`: Leitfaden und Paketvorlage könnten ein `@start9labs/start-sdk` beschreiben, das npm nicht auflösen kann. Statt diesen Checkout umzuschalten, entferne den Link und %{next}, damit der Arbeitsbereich einen eigenen Checkout erhält."
+  es_ES: "%{path} enlaza a %{target}, que está en la rama `%{branch}`, no en `%{expected}`: su guía y su plantilla de paquete pueden describir un `@start9labs/start-sdk` que npm no puede resolver. En lugar de cambiar ese checkout, elimina el enlace y %{next} para que el espacio de trabajo tenga un checkout propio."
+  fr_FR: "%{path} pointe vers %{target}, qui est sur la branche `%{branch}`, pas `%{expected}` : son guide et son modèle de paquet peuvent décrire un `@start9labs/start-sdk` que npm ne peut pas résoudre. Plutôt que de changer la branche de ce dépôt, supprimez le lien et %{next} pour donner à l'espace de travail son propre clone."
+  pl_PL: "%{path} wskazuje na %{target}, który jest na gałęzi `%{branch}`, a nie `%{expected}`: jego przewodnik i szablon pakietu mogą opisywać `@start9labs/start-sdk`, którego npm nie może rozwiązać. Zamiast przełączać tamto repozytorium, usuń link i %{next}, aby obszar roboczy otrzymał własną kopię."
+
+s9pk.init.guide-off-branch:
+  en_US: "%{path} is on branch `%{branch}`, not `%{expected}`: its guide and package template may describe an `@start9labs/start-sdk` that npm cannot resolve. Move it out of the workspace, then %{next} to clone a fresh checkout on `%{expected}`."
+  de_DE: "%{path} steht auf dem Branch `%{branch}`, nicht `%{expected}`: Leitfaden und Paketvorlage könnten ein `@start9labs/start-sdk` beschreiben, das npm nicht auflösen kann. Verschiebe es aus dem Arbeitsbereich und %{next}, um einen frischen Checkout auf `%{expected}` zu klonen."
+  es_ES: "%{path} está en la rama `%{branch}`, no en `%{expected}`: su guía y su plantilla de paquete pueden describir un `@start9labs/start-sdk` que npm no puede resolver. Sácalo del espacio de trabajo y después %{next} para clonar un checkout nuevo en `%{expected}`."
+  fr_FR: "%{path} est sur la branche `%{branch}`, pas `%{expected}` : son guide et son modèle de paquet peuvent décrire un `@start9labs/start-sdk` que npm ne peut pas résoudre. Déplacez-le hors de l'espace de travail, puis %{next} pour cloner un nouveau dépôt sur `%{expected}`."
+  pl_PL: "%{path} jest na gałęzi `%{branch}`, a nie `%{expected}`: jego przewodnik i szablon pakietu mogą opisywać `@start9labs/start-sdk`, którego npm nie może rozwiązać. Przenieś go poza obszar roboczy, a następnie %{next}, aby sklonować świeżą kopię na `%{expected}`."
+
 s9pk.init.installing-deps:
   en_US: "Installing dependencies (npm install)…"
   de_DE: "Abhängigkeiten werden installiert (npm install)…"
@@ -203,6 +217,20 @@ s9pk.init.package-exists:
   es_ES: "%{path} ya existe; elige otro nombre o elimínalo."
   fr_FR: "%{path} existe déjà ; choisissez un autre nom ou supprimez-le."
   pl_PL: "%{path} już istnieje; wybierz inną nazwę lub usuń je."
+
+s9pk.init.run-init-workspace:
+  en_US: "run `%{command}`"
+  de_DE: "führe `%{command}` aus"
+  es_ES: "ejecuta `%{command}`"
+  fr_FR: "exécutez `%{command}`"
+  pl_PL: "uruchom `%{command}`"
+
+s9pk.init.run-init-workspace-in-root:
+  en_US: "run `start-cli s9pk init-workspace` from the workspace root"
+  de_DE: "führe `start-cli s9pk init-workspace` im Wurzelverzeichnis des Arbeitsbereichs aus"
+  es_ES: "ejecuta `start-cli s9pk init-workspace` desde la raíz del espacio de trabajo"
+  fr_FR: "exécutez `start-cli s9pk init-workspace` depuis la racine de l'espace de travail"
+  pl_PL: "uruchom `start-cli s9pk init-workspace` w katalogu głównym obszaru roboczego"
 
 s9pk.init.template-missing:
   en_US: "Package template not found at %{path}. Re-run `start-cli s9pk init-workspace` to restore the packaging guide."

--- a/shared-libs/crates/start-core/src/s9pk/init.rs
+++ b/shared-libs/crates/start-core/src/s9pk/init.rs
@@ -150,6 +150,8 @@ pub async fn init_workspace(
             .capture(false)
             .invoke(ErrorKind::Git)
             .await?;
+    } else {
+        warn_if_guide_off_branch(&root);
     }
 
     // Symlink (not a copy) so a guide sync keeps the workspace AGENTS.md current.
@@ -216,6 +218,8 @@ pub async fn init_package(
             ErrorKind::InvalidRequest,
         )
     })?;
+    warn_if_start_cli_outdated(&root);
+    warn_if_guide_off_branch(&root);
 
     // Normalize to a candidate ID, then validate it through the manifest's own
     // rules rather than re-implementing them.
@@ -240,8 +244,6 @@ pub async fn init_package(
             ErrorKind::InvalidRequest,
         ));
     }
-
-    warn_if_start_cli_outdated(&root);
 
     let template = root.join(MONOREPO_DIR).join(TEMPLATE_SUBPATH);
     if !template.exists() {
@@ -296,6 +298,10 @@ pub async fn init_package(
 pub fn warn_if_start_cli_outdated(workspace: &Path) {
     static WARNED: std::sync::Once = std::sync::Once::new();
     WARNED.call_once(|| {
+        // Off `live-docs` the manifest names a version that has not shipped.
+        if guide_branch(workspace).as_deref() != Some(MONOREPO_BRANCH) {
+            return;
+        }
         let Ok(manifest) =
             std::fs::read_to_string(workspace.join(MONOREPO_DIR).join(CLI_MANIFEST_SUBPATH))
         else {
@@ -330,6 +336,61 @@ pub fn warn_if_start_cli_outdated(workspace: &Path) {
             );
         }
     });
+}
+
+fn guide_branch(workspace: &Path) -> Option<String> {
+    let dot_git = workspace.join(MONOREPO_DIR).join(".git");
+    let git_dir = match std::fs::read_to_string(&dot_git) {
+        Ok(gitfile) => dot_git
+            .parent()?
+            .join(gitfile.strip_prefix("gitdir:")?.trim()),
+        Err(_) => dot_git,
+    };
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    Some(head.trim().strip_prefix("ref: refs/heads/")?.to_owned())
+}
+
+fn init_workspace_command(workspace: &Path) -> Option<String> {
+    Some(format!(
+        "start-cli s9pk init-workspace '{}'",
+        workspace.to_str()?.replace('\'', "'\\''")
+    ))
+}
+
+fn warn_if_guide_off_branch(workspace: &Path) {
+    let Some(branch) = guide_branch(workspace).filter(|branch| branch != MONOREPO_BRANCH) else {
+        return;
+    };
+    let docs = workspace.join(MONOREPO_DIR);
+    let next = match init_workspace_command(workspace) {
+        Some(command) => t!("s9pk.init.run-init-workspace", command = command).to_string(),
+        None => t!("s9pk.init.run-init-workspace-in-root").to_string(),
+    };
+    if std::fs::symlink_metadata(&docs).is_ok_and(|meta| meta.file_type().is_symlink()) {
+        let target = std::fs::canonicalize(&docs).unwrap_or_else(|_| docs.clone());
+        eprintln!(
+            "{}",
+            t!(
+                "s9pk.init.guide-linked-off-branch",
+                path = docs.display().to_string(),
+                target = target.display().to_string(),
+                branch = branch,
+                expected = MONOREPO_BRANCH,
+                next = next
+            )
+        );
+    } else {
+        eprintln!(
+            "{}",
+            t!(
+                "s9pk.init.guide-off-branch",
+                path = docs.display().to_string(),
+                branch = branch,
+                expected = MONOREPO_BRANCH,
+                next = next
+            )
+        );
+    }
 }
 
 /// Walk up from `start` (inclusive) for the nearest workspace — a directory whose
@@ -553,6 +614,63 @@ mod test {
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    #[test]
+    fn guide_branch_reads_the_checkouts_own_head() {
+        let ws = tmp();
+        assert_eq!(guide_branch(&ws), None);
+
+        let git = ws.join(MONOREPO_DIR).join(".git");
+        std::fs::create_dir_all(&git).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/master\n").unwrap();
+        assert_eq!(guide_branch(&ws).as_deref(), Some("master"));
+
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/live-docs\n").unwrap();
+        assert_eq!(guide_branch(&ws).as_deref(), Some(MONOREPO_BRANCH));
+
+        // detached
+        std::fs::write(
+            git.join("HEAD"),
+            "0123456789abcdef0123456789abcdef01234567\n",
+        )
+        .unwrap();
+        assert_eq!(guide_branch(&ws), None);
+    }
+
+    #[test]
+    fn guide_branch_follows_a_gitfile() {
+        // a linked worktree or submodule keeps HEAD where its `.git` file points
+        let ws = tmp();
+        let docs = ws.join(MONOREPO_DIR);
+        std::fs::create_dir_all(&docs).unwrap();
+        let git_dir = ws.join("elsewhere/.git/worktrees/x");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(git_dir.join("HEAD"), "ref: refs/heads/feature/x\n").unwrap();
+
+        std::fs::write(
+            docs.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .unwrap();
+        assert_eq!(guide_branch(&ws).as_deref(), Some("feature/x"));
+
+        std::fs::write(docs.join(".git"), "gitdir: ../elsewhere/.git/worktrees/x\n").unwrap();
+        assert_eq!(guide_branch(&ws).as_deref(), Some("feature/x"));
+    }
+
+    #[test]
+    fn init_workspace_command_quotes_the_path() {
+        assert_eq!(
+            init_workspace_command(Path::new("/w s/it's")).as_deref(),
+            Some("start-cli s9pk init-workspace '/w s/it'\\''s'")
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStrExt;
+            let bad = Path::new(std::ffi::OsStr::from_bytes(b"/ws/\xff"));
+            assert_eq!(init_workspace_command(bad), None);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`s9pk init-package` scaffolds from the package template in whatever branch the workspace's `start-technologies` checkout is on, and never looks at that branch. A workspace scaffolded by start-cli 1.x cloned `master`, whose template has pinned `@start9labs/start-sdk@3.0.0` since #3900 — a version npm does not have — so `npm install` fails with `ETARGET` and nothing names the cause:

```
$ start-cli s9pk init-package "Hello World"
Installing dependencies (npm install)…
npm error notarget No matching version found for @start9labs/start-sdk@3.0.0.
```

start-cli 2.0.0 clones `live-docs` for new workspaces and documents a manual `git checkout live-docs` for existing ones, which a 1.0.1 workspace cannot even run (its clone is single-branch, shallow, and sparse).

### Diagnosis, no git

`init-package` — right after workspace discovery, before the package-name and destination checks, so the scaffold directory a failed `npm install` left behind cannot hide it — and `init-workspace`, when it finds an existing checkout, print one line when `start-technologies` is on a branch other than `live-docs`. It names the checkout's path and branch and says what to do:

- **A checkout the workspace owns:** move it out of the workspace, then run `start-cli s9pk init-workspace '<workspace>'`, which clones a fresh checkout on `live-docs`. Moving rather than deleting keeps any local work; the discovered workspace path is single-quoted, and when it is not valid UTF-8 the notice says to run `init-workspace` from the workspace root instead of printing a path.
- **A symlinked checkout** (the "already have the monorepo" layout): the notice names the link and its target and says to remove the link and run the same command, so the workspace gets a checkout of its own and the owner's branch is never touched.

Nothing prescribes or performs a git operation. No single command sequence is right for every checkout state (single-branch refspecs, shallow and sparse clones, stale or diverged local branches, dirty trees, forks), and a fresh blobless clone costs seconds.

### Detection

The branch is read from `start-technologies/.git/HEAD`, following a `gitdir:` file for a linked worktree or submodule. No git process runs, so nothing walks up into an enclosing repository, no path passes through a subprocess's stdout, and a detached HEAD (no `ref:` line) says nothing. A missing checkout says nothing either; `init-workspace` clones it and `init-package` reports the missing template as before.

### Also

- **The notice that `start-cli` is behind the published release is given only when the checkout is on `live-docs`.** The gate lives inside `warn_if_start_cli_outdated`, so `CliContext::build_key()` (e.g. `s9pk pack`) is covered too; on any other branch the manifest names an unreleased version.
- **Unit tests** in the module cover reading a plain `.git/HEAD`, following a `gitdir:` file by absolute and by relative path, a detached HEAD, a missing checkout, and the printed command's quoting and UTF-8 gate. They need no git binary.
- Strings in all five locales; the start-cli changelog under `## [2.0.1]` with the matching bump in `Cargo.toml`, `Cargo.lock`, and the `.TH` header and VERSION section of `man/start-cli.1`; one sentence in the packaging guide's environment-setup page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
