### PR TITLE
fix(core): stop IPv6 stalls on a gateway with no IPv6 address of its own

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -461,6 +461,15 @@ file tracks notable changes since the move to the monorepo.
   you also reach on your local network keeps answering there with your server's
   own certificate.
 
+- **Marketplace, service and OS-update downloads no longer stall for minutes on
+  a server whose IPv6 cannot reach the Internet.** StartOS connects over
+  whichever of a host's IPv6 or IPv4 addresses answers first.
+
+- **An outbound gateway that has an IPv6 router but no IPv6 address of its own
+  carries no IPv6.** Such traffic fails at once and falls back to IPv4, instead
+  of leaving with an address that belongs to another of the server's
+  interfaces.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -441,14 +441,13 @@ file tracks notable changes since the move to the monorepo.
   flavors produced no answer, so a list mixing Bitcoin Core with Bitcoin Knots
   kept whatever order it arrived in.
 
-- **Marketplace, service and OS-update downloads proceed over IPv4 at once when
-  a host's IPv6 is unreachable.** StartOS connects over whichever of a host's
-  IPv6 or IPv4 addresses answers first.
+- **Marketplace, service-package and OS-update downloads fall back to IPv4
+  within a fraction of a second when a host's IPv6 does not answer.** StartOS
+  tries a host's IPv6 and IPv4 addresses a quarter of a second apart and uses
+  the first connection that succeeds.
 
-- **Routes with more than one next hop, a lifetime, or an `unreachable` or
-  `prohibit` type are carried into each gateway's routing table.** The OS log
-  stays clear of `ip route` usage text on a network whose router advertises
-  such routes.
+- **The OS log stays free of `ip route` usage text on a network whose router
+  advertises a route with more than one next hop.**
 
 ### Security
 
@@ -472,7 +471,8 @@ file tracks notable changes since the move to the monorepo.
 
 - **Outbound IPv6 leaves only through an address of the selected gateway's
   own.** A gateway with an IPv6 router but no IPv6 address of its own carries
-  no IPv6; such traffic fails at once and falls back to IPv4.
+  no IPv6; such traffic is refused on the spot rather than sent with another
+  interface's address.
 
 ## [0.4.0.1]
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -470,6 +470,11 @@ file tracks notable changes since the move to the monorepo.
   of leaving with an address that belongs to another of the server's
   interfaces.
 
+- **The gateway watcher no longer logs `ip route`'s usage text every few
+  minutes** on a network whose router advertises a route with more than one
+  next hop. Such routes, routes with a lifetime, and `unreachable` or
+  `prohibit` routes are now carried into each gateway's routing table too.
+
 ## [0.4.0.1]
 
 ### Changed

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -446,7 +446,7 @@ file tracks notable changes since the move to the monorepo.
   tries a host's IPv6 and IPv4 addresses a quarter of a second apart and uses
   the first connection that succeeds.
 
-- **The OS log stays free of `ip route` usage text on a network whose router
+- **The OS log stays focused on actionable errors on a network whose router
   advertises a route with more than one next hop.**
 
 ### Security
@@ -469,10 +469,9 @@ file tracks notable changes since the move to the monorepo.
   you also reach on your local network keeps answering there with your server's
   own certificate.
 
-- **Outbound IPv6 leaves only through an address of the selected gateway's
-  own.** A gateway with an IPv6 router but no IPv6 address of its own carries
-  no IPv6; such traffic is refused on the spot rather than sent with another
-  interface's address.
+- **Outbound IPv6 uses an address assigned to the selected gateway.** Traffic
+  through a gateway that has an IPv6 router but no IPv6 address of its own
+  fails immediately.
 
 ## [0.4.0.1]
 

--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -441,6 +441,15 @@ file tracks notable changes since the move to the monorepo.
   flavors produced no answer, so a list mixing Bitcoin Core with Bitcoin Knots
   kept whatever order it arrived in.
 
+- **Marketplace, service and OS-update downloads proceed over IPv4 at once when
+  a host's IPv6 is unreachable.** StartOS connects over whichever of a host's
+  IPv6 or IPv4 addresses answers first.
+
+- **Routes with more than one next hop, a lifetime, or an `unreachable` or
+  `prohibit` type are carried into each gateway's routing table.** The OS log
+  stays clear of `ip route` usage text on a network whose router advertises
+  such routes.
+
 ### Security
 
 - **Service mount paths are validated and confined to their intended
@@ -461,19 +470,9 @@ file tracks notable changes since the move to the monorepo.
   you also reach on your local network keeps answering there with your server's
   own certificate.
 
-- **Marketplace, service and OS-update downloads no longer stall for minutes on
-  a server whose IPv6 cannot reach the Internet.** StartOS connects over
-  whichever of a host's IPv6 or IPv4 addresses answers first.
-
-- **An outbound gateway that has an IPv6 router but no IPv6 address of its own
-  carries no IPv6.** Such traffic fails at once and falls back to IPv4, instead
-  of leaving with an address that belongs to another of the server's
-  interfaces.
-
-- **The gateway watcher no longer logs `ip route`'s usage text every few
-  minutes** on a network whose router advertises a route with more than one
-  next hop. Such routes, routes with a lifetime, and `unreachable` or
-  `prohibit` routes are now carried into each gateway's routing table too.
+- **Outbound IPv6 leaves only through an address of the selected gateway's
+  own.** A gateway with an IPv6 router but no IPv6 address of its own carries
+  no IPv6; such traffic fails at once and falls back to IPv4.
 
 ## [0.4.0.1]
 

--- a/projects/start-os/docs/src/outbound-vpn.md
+++ b/projects/start-os/docs/src/outbound-vpn.md
@@ -30,7 +30,7 @@ StartOS treats IPv6 outbound routing the same way as IPv4: the default gateway i
 
 If the gateway you select for outbound traffic can't carry IPv6 — for example a commercial VPN whose WireGuard config has no IPv6 address, or a LAN whose router advertises IPv6 without assigning your server an address — StartOS **drops** the server's outbound IPv6 rather than letting it fall back to your ISP connection, so your real IPv6 address never leaks around the VPN. (The drop is a blackhole in that gateway's own routing table.) A gateway that does provide IPv6 (such as a StartTunnel with a [delegated prefix](/start-tunnel/ipv6.html)) carries IPv6 normally; on a server with no native ISP IPv6, such a tunnel can also become your IPv6 default before you pin it, so select an outbound gateway explicitly if you want to control which one.
 
-When an Internet host offers both address families, StartOS tries IPv6 and IPv4 close together and uses the first connection that succeeds.
+For its own connections — marketplace, service-package and OS-update downloads — StartOS tries a host's IPv6 and IPv4 addresses a quarter of a second apart and uses the first connection that succeeds. Services make their own connections and follow their own behavior.
 
 ## Route Individual Services Through VPN
 

--- a/projects/start-os/docs/src/outbound-vpn.md
+++ b/projects/start-os/docs/src/outbound-vpn.md
@@ -28,7 +28,9 @@ By default, StartOS dynamically selects which gateway to use for outbound traffi
 
 StartOS treats IPv6 outbound routing the same way as IPv4: the default gateway is chosen by route metric, and you can set the system-wide default under `System > Gateways > Outbound Traffic`.
 
-If the gateway you select for outbound traffic can't carry IPv6 — for example a commercial VPN whose WireGuard config has no IPv6 address — StartOS **drops** the server's outbound IPv6 rather than letting it fall back to your ISP connection, so your real IPv6 address never leaks around the VPN. (The drop is a blackhole in that gateway's own routing table.) A gateway that does provide IPv6 (such as a StartTunnel with a [delegated prefix](/start-tunnel/ipv6.html)) carries IPv6 normally; on a server with no native ISP IPv6, such a tunnel can also become your IPv6 default before you pin it, so select an outbound gateway explicitly if you want to control which one.
+If the gateway you select for outbound traffic can't carry IPv6 — for example a commercial VPN whose WireGuard config has no IPv6 address, or a LAN whose router advertises IPv6 without assigning your server an address — StartOS **drops** the server's outbound IPv6 rather than letting it fall back to your ISP connection, so your real IPv6 address never leaks around the VPN. (The drop is a blackhole in that gateway's own routing table.) A gateway that does provide IPv6 (such as a StartTunnel with a [delegated prefix](/start-tunnel/ipv6.html)) carries IPv6 normally; on a server with no native ISP IPv6, such a tunnel can also become your IPv6 default before you pin it, so select an outbound gateway explicitly if you want to control which one.
+
+When an Internet host offers both address families, StartOS tries IPv6 and IPv4 close together and uses the first connection that succeeds.
 
 ## Route Individual Services Through VPN
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2138,6 +2138,17 @@ async fn apply_policy_routing(
 /// reroute, but the reply that opens a connection is routed before the output
 /// hook runs, so the source rule is what lets a v6 service reached through a
 /// tunnel answer.
+/// Sending needs an address of the interface's own beyond link-local; without
+/// a gateway it must be global.
+fn carries_v6(gateway: Option<Ipv6Addr>, addrs: impl IntoIterator<Item = Ipv6Addr>) -> bool {
+    let (mut own, mut global) = (false, false);
+    for addr in addrs {
+        own |= !ipv6_is_link_local(addr);
+        global |= !ipv6_is_local(addr);
+    }
+    own && (gateway.is_some() || global)
+}
+
 async fn apply_policy_routing_v6(
     guard: &PolicyRoutingGuard,
     iface: &GatewayId,
@@ -2161,7 +2172,13 @@ async fn apply_policy_routing_v6(
             _ => None,
         })
         .collect();
-    let v6_capable = ipv6_gateway.is_some() || !global_v6.is_empty();
+    let v6_capable = carries_v6(
+        ipv6_gateway,
+        subnets.iter().filter_map(|n| match n {
+            IpNet::V6(v6n) => Some(v6n.addr()),
+            _ => None,
+        }),
+    );
 
     // Mirror main's non-default v6 routes into the per-interface table, so the
     // priority-75 catch-all does not send on-link/local v6 through the gateway.
@@ -3426,6 +3443,38 @@ mod parse_echoip_tests {
     #[test]
     fn a_malformed_echoip_answer_is_an_error() {
         assert!(parse_echoip("<html>oops</html>").is_err());
+    }
+}
+
+#[cfg(test)]
+mod carries_v6_tests {
+    use super::*;
+
+    fn v6(s: &str) -> Ipv6Addr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn a_router_without_an_address_of_our_own_carries_nothing() {
+        assert!(!carries_v6(Some(v6("fe80::1")), [v6("fe80::2")]));
+    }
+
+    #[test]
+    fn a_router_with_a_ula_address_carries_v6() {
+        assert!(carries_v6(
+            Some(v6("fe80::1")),
+            [v6("fe80::2"), v6("fd00:0:104:1::5")]
+        ));
+    }
+
+    #[test]
+    fn a_global_address_without_a_router_carries_v6() {
+        assert!(carries_v6(None, [v6("2001:db8::5")]));
+    }
+
+    #[test]
+    fn a_ula_address_without_a_router_carries_nothing() {
+        assert!(!carries_v6(None, [v6("fd00::5")]));
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1979,6 +1979,7 @@ const ROUTE_TYPES: &[&str] = &[
     "blackhole",
     "nat",
     "anycast",
+    "xresolve",
 ];
 
 /// Flags `ip route show` prints that `ip route replace` rejects.
@@ -1995,14 +1996,41 @@ const DISPLAY_FLAGS: &[&str] = &[
     "rt_offload_failed",
 ];
 
-/// One route as `ip route show` prints it, as arguments `ip route replace` accepts.
+/// Keywords followed by their value.
+const VALUED_KEYWORDS: &[&str] = &[
+    "via",
+    "dev",
+    "proto",
+    "scope",
+    "src",
+    "metric",
+    "tos",
+    "table",
+    "mtu",
+    "advmss",
+    "rtt",
+    "rttvar",
+    "reordering",
+    "window",
+    "cwnd",
+    "initcwnd",
+    "initrwnd",
+    "ssthresh",
+    "rto_min",
+    "hoplimit",
+    "quickack",
+    "congctl",
+    "pref",
+    "weight",
+    "nhid",
+    "realm",
+    "realms",
+];
+
 #[derive(Debug, PartialEq, Eq)]
 struct ShownRoute {
-    /// The destination: a prefix, or `default`.
     prefix: String,
-    /// The header line, less what only `show` understands.
     attrs: Vec<String>,
-    /// A multipath route's indented `nexthop …` continuation lines, folded together.
     nexthops: Vec<String>,
 }
 
@@ -2011,16 +2039,14 @@ fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> Vec<Stri
     let mut tokens = tokens.into_iter();
     while let Some(token) = tokens.next() {
         match token {
-            // `show` prints an unreachable/prohibit route's errno; `replace` derives it from the type.
-            "error" => {
+            // `error` is output-only; the route type determines errno.
+            // A copied lifetime is never renewed.
+            "error" | "expires" => {
                 tokens.next();
             }
-            // `show` prints `expires 1786sec`; `replace` takes the bare number.
-            "expires" => {
-                if let Some(secs) = tokens.next() {
-                    out.push(token.to_owned());
-                    out.push(secs.trim_end_matches("sec").to_owned());
-                }
+            key if VALUED_KEYWORDS.contains(&key) => {
+                out.push(key.to_owned());
+                out.extend(tokens.next().map(str::to_owned));
             }
             flag if DISPLAY_FLAGS.contains(&flag) => {}
             token => out.push(token.to_owned()),
@@ -2057,7 +2083,7 @@ fn parse_route_show(output: &str) -> Vec<ShownRoute> {
     routes
 }
 
-// iproute2 rejects `table` after a nexthop list, so it goes between the header and the next hops.
+// `table` must precede a multipath `nexthop` list.
 fn route_replace_args(route: &ShownRoute, table: &str) -> Vec<String> {
     route
         .attrs
@@ -2088,10 +2114,6 @@ async fn apply_policy_routing(
     // the connectivity gap that a flush+add cycle would create.  We replace
     // every desired route in-place (each replace is atomic in the kernel),
     // then delete any stale routes that are no longer in the desired set.
-
-    // Collect the set of desired non-default route prefixes (the first
-    // whitespace-delimited token of each `ip route show` line is the
-    // destination prefix, e.g. "192.168.1.0/24" or "10.0.0.0/8").
     let mut desired_prefixes = BTreeSet::<String>::new();
 
     if let Ok(main_routes) = Command::new("ip")
@@ -2203,6 +2225,17 @@ async fn apply_policy_routing(
     Ok(())
 }
 
+/// Sending needs an address of the interface's own beyond link-local; without
+/// a gateway it must be global.
+fn carries_v6(gateway: Option<Ipv6Addr>, addrs: impl IntoIterator<Item = Ipv6Addr>) -> bool {
+    let (mut own, mut global) = (false, false);
+    for addr in addrs {
+        own |= !ipv6_is_link_local(addr);
+        global |= !ipv6_is_local(addr);
+    }
+    own && (gateway.is_some() || global)
+}
+
 /// IPv6 counterpart of [`apply_policy_routing`]'s per-interface table work.
 ///
 /// The table `1000 + ifindex` mirrors `main`'s non-default v6 routes (so
@@ -2221,17 +2254,6 @@ async fn apply_policy_routing(
 /// reroute, but the reply that opens a connection is routed before the output
 /// hook runs, so the source rule is what lets a v6 service reached through a
 /// tunnel answer.
-/// Sending needs an address of the interface's own beyond link-local; without
-/// a gateway it must be global.
-fn carries_v6(gateway: Option<Ipv6Addr>, addrs: impl IntoIterator<Item = Ipv6Addr>) -> bool {
-    let (mut own, mut global) = (false, false);
-    for addr in addrs {
-        own |= !ipv6_is_link_local(addr);
-        global |= !ipv6_is_local(addr);
-    }
-    own && (gateway.is_some() || global)
-}
-
 async fn apply_policy_routing_v6(
     guard: &PolicyRoutingGuard,
     iface: &GatewayId,
@@ -3677,7 +3699,7 @@ mod route_show_tests {
     }
 
     #[test]
-    fn a_lifetime_loses_its_unit() {
+    fn a_lifetime_is_dropped() {
         let routes = parse_route_show(
             "2001:db8::/64 via fe80::1 dev eth0 proto ra metric 1024 expires 1786sec hoplimit 64 pref medium",
         );
@@ -3693,13 +3715,35 @@ mod route_show_tests {
                 "ra",
                 "metric",
                 "1024",
-                "expires",
-                "1786",
                 "hoplimit",
                 "64",
                 "pref",
                 "medium",
             ])
+        );
+    }
+
+    #[test]
+    fn an_interface_named_like_a_flag_survives() {
+        for name in ["trap", "error", "expires"] {
+            let routes = parse_route_show(&format!(
+                "2001:db8::/64 dev {name} proto ra metric 100 trap"
+            ));
+            assert_eq!(
+                routes[0].attrs,
+                strs(&["2001:db8::/64", "dev", name, "proto", "ra", "metric", "100"]),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_xresolve_route_keeps_its_destination() {
+        let routes = parse_route_show("xresolve 10.0.0.0/8 dev lo metric 1024");
+        assert_eq!(routes[0].prefix, "10.0.0.0/8");
+        assert_eq!(
+            routes[0].attrs,
+            strs(&["xresolve", "10.0.0.0/8", "dev", "lo", "metric", "1024"])
         );
     }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2071,6 +2071,21 @@ struct CleanedTokens {
     nhid: bool,
 }
 
+fn keep(
+    attrs: &mut Vec<String>,
+    selectors: &mut BTreeMap<usize, [String; 2]>,
+    key: &str,
+    value: Option<&str>,
+) {
+    attrs.push(key.to_owned());
+    if let Some(value) = value {
+        attrs.push(value.to_owned());
+        if let Some(i) = SELECTOR_KEYWORDS.iter().position(|s| *s == key) {
+            selectors.insert(i, [key.to_owned(), value.to_owned()]);
+        }
+    }
+}
+
 /// Attributes expanded from a nexthop id cannot be replayed with it.
 fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedTokens {
     let mut attrs = Vec::new();
@@ -2089,7 +2104,21 @@ fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedT
                 attrs.push(token.to_owned());
                 attrs.extend(tokens.next().map(str::to_owned));
             }
-            "encap" if nhid => while tokens.next_if(|t| !matches!(*t, "via" | "dev")).is_some() {},
+            "encap" if nhid => {
+                // An ip encap always prints its own `tos`; the route's follows it.
+                let mut payload_tos = tokens.next() == Some("ip");
+                while let Some(token) = tokens.next_if(|t| !matches!(*t, "via" | "dev")) {
+                    if token != "tos" {
+                        continue;
+                    }
+                    if payload_tos {
+                        payload_tos = false;
+                        tokens.next();
+                    } else {
+                        keep(&mut attrs, &mut selectors, token, tokens.next());
+                    }
+                }
+            }
             "via" if nhid => {
                 if tokens.next() == Some("inet6") {
                     tokens.next();
@@ -2104,13 +2133,7 @@ fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedT
                 attrs.extend(tokens.next().map(str::to_owned));
             }
             key if VALUED_KEYWORDS.contains(&key) => {
-                attrs.push(key.to_owned());
-                if let Some(value) = tokens.next() {
-                    attrs.push(value.to_owned());
-                    if let Some(i) = SELECTOR_KEYWORDS.iter().position(|s| *s == key) {
-                        selectors.insert(i, [key.to_owned(), value.to_owned()]);
-                    }
-                }
+                keep(&mut attrs, &mut selectors, key, tokens.next());
             }
             flag if DISPLAY_FLAGS.contains(&flag) => {}
             token => attrs.push(token.to_owned()),
@@ -3859,6 +3882,56 @@ mod route_show_tests {
             assert_eq!(
                 route.attrs,
                 shown.split_whitespace().collect::<Vec<_>>(),
+                "{shown}"
+            );
+        }
+
+        // iproute2 6.9 output: the route's `tos` follows the expansion, an ip encap carries one of its own.
+        for (shown, attrs) in [
+            (
+                "10.1.0.0/16 nhid 5 tos 0x10 via 10.0.0.1 dev dummy0",
+                vec!["10.1.0.0/16", "nhid", "5", "tos", "0x10"],
+            ),
+            (
+                "10.3.0.0/16 nhid 6  encap ip id 7 src 0.0.0.0 dst 10.0.0.9 ttl 0 tos 0 tos 0x10 via 10.0.0.1 dev dummy0",
+                vec!["10.3.0.0/16", "nhid", "6", "tos", "0x10"],
+            ),
+            (
+                "10.3.0.0/16 nhid 6  encap ip id 7 src 0.0.0.0 dst 10.0.0.9 ttl 0 tos 0 via 10.0.0.1 dev dummy0",
+                vec!["10.3.0.0/16", "nhid", "6"],
+            ),
+            (
+                "10.0.0.0/8 nhid 5 encap mpls 100/200 tos 0x10 via 10.0.0.1 dev eth0 proto ra metric 100",
+                vec![
+                    "10.0.0.0/8",
+                    "nhid",
+                    "5",
+                    "tos",
+                    "0x10",
+                    "proto",
+                    "ra",
+                    "metric",
+                    "100",
+                ],
+            ),
+        ] {
+            let route = &parse_route_show(shown)[0];
+            assert_eq!(route.attrs, strs(&attrs), "{shown}");
+            let tos: Vec<_> = attrs
+                .windows(2)
+                .find(|w| w[0] == "tos")
+                .into_iter()
+                .flatten()
+                .copied()
+                .collect();
+            assert_eq!(
+                route
+                    .selectors
+                    .iter()
+                    .take(2)
+                    .map(String::as_str)
+                    .collect::<Vec<_>>(),
+                tos,
                 "{shown}"
             );
         }

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1180,6 +1180,9 @@ trait Ip6Config {
     fn address_data(&self) -> Result<Vec<AddressData>, Error>;
 
     #[zbus(property)]
+    fn route_data(&self) -> Result<Vec<RouteData>, Error>;
+
+    #[zbus(property)]
     fn gateway(&self) -> Result<String, Error>;
 
     // IP6Config has no `NameserverData`; its resolvers are `Nameservers` (aay),
@@ -1925,6 +1928,7 @@ async fn watch_ip(
                                     ip4_proxy.receive_nameserver_data_changed().await.stub(),
                                 )
                                 .with_stream(ip6_proxy.receive_address_data_changed().await.stub())
+                                .with_stream(ip6_proxy.receive_route_data_changed().await.stub())
                                 .with_stream(ip6_proxy.receive_gateway_changed().await.stub())
                                 .with_stream(ip6_proxy.receive_nameservers_changed().await.stub());
 
@@ -1996,10 +2000,12 @@ const DISPLAY_FLAGS: &[&str] = &[
     "rt_offload_failed",
 ];
 
-/// Keywords followed by their value.
 const VALUED_KEYWORDS: &[&str] = &[
     "via",
     "dev",
+    "link_dev",
+    "iif",
+    "oif",
     "proto",
     "scope",
     "src",
@@ -2027,11 +2033,34 @@ const VALUED_KEYWORDS: &[&str] = &[
     "realms",
 ];
 
+/// A nexthop id and its expanded gateway are mutually exclusive on replay.
+const NEXTHOP_KEYWORDS: &[&str] = &["via", "dev", "weight"];
+
 #[derive(Debug, PartialEq, Eq)]
 struct ShownRoute {
     prefix: String,
+    metric: Option<String>,
     attrs: Vec<String>,
     nexthops: Vec<String>,
+}
+
+impl ShownRoute {
+    fn identity(&self) -> (String, Option<String>) {
+        (self.prefix.clone(), self.metric.clone())
+    }
+}
+
+fn strip_nexthop_expansion(attrs: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut attrs = attrs.into_iter();
+    while let Some(attr) = attrs.next() {
+        if NEXTHOP_KEYWORDS.contains(&attr.as_str()) {
+            attrs.next();
+        } else if attr != "onlink" {
+            out.push(attr);
+        }
+    }
+    out
 }
 
 fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> Vec<String> {
@@ -2063,19 +2092,30 @@ fn parse_route_show(output: &str) -> Vec<ShownRoute> {
             continue;
         };
         if first == "nexthop" {
-            if let Some(route) = routes.last_mut() {
+            if let Some(route) = routes
+                .last_mut()
+                .filter(|r| !r.attrs.iter().any(|t| t == "nhid"))
+            {
                 route.nexthops.extend(clean_route_tokens(tokens));
             }
             continue;
         }
-        let attrs = clean_route_tokens(tokens);
+        let mut attrs = clean_route_tokens(tokens);
+        if attrs.iter().any(|t| t == "nhid") {
+            attrs = strip_nexthop_expansion(attrs);
+        }
         let prefix = attrs
             .iter()
             .find(|t| !ROUTE_TYPES.contains(&t.as_str()))
             .cloned()
             .unwrap_or_default();
+        let metric = attrs
+            .windows(2)
+            .find(|w| w[0] == "metric")
+            .map(|w| w[1].clone());
         routes.push(ShownRoute {
             prefix,
+            metric,
             attrs,
             nexthops: Vec::new(),
         });
@@ -2091,6 +2131,19 @@ fn route_replace_args(route: &ShownRoute, table: &str) -> Vec<String> {
         .cloned()
         .chain(["table".to_owned(), table.to_owned()])
         .chain(route.nexthops.iter().cloned())
+        .collect()
+}
+
+fn route_del_args(route: &ShownRoute, table: &str) -> Vec<String> {
+    [route.prefix.clone()]
+        .into_iter()
+        .chain(
+            route
+                .metric
+                .iter()
+                .flat_map(|m| ["metric".to_owned(), m.clone()]),
+        )
+        .chain(["table".to_owned(), table.to_owned()])
         .collect()
 }
 
@@ -2110,11 +2163,8 @@ async fn apply_policy_routing(
         })
         .copied();
 
-    // Rebuild per-interface routing table using `ip route replace` to avoid
-    // the connectivity gap that a flush+add cycle would create.  We replace
-    // every desired route in-place (each replace is atomic in the kernel),
-    // then delete any stale routes that are no longer in the desired set.
-    let mut desired_prefixes = BTreeSet::<String>::new();
+    // `replace` keeps the table live; a flush would open a connectivity gap.
+    let mut desired = None;
 
     if let Ok(main_routes) = Command::new("ip")
         .arg("route")
@@ -2125,11 +2175,12 @@ async fn apply_policy_routing(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
+        let mut identities = BTreeSet::new();
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
             }
-            desired_prefixes.insert(route.prefix.clone());
+            identities.insert(route.identity());
             let mut cmd = Command::new("ip");
             cmd.arg("route")
                 .arg("replace")
@@ -2146,6 +2197,7 @@ async fn apply_policy_routing(
                 }
             }
         }
+        desired = Some(identities);
     }
 
     // Replace the default route via this interface's gateway.
@@ -2165,27 +2217,23 @@ async fn apply_policy_routing(
         cmd.invoke(ErrorKind::Network).await.log_err();
     }
 
-    // Delete stale routes: any non-default route in the per-interface table
-    // whose prefix is not in the desired set.
-    if let Ok(existing_routes) = Command::new("ip")
+    let existing_routes = Command::new("ip")
         .arg("route")
         .arg("show")
         .arg("table")
         .arg(&table_str)
         .invoke(ErrorKind::Network)
         .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
-    {
+        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
+    if let (Some(desired), Ok(existing_routes)) = (desired, existing_routes) {
         for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default" || desired_prefixes.contains(&route.prefix) {
+            if route.prefix == "default" || desired.contains(&route.identity()) {
                 continue;
             }
             Command::new("ip")
                 .arg("route")
                 .arg("del")
-                .arg(&route.prefix)
-                .arg("table")
-                .arg(&table_str)
+                .args(route_del_args(&route, &table_str))
                 .invoke(ErrorKind::Network)
                 .await
                 .log_err();
@@ -2287,7 +2335,7 @@ async fn apply_policy_routing_v6(
 
     // Mirror main's non-default v6 routes into the per-interface table, so the
     // priority-75 catch-all does not send on-link/local v6 through the gateway.
-    let mut desired_prefixes = BTreeSet::<String>::new();
+    let mut desired = None;
     if let Ok(main_routes) = Command::new("ip")
         .arg("-6")
         .arg("route")
@@ -2298,11 +2346,12 @@ async fn apply_policy_routing_v6(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
+        let mut identities = BTreeSet::new();
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
             }
-            desired_prefixes.insert(route.prefix.clone());
+            identities.insert(route.identity());
             let mut cmd = Command::new("ip");
             cmd.arg("-6")
                 .arg("route")
@@ -2317,6 +2366,7 @@ async fn apply_policy_routing_v6(
                 }
             }
         }
+        desired = Some(identities);
     }
 
     // Replace the default: a real route when the interface can carry v6, else a
@@ -2342,8 +2392,7 @@ async fn apply_policy_routing_v6(
         cmd.invoke(ErrorKind::Network).await.log_err();
     }
 
-    // Delete stale non-default v6 routes no longer mirrored from main.
-    if let Ok(existing_routes) = Command::new("ip")
+    let existing_routes = Command::new("ip")
         .arg("-6")
         .arg("route")
         .arg("show")
@@ -2351,19 +2400,17 @@ async fn apply_policy_routing_v6(
         .arg(&table_str)
         .invoke(ErrorKind::Network)
         .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
-    {
+        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
+    if let (Some(desired), Ok(existing_routes)) = (desired, existing_routes) {
         for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default" || desired_prefixes.contains(&route.prefix) {
+            if route.prefix == "default" || desired.contains(&route.identity()) {
                 continue;
             }
             Command::new("ip")
                 .arg("-6")
                 .arg("route")
                 .arg("del")
-                .arg(&route.prefix)
-                .arg("table")
-                .arg(&table_str)
+                .args(route_del_args(&route, &table_str))
                 .invoke(ErrorKind::Network)
                 .await
                 .log_err();
@@ -3735,6 +3782,62 @@ mod route_show_tests {
                 "{name}"
             );
         }
+    }
+
+    #[test]
+    fn nested_interface_keywords_keep_their_values() {
+        for line in [
+            "2001:db8::/64 dev eth0 iif trap oif error metric 100",
+            "10.0.0.0/8 dev tun0 link_dev expires metric 5",
+        ] {
+            assert_eq!(
+                parse_route_show(line)[0].attrs,
+                line.split_whitespace().collect::<Vec<_>>(),
+                "{line}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_nexthop_id_drops_its_expansion() {
+        let single =
+            parse_route_show("10.0.0.0/8 nhid 5 via 10.0.0.1 dev eth0 proto ra metric 100");
+        assert_eq!(
+            single[0].attrs,
+            strs(&["10.0.0.0/8", "nhid", "5", "proto", "ra", "metric", "100"])
+        );
+
+        let group = parse_route_show(
+            "default nhid 7 proto ra metric 1024 pref medium\n\
+             \tnexthop via fe80::1 dev eth0 weight 1\n\
+             \tnexthop via fe80::2 dev eth0 weight 1\n",
+        );
+        assert_eq!(group.len(), 1);
+        assert!(group[0].nexthops.is_empty());
+        assert_eq!(
+            route_replace_args(&group[0], "75"),
+            strs(&[
+                "default", "nhid", "7", "proto", "ra", "metric", "1024", "pref", "medium", "table",
+                "75",
+            ])
+        );
+    }
+
+    #[test]
+    fn routes_differing_only_in_metric_are_distinct_and_deleted_by_metric() {
+        let routes = parse_route_show(
+            "2001:db8::/64 dev eth0 proto ra metric 100\n\
+             2001:db8::/64 dev eth0 proto kernel metric 1024\n",
+        );
+        assert_ne!(routes[0].identity(), routes[1].identity());
+        assert_eq!(
+            route_del_args(&routes[1], "75"),
+            strs(&["2001:db8::/64", "metric", "1024", "table", "75"])
+        );
+        assert_eq!(
+            route_del_args(&parse_route_show("10.0.0.0/8 dev eth0")[0], "75"),
+            strs(&["10.0.0.0/8", "table", "75"])
+        );
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2032,6 +2032,7 @@ const VALUED_KEYWORDS: &[&str] = &[
     "nhid",
     "realm",
     "realms",
+    "ttl-propagate",
 ];
 
 /// Keywords that distinguish routes sharing a destination, in `ip route del` order.
@@ -2049,6 +2050,18 @@ struct ShownRoute {
 impl ShownRoute {
     fn identity(&self) -> (String, Vec<String>) {
         (self.prefix.clone(), self.selectors.clone())
+    }
+
+    fn failure_domain(&self) -> (String, Vec<String>) {
+        (
+            self.prefix.clone(),
+            self.selectors
+                .chunks_exact(2)
+                .filter(|selector| selector[0] != "metric")
+                .flatten()
+                .cloned()
+                .collect(),
+        )
     }
 }
 
@@ -2086,6 +2099,10 @@ fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedT
                 tokens.next();
             }
             "onlink" if nhid => {}
+            "ttl-propogate" => {
+                attrs.push("ttl-propagate".to_owned());
+                attrs.extend(tokens.next().map(str::to_owned));
+            }
             key if VALUED_KEYWORDS.contains(&key) => {
                 attrs.push(key.to_owned());
                 if let Some(value) = tokens.next() {
@@ -2188,7 +2205,7 @@ async fn apply_policy_routing(
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
         let mut identities = BTreeSet::new();
-        let mut replayed = true;
+        let mut failed_domains = BTreeSet::new();
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
@@ -2199,7 +2216,7 @@ async fn apply_policy_routing(
                 .arg("replace")
                 .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
-                replayed = false;
+                failed_domains.insert(route.failure_domain());
                 // Transient interfaces (podman, wg-quick, etc.) may
                 // vanish between reading the main table and replaying
                 // the route — demote to debug to avoid log noise.
@@ -2211,10 +2228,7 @@ async fn apply_policy_routing(
                 }
             }
         }
-        // A failed replay leaves its predecessor as the only route for that destination.
-        if replayed {
-            desired = Some(identities);
-        }
+        desired = Some((identities, failed_domains));
     }
 
     // Replace the default route via this interface's gateway.
@@ -2242,9 +2256,12 @@ async fn apply_policy_routing(
         .invoke(ErrorKind::Network)
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
-    if let (Some(desired), Ok(existing_routes)) = (desired, existing_routes) {
+    if let (Some((desired, failed_domains)), Ok(existing_routes)) = (desired, existing_routes) {
         for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default" || desired.contains(&route.identity()) {
+            if route.prefix == "default"
+                || desired.contains(&route.identity())
+                || failed_domains.contains(&route.failure_domain())
+            {
                 continue;
             }
             Command::new("ip")
@@ -2364,7 +2381,7 @@ async fn apply_policy_routing_v6(
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
         let mut identities = BTreeSet::new();
-        let mut replayed = true;
+        let mut failed_domains = BTreeSet::new();
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
@@ -2376,7 +2393,7 @@ async fn apply_policy_routing_v6(
                 .arg("replace")
                 .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
-                replayed = false;
+                failed_domains.insert(route.failure_domain());
                 if e.source.to_string().contains("No such file or directory") {
                     tracing::trace!("ip -6 route replace (transient device): {e}");
                 } else {
@@ -2385,9 +2402,7 @@ async fn apply_policy_routing_v6(
                 }
             }
         }
-        if replayed {
-            desired = Some(identities);
-        }
+        desired = Some((identities, failed_domains));
     }
 
     // Replace the default: a real route when the interface can carry v6, else a
@@ -2422,9 +2437,12 @@ async fn apply_policy_routing_v6(
         .invoke(ErrorKind::Network)
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
-    if let (Some(desired), Ok(existing_routes)) = (desired, existing_routes) {
+    if let (Some((desired, failed_domains)), Ok(existing_routes)) = (desired, existing_routes) {
         for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default" || desired.contains(&route.identity()) {
+            if route.prefix == "default"
+                || desired.contains(&route.identity())
+                || failed_domains.contains(&route.failure_domain())
+            {
                 continue;
             }
             Command::new("ip")
@@ -3907,6 +3925,28 @@ mod route_show_tests {
                 "75"
             ])
         );
+        assert_eq!(
+            v6[0].failure_domain(),
+            ("2001:db8::/64".to_owned(), Vec::new())
+        );
+        assert_eq!(
+            v6[1].failure_domain(),
+            (
+                "2001:db8::/64".to_owned(),
+                strs(&["from", "2001:db8:1::/64"])
+            )
+        );
+    }
+
+    #[test]
+    fn ttl_propagate_uses_the_spelling_accepted_on_replay() {
+        for value in ["enabled", "disabled"] {
+            let route = parse_route_show(&format!("192.0.2.0/24 dev eth0 ttl-propogate {value}"));
+            assert_eq!(
+                route[0].attrs,
+                strs(&["192.0.2.0/24", "dev", "eth0", "ttl-propagate", value])
+            );
+        }
     }
 
     #[test]

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1422,6 +1422,11 @@ async fn watcher(
                         });
                         gc_policy_routing(&ifaces).await;
                         reconcile_mangle_rules(&policy_ifaces).await.log_err();
+                        if !policy_ifaces.is_empty() {
+                            for v6 in [false, true] {
+                                ensure_main_suppress_rule(v6).await.log_err();
+                            }
+                        }
                         for result in futures::future::join_all(jobs).await {
                             result.log_err();
                         }
@@ -1939,7 +1944,6 @@ async fn watch_ip(
                                 None
                             };
 
-                            // Policy routing: track per-interface table for cleanup on scope exit
                             let policy_guard: Option<PolicyRoutingGuard> =
                                 policy_table_for(device_type, &iface)
                                     .map(|table_id| PolicyRoutingGuard { table_id });
@@ -1975,7 +1979,50 @@ fn rule_has(line: &str, key: &str, value: &str) -> bool {
         .any(|w| w[0] == key && w[1] == value)
 }
 
-/// Specific routes are `main`'s; a per-interface table holds only its default.
+fn main_suppress_rule(line: &str) -> bool {
+    line.split_whitespace().eq([
+        "50:",
+        "from",
+        "all",
+        "lookup",
+        "main",
+        "suppress_prefixlength",
+        "0",
+    ])
+}
+
+/// Specific routes are `main`'s; per-interface tables hold only defaults.
+async fn ensure_main_suppress_rule(v6: bool) -> Result<(), Error> {
+    // Reject-type defaults terminate before suppression; `throw` routes fall through.
+    let mut ip = Command::new("ip");
+    if v6 {
+        ip.arg("-6");
+    }
+    let rules = String::from_utf8(
+        ip.arg("rule")
+            .arg("show")
+            .invoke(ErrorKind::Network)
+            .await?,
+    )?;
+    if !rules.lines().any(main_suppress_rule) {
+        let mut ip = Command::new("ip");
+        if v6 {
+            ip.arg("-6");
+        }
+        ip.arg("rule")
+            .arg("add")
+            .arg("lookup")
+            .arg("main")
+            .arg("suppress_prefixlength")
+            .arg("0")
+            .arg("priority")
+            .arg("50")
+            .invoke(ErrorKind::Network)
+            .await?;
+    }
+    Ok(())
+}
+
 async fn ensure_table_rules(v6: bool, table_id: u32, rules_output: &str) {
     let ip = || {
         let mut c = Command::new("ip");
@@ -1985,26 +2032,6 @@ async fn ensure_table_rules(v6: bool, table_id: u32, rules_output: &str) {
         c
     };
     let table_str = table_id.to_string();
-    // A reject-type default in `main` ends the lookup before it can be suppressed.
-    // A `throw` in `main` falls through to the outbound table's default.
-    if !rules_output.lines().any(|l| {
-        let l = l.trim();
-        l.starts_with("50:")
-            && rule_has(l, "lookup", "main")
-            && l.contains("suppress_prefixlength 0")
-    }) {
-        ip().arg("rule")
-            .arg("add")
-            .arg("lookup")
-            .arg("main")
-            .arg("suppress_prefixlength")
-            .arg("0")
-            .arg("priority")
-            .arg("50")
-            .invoke(ErrorKind::Network)
-            .await
-            .log_err();
-    }
     let mut reply_rule = false;
     for line in rules_output.lines().map(str::trim) {
         if !(rule_has(line, "fwmark", &format!("0x{table_id:x}"))
@@ -3227,6 +3254,24 @@ impl Accept for WildcardListener {
             )));
         }
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod policy_rule_tests {
+    use super::*;
+
+    #[test]
+    fn main_suppress_rule_requires_the_unrestricted_rule() {
+        assert!(main_suppress_rule(
+            "50: from all lookup main suppress_prefixlength 0"
+        ));
+        assert!(!main_suppress_rule(
+            "50: from 192.0.2.1 lookup main suppress_prefixlength 0"
+        ));
+        assert!(!main_suppress_rule(
+            "50: from all fwmark 0x3e9 lookup main suppress_prefixlength 0"
+        ));
     }
 }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -2006,6 +2006,7 @@ const VALUED_KEYWORDS: &[&str] = &[
     "link_dev",
     "iif",
     "oif",
+    "from",
     "proto",
     "scope",
     "src",
@@ -2033,39 +2034,36 @@ const VALUED_KEYWORDS: &[&str] = &[
     "realms",
 ];
 
-/// A nexthop id and its expanded gateway are mutually exclusive on replay.
-const NEXTHOP_KEYWORDS: &[&str] = &["via", "dev", "weight"];
+/// Keywords that distinguish routes sharing a destination, in `ip route del` order.
+const SELECTOR_KEYWORDS: &[&str] = &["tos", "from", "metric"];
 
 #[derive(Debug, PartialEq, Eq)]
 struct ShownRoute {
     prefix: String,
-    metric: Option<String>,
+    selectors: Vec<String>,
+    nhid: bool,
     attrs: Vec<String>,
     nexthops: Vec<String>,
 }
 
 impl ShownRoute {
-    fn identity(&self) -> (String, Option<String>) {
-        (self.prefix.clone(), self.metric.clone())
+    fn identity(&self) -> (String, Vec<String>) {
+        (self.prefix.clone(), self.selectors.clone())
     }
 }
 
-fn strip_nexthop_expansion(attrs: Vec<String>) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut attrs = attrs.into_iter();
-    while let Some(attr) = attrs.next() {
-        if NEXTHOP_KEYWORDS.contains(&attr.as_str()) {
-            attrs.next();
-        } else if attr != "onlink" {
-            out.push(attr);
-        }
-    }
-    out
+struct CleanedTokens {
+    attrs: Vec<String>,
+    selectors: Vec<String>,
+    nhid: bool,
 }
 
-fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> Vec<String> {
-    let mut out = Vec::new();
-    let mut tokens = tokens.into_iter();
+/// Attributes expanded from a nexthop id cannot be replayed with it.
+fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedTokens {
+    let mut attrs = Vec::new();
+    let mut selectors = BTreeMap::new();
+    let mut nhid = false;
+    let mut tokens = tokens.into_iter().peekable();
     while let Some(token) = tokens.next() {
         match token {
             // `error` is output-only; the route type determines errno.
@@ -2073,15 +2071,39 @@ fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> Vec<Stri
             "error" | "expires" => {
                 tokens.next();
             }
+            "nhid" => {
+                nhid = true;
+                attrs.push(token.to_owned());
+                attrs.extend(tokens.next().map(str::to_owned));
+            }
+            "encap" if nhid => while tokens.next_if(|t| !matches!(*t, "via" | "dev")).is_some() {},
+            "via" if nhid => {
+                if tokens.next() == Some("inet6") {
+                    tokens.next();
+                }
+            }
+            "dev" | "weight" if nhid => {
+                tokens.next();
+            }
+            "onlink" if nhid => {}
             key if VALUED_KEYWORDS.contains(&key) => {
-                out.push(key.to_owned());
-                out.extend(tokens.next().map(str::to_owned));
+                attrs.push(key.to_owned());
+                if let Some(value) = tokens.next() {
+                    attrs.push(value.to_owned());
+                    if let Some(i) = SELECTOR_KEYWORDS.iter().position(|s| *s == key) {
+                        selectors.insert(i, [key.to_owned(), value.to_owned()]);
+                    }
+                }
             }
             flag if DISPLAY_FLAGS.contains(&flag) => {}
-            token => out.push(token.to_owned()),
+            token => attrs.push(token.to_owned()),
         }
     }
-    out
+    CleanedTokens {
+        attrs,
+        selectors: selectors.into_values().flatten().collect(),
+        nhid,
+    }
 }
 
 fn parse_route_show(output: &str) -> Vec<ShownRoute> {
@@ -2092,30 +2114,25 @@ fn parse_route_show(output: &str) -> Vec<ShownRoute> {
             continue;
         };
         if first == "nexthop" {
-            if let Some(route) = routes
-                .last_mut()
-                .filter(|r| !r.attrs.iter().any(|t| t == "nhid"))
-            {
-                route.nexthops.extend(clean_route_tokens(tokens));
+            if let Some(route) = routes.last_mut().filter(|r| !r.nhid) {
+                route.nexthops.extend(clean_route_tokens(tokens).attrs);
             }
             continue;
         }
-        let mut attrs = clean_route_tokens(tokens);
-        if attrs.iter().any(|t| t == "nhid") {
-            attrs = strip_nexthop_expansion(attrs);
-        }
+        let CleanedTokens {
+            attrs,
+            selectors,
+            nhid,
+        } = clean_route_tokens(tokens);
         let prefix = attrs
             .iter()
             .find(|t| !ROUTE_TYPES.contains(&t.as_str()))
             .cloned()
             .unwrap_or_default();
-        let metric = attrs
-            .windows(2)
-            .find(|w| w[0] == "metric")
-            .map(|w| w[1].clone());
         routes.push(ShownRoute {
             prefix,
-            metric,
+            selectors,
+            nhid,
             attrs,
             nexthops: Vec::new(),
         });
@@ -2137,12 +2154,7 @@ fn route_replace_args(route: &ShownRoute, table: &str) -> Vec<String> {
 fn route_del_args(route: &ShownRoute, table: &str) -> Vec<String> {
     [route.prefix.clone()]
         .into_iter()
-        .chain(
-            route
-                .metric
-                .iter()
-                .flat_map(|m| ["metric".to_owned(), m.clone()]),
-        )
+        .chain(route.selectors.iter().cloned())
         .chain(["table".to_owned(), table.to_owned()])
         .collect()
 }
@@ -2176,6 +2188,7 @@ async fn apply_policy_routing(
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
         let mut identities = BTreeSet::new();
+        let mut replayed = true;
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
@@ -2186,6 +2199,7 @@ async fn apply_policy_routing(
                 .arg("replace")
                 .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
+                replayed = false;
                 // Transient interfaces (podman, wg-quick, etc.) may
                 // vanish between reading the main table and replaying
                 // the route — demote to debug to avoid log noise.
@@ -2197,7 +2211,10 @@ async fn apply_policy_routing(
                 }
             }
         }
-        desired = Some(identities);
+        // A failed replay leaves its predecessor as the only route for that destination.
+        if replayed {
+            desired = Some(identities);
+        }
     }
 
     // Replace the default route via this interface's gateway.
@@ -2347,6 +2364,7 @@ async fn apply_policy_routing_v6(
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
         let mut identities = BTreeSet::new();
+        let mut replayed = true;
         for route in parse_route_show(&main_routes) {
             if route.prefix == "default" {
                 continue;
@@ -2358,6 +2376,7 @@ async fn apply_policy_routing_v6(
                 .arg("replace")
                 .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
+                replayed = false;
                 if e.source.to_string().contains("No such file or directory") {
                     tracing::trace!("ip -6 route replace (transient device): {e}");
                 } else {
@@ -2366,7 +2385,9 @@ async fn apply_policy_routing_v6(
                 }
             }
         }
-        desired = Some(identities);
+        if replayed {
+            desired = Some(identities);
+        }
     }
 
     // Replace the default: a real route when the interface can carry v6, else a
@@ -3800,12 +3821,29 @@ mod route_show_tests {
 
     #[test]
     fn a_nexthop_id_drops_its_expansion() {
-        let single =
-            parse_route_show("10.0.0.0/8 nhid 5 via 10.0.0.1 dev eth0 proto ra metric 100");
-        assert_eq!(
-            single[0].attrs,
-            strs(&["10.0.0.0/8", "nhid", "5", "proto", "ra", "metric", "100"])
-        );
+        for shown in [
+            "10.0.0.0/8 nhid 5 via 10.0.0.1 dev eth0 proto ra metric 100",
+            "10.0.0.0/8 nhid 5 via inet6 fe80::1 dev eth0 proto ra metric 100",
+            "10.0.0.0/8 nhid 5 encap mpls 100/200 via 10.0.0.1 dev eth0 onlink proto ra metric 100",
+        ] {
+            assert_eq!(
+                parse_route_show(shown)[0].attrs,
+                strs(&["10.0.0.0/8", "nhid", "5", "proto", "ra", "metric", "100"]),
+                "{shown}"
+            );
+        }
+        for shown in [
+            "10.0.0.0/8 via 10.0.0.1 dev nhid proto static metric 100",
+            "10.0.0.0/8 encap mpls 100 via 10.0.0.1 dev eth0 proto static metric 100",
+        ] {
+            let route = &parse_route_show(shown)[0];
+            assert!(!route.nhid, "{shown}");
+            assert_eq!(
+                route.attrs,
+                shown.split_whitespace().collect::<Vec<_>>(),
+                "{shown}"
+            );
+        }
 
         let group = parse_route_show(
             "default nhid 7 proto ra metric 1024 pref medium\n\
@@ -3837,6 +3875,37 @@ mod route_show_tests {
         assert_eq!(
             route_del_args(&parse_route_show("10.0.0.0/8 dev eth0")[0], "75"),
             strs(&["10.0.0.0/8", "table", "75"])
+        );
+    }
+
+    #[test]
+    fn routes_alias_on_tos_and_source_and_are_deleted_with_them() {
+        let v4 = parse_route_show(
+            "10.0.0.0/8 via 10.0.0.1 dev eth0 metric 100\n\
+             10.0.0.0/8 tos 0x10 via 10.0.0.2 dev eth0 metric 100\n",
+        );
+        assert_ne!(v4[0].identity(), v4[1].identity());
+        assert_eq!(
+            route_del_args(&v4[1], "75"),
+            strs(&["10.0.0.0/8", "tos", "0x10", "metric", "100", "table", "75"])
+        );
+
+        let v6 = parse_route_show(
+            "2001:db8::/64 via fe80::1 dev eth0 metric 1024\n\
+             2001:db8::/64 from 2001:db8:1::/64 via fe80::2 dev eth0 metric 1024\n",
+        );
+        assert_ne!(v6[0].identity(), v6[1].identity());
+        assert_eq!(
+            route_del_args(&v6[1], "75"),
+            strs(&[
+                "2001:db8::/64",
+                "from",
+                "2001:db8:1::/64",
+                "metric",
+                "1024",
+                "table",
+                "75"
+            ])
         );
     }
 

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1968,6 +1968,106 @@ async fn watch_ip(
     }
 }
 
+const ROUTE_TYPES: &[&str] = &[
+    "unicast",
+    "local",
+    "broadcast",
+    "multicast",
+    "throw",
+    "unreachable",
+    "prohibit",
+    "blackhole",
+    "nat",
+    "anycast",
+];
+
+/// Flags `ip route show` prints that `ip route replace` rejects.
+const DISPLAY_FLAGS: &[&str] = &[
+    "dead",
+    "linkdown",
+    "pervasive",
+    "offload",
+    "notify",
+    "unresolved",
+    "trap",
+    "rt_offload",
+    "rt_trap",
+    "rt_offload_failed",
+];
+
+/// One route as `ip route show` prints it, as arguments `ip route replace` accepts.
+#[derive(Debug, PartialEq, Eq)]
+struct ShownRoute {
+    /// The destination: a prefix, or `default`.
+    prefix: String,
+    /// The header line, less what only `show` understands.
+    attrs: Vec<String>,
+    /// A multipath route's indented `nexthop …` continuation lines, folded together.
+    nexthops: Vec<String>,
+}
+
+fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut tokens = tokens.into_iter();
+    while let Some(token) = tokens.next() {
+        match token {
+            // `show` prints an unreachable/prohibit route's errno; `replace` derives it from the type.
+            "error" => {
+                tokens.next();
+            }
+            // `show` prints `expires 1786sec`; `replace` takes the bare number.
+            "expires" => {
+                if let Some(secs) = tokens.next() {
+                    out.push(token.to_owned());
+                    out.push(secs.trim_end_matches("sec").to_owned());
+                }
+            }
+            flag if DISPLAY_FLAGS.contains(&flag) => {}
+            token => out.push(token.to_owned()),
+        }
+    }
+    out
+}
+
+fn parse_route_show(output: &str) -> Vec<ShownRoute> {
+    let mut routes = Vec::<ShownRoute>::new();
+    for line in output.lines() {
+        let mut tokens = line.split_whitespace().peekable();
+        let Some(&first) = tokens.peek() else {
+            continue;
+        };
+        if first == "nexthop" {
+            if let Some(route) = routes.last_mut() {
+                route.nexthops.extend(clean_route_tokens(tokens));
+            }
+            continue;
+        }
+        let attrs = clean_route_tokens(tokens);
+        let prefix = attrs
+            .iter()
+            .find(|t| !ROUTE_TYPES.contains(&t.as_str()))
+            .cloned()
+            .unwrap_or_default();
+        routes.push(ShownRoute {
+            prefix,
+            attrs,
+            nexthops: Vec::new(),
+        });
+    }
+    routes
+}
+
+// iproute2 rejects `table` after a nexthop list, so it goes between the header and the next hops.
+fn route_replace_args(route: &ShownRoute, table: &str) -> Vec<String> {
+    route
+        .attrs
+        .iter()
+        .cloned()
+        .chain(["table".to_owned(), table.to_owned()])
+        .chain(route.nexthops.iter().cloned())
+        .collect()
+}
+
 async fn apply_policy_routing(
     guard: &PolicyRoutingGuard,
     iface: &GatewayId,
@@ -2003,25 +2103,15 @@ async fn apply_policy_routing(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
-        for line in main_routes.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with("default") {
+        for route in parse_route_show(&main_routes) {
+            if route.prefix == "default" {
                 continue;
             }
-            if let Some(prefix) = line.split_whitespace().next() {
-                desired_prefixes.insert(prefix.to_owned());
-            }
+            desired_prefixes.insert(route.prefix.clone());
             let mut cmd = Command::new("ip");
-            cmd.arg("route").arg("replace");
-            for part in line.split_whitespace() {
-                // Skip status flags that appear in route output but
-                // are not valid for `ip route replace`.
-                if part == "linkdown" || part == "dead" {
-                    continue;
-                }
-                cmd.arg(part);
-            }
-            cmd.arg("table").arg(&table_str);
+            cmd.arg("route")
+                .arg("replace")
+                .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
                 // Transient interfaces (podman, wg-quick, etc.) may
                 // vanish between reading the main table and replaying
@@ -2064,21 +2154,14 @@ async fn apply_policy_routing(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
-        for line in existing_routes.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with("default") {
-                continue;
-            }
-            let Some(prefix) = line.split_whitespace().next() else {
-                continue;
-            };
-            if desired_prefixes.contains(prefix) {
+        for route in parse_route_show(&existing_routes) {
+            if route.prefix == "default" || desired_prefixes.contains(&route.prefix) {
                 continue;
             }
             Command::new("ip")
                 .arg("route")
                 .arg("del")
-                .arg(prefix)
+                .arg(&route.prefix)
                 .arg("table")
                 .arg(&table_str)
                 .invoke(ErrorKind::Network)
@@ -2193,23 +2276,16 @@ async fn apply_policy_routing_v6(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
-        for line in main_routes.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with("default") {
+        for route in parse_route_show(&main_routes) {
+            if route.prefix == "default" {
                 continue;
             }
-            if let Some(prefix) = line.split_whitespace().next() {
-                desired_prefixes.insert(prefix.to_owned());
-            }
+            desired_prefixes.insert(route.prefix.clone());
             let mut cmd = Command::new("ip");
-            cmd.arg("-6").arg("route").arg("replace");
-            for part in line.split_whitespace() {
-                if part == "linkdown" || part == "dead" {
-                    continue;
-                }
-                cmd.arg(part);
-            }
-            cmd.arg("table").arg(&table_str);
+            cmd.arg("-6")
+                .arg("route")
+                .arg("replace")
+                .args(route_replace_args(&route, &table_str));
             if let Err(e) = cmd.invoke(ErrorKind::Network).await {
                 if e.source.to_string().contains("No such file or directory") {
                     tracing::trace!("ip -6 route replace (transient device): {e}");
@@ -2255,22 +2331,15 @@ async fn apply_policy_routing_v6(
         .await
         .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
     {
-        for line in existing_routes.lines() {
-            let line = line.trim();
-            if line.is_empty() || line.starts_with("default") || line.starts_with("blackhole") {
-                continue;
-            }
-            let Some(prefix) = line.split_whitespace().next() else {
-                continue;
-            };
-            if desired_prefixes.contains(prefix) {
+        for route in parse_route_show(&existing_routes) {
+            if route.prefix == "default" || desired_prefixes.contains(&route.prefix) {
                 continue;
             }
             Command::new("ip")
                 .arg("-6")
                 .arg("route")
                 .arg("del")
-                .arg(prefix)
+                .arg(&route.prefix)
                 .arg("table")
                 .arg(&table_str)
                 .invoke(ErrorKind::Network)
@@ -3578,5 +3647,133 @@ mod wg_config_tests {
         assert!(!parsed.to_nm_settings("wg0", None).unwrap()["connection"].contains_key("uuid"));
         let updated = parsed.to_nm_settings("wg0", Some("uuid-x")).unwrap();
         assert_eq!(as_str(&updated["connection"]["uuid"]), "uuid-x");
+    }
+}
+
+#[cfg(test)]
+mod route_show_tests {
+    use super::*;
+
+    fn strs(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn a_multipath_route_folds_its_next_hops_behind_the_table() {
+        let shown = "default proto ra metric 1024 pref medium\n\
+                     \tnexthop via fe80::1 dev enp2s0 weight 1\n\
+                     \tnexthop via fe80::2 dev enp2s0 weight 1\n";
+        let routes = parse_route_show(shown);
+        assert_eq!(routes.len(), 1);
+        assert_eq!(routes[0].prefix, "default");
+        assert_eq!(
+            route_replace_args(&routes[0], "75"),
+            strs(&[
+                "default", "proto", "ra", "metric", "1024", "pref", "medium", "table", "75",
+                "nexthop", "via", "fe80::1", "dev", "enp2s0", "weight", "1", "nexthop", "via",
+                "fe80::2", "dev", "enp2s0", "weight", "1",
+            ])
+        );
+    }
+
+    #[test]
+    fn a_lifetime_loses_its_unit() {
+        let routes = parse_route_show(
+            "2001:db8::/64 via fe80::1 dev eth0 proto ra metric 1024 expires 1786sec hoplimit 64 pref medium",
+        );
+        assert_eq!(
+            routes[0].attrs,
+            strs(&[
+                "2001:db8::/64",
+                "via",
+                "fe80::1",
+                "dev",
+                "eth0",
+                "proto",
+                "ra",
+                "metric",
+                "1024",
+                "expires",
+                "1786",
+                "hoplimit",
+                "64",
+                "pref",
+                "medium",
+            ])
+        );
+    }
+
+    #[test]
+    fn a_typed_route_keeps_its_type_and_drops_its_errno() {
+        let routes =
+            parse_route_show("unreachable fd00::/64 dev lo metric 1024 error -113 pref medium");
+        assert_eq!(routes[0].prefix, "fd00::/64");
+        assert_eq!(
+            routes[0].attrs,
+            strs(&[
+                "unreachable",
+                "fd00::/64",
+                "dev",
+                "lo",
+                "metric",
+                "1024",
+                "pref",
+                "medium"
+            ])
+        );
+    }
+
+    #[test]
+    fn a_blackhole_default_is_a_default() {
+        let routes = parse_route_show("blackhole default dev lo metric 1024 error -22 pref medium");
+        assert_eq!(routes[0].prefix, "default");
+    }
+
+    #[test]
+    fn display_flags_are_dropped() {
+        let routes = parse_route_show(
+            "2001:db8::/64 dev eth0 proto kernel metric 256 rt_offload linkdown dead pref medium",
+        );
+        assert_eq!(
+            routes[0].attrs,
+            strs(&[
+                "2001:db8::/64",
+                "dev",
+                "eth0",
+                "proto",
+                "kernel",
+                "metric",
+                "256",
+                "pref",
+                "medium"
+            ])
+        );
+    }
+
+    #[test]
+    fn a_plain_route_passes_through() {
+        let routes = parse_route_show("fe80::/64 dev eno0 proto kernel metric 1024 pref medium\n");
+        assert_eq!(routes[0].prefix, "fe80::/64");
+        assert_eq!(
+            route_replace_args(&routes[0], "75"),
+            strs(&[
+                "fe80::/64",
+                "dev",
+                "eno0",
+                "proto",
+                "kernel",
+                "metric",
+                "1024",
+                "pref",
+                "medium",
+                "table",
+                "75"
+            ])
+        );
+    }
+
+    #[test]
+    fn a_stray_next_hop_line_is_ignored() {
+        assert!(parse_route_show("nexthop via fe80::1 dev eth0 weight 1\n").is_empty());
     }
 }

--- a/shared-libs/crates/start-core/src/net/gateway.rs
+++ b/shared-libs/crates/start-core/src/net/gateway.rs
@@ -1180,9 +1180,6 @@ trait Ip6Config {
     fn address_data(&self) -> Result<Vec<AddressData>, Error>;
 
     #[zbus(property)]
-    fn route_data(&self) -> Result<Vec<RouteData>, Error>;
-
-    #[zbus(property)]
     fn gateway(&self) -> Result<String, Error>;
 
     // IP6Config has no `NameserverData`; its resolvers are `Nameservers` (aay),
@@ -1503,7 +1500,7 @@ async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
         .filter_map(|iface| if_nametoindex(iface.as_str()).ok().map(|idx| 1000 + idx))
         .collect();
 
-    // Collect stale per-interface table ids from the priority-50 fwmark rules in
+    // Collect stale per-interface table ids from the priority-51 fwmark rules in
     // both families (IPv4 and IPv6 install the same `1000 + ifindex` rule).
     let mut stale = BTreeSet::<u32>::new();
     for v6 in [false, true] {
@@ -1522,7 +1519,7 @@ async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
         };
         for line in rules.lines() {
             let line = line.trim();
-            if !line.starts_with("50:") {
+            if !line.starts_with("51:") {
                 continue;
             }
             let Some(pos) = line.find("lookup ") else {
@@ -1596,7 +1593,7 @@ async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
             .ok();
     }
 
-    // For each stale table, remove the priority-50 fwmark rule and flush its
+    // For each stale table, remove the priority-51 fwmark rule and flush its
     // routing table in both families, so a removed interface leaves no stale
     // reply-routing rule, v4 default, or v6 default/blackhole behind.
     for table_id in stale {
@@ -1614,7 +1611,7 @@ async fn gc_policy_routing(active_ifaces: &BTreeSet<GatewayId>) {
                 .arg("lookup")
                 .arg(&table_str)
                 .arg("priority")
-                .arg("50")
+                .arg("51")
                 .invoke(ErrorKind::Network)
                 .await
                 .ok();
@@ -1793,7 +1790,7 @@ fn policy_table_for(device_type: Option<NetworkInterfaceType>, iface: &GatewayId
 ///
 /// IPv4 and IPv6 carry the same CONNMARK reply-routing layer, rebuilt together
 /// so a reply to a v6 connection that arrived on a tunnel (host-terminated or
-/// DNAT'd to a container) routes back out it via the priority-50 fwmark rule,
+/// DNAT'd to a container) routes back out it via the priority-51 fwmark rule,
 /// exactly like v4. `sni-divert` is emitted for both families.
 async fn reconcile_mangle_rules(policy_ifaces: &BTreeMap<GatewayId, u32>) -> Result<(), Error> {
     nft_ensure_base().await?;
@@ -1928,7 +1925,6 @@ async fn watch_ip(
                                     ip4_proxy.receive_nameserver_data_changed().await.stub(),
                                 )
                                 .with_stream(ip6_proxy.receive_address_data_changed().await.stub())
-                                .with_stream(ip6_proxy.receive_route_data_changed().await.stub())
                                 .with_stream(ip6_proxy.receive_gateway_changed().await.stub())
                                 .with_stream(ip6_proxy.receive_nameservers_changed().await.stub());
 
@@ -1972,231 +1968,81 @@ async fn watch_ip(
     }
 }
 
-const ROUTE_TYPES: &[&str] = &[
-    "unicast",
-    "local",
-    "broadcast",
-    "multicast",
-    "throw",
-    "unreachable",
-    "prohibit",
-    "blackhole",
-    "nat",
-    "anycast",
-    "xresolve",
-];
-
-/// Flags `ip route show` prints that `ip route replace` rejects.
-const DISPLAY_FLAGS: &[&str] = &[
-    "dead",
-    "linkdown",
-    "pervasive",
-    "offload",
-    "notify",
-    "unresolved",
-    "trap",
-    "rt_offload",
-    "rt_trap",
-    "rt_offload_failed",
-];
-
-const VALUED_KEYWORDS: &[&str] = &[
-    "via",
-    "dev",
-    "link_dev",
-    "iif",
-    "oif",
-    "from",
-    "proto",
-    "scope",
-    "src",
-    "metric",
-    "tos",
-    "table",
-    "mtu",
-    "advmss",
-    "rtt",
-    "rttvar",
-    "reordering",
-    "window",
-    "cwnd",
-    "initcwnd",
-    "initrwnd",
-    "ssthresh",
-    "rto_min",
-    "hoplimit",
-    "quickack",
-    "congctl",
-    "pref",
-    "weight",
-    "nhid",
-    "realm",
-    "realms",
-    "ttl-propagate",
-];
-
-/// Keywords that distinguish routes sharing a destination, in `ip route del` order.
-const SELECTOR_KEYWORDS: &[&str] = &["tos", "from", "metric"];
-
-#[derive(Debug, PartialEq, Eq)]
-struct ShownRoute {
-    prefix: String,
-    selectors: Vec<String>,
-    nhid: bool,
-    attrs: Vec<String>,
-    nexthops: Vec<String>,
+fn rule_has(line: &str, key: &str, value: &str) -> bool {
+    line.split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|w| w[0] == key && w[1] == value)
 }
 
-impl ShownRoute {
-    fn identity(&self) -> (String, Vec<String>) {
-        (self.prefix.clone(), self.selectors.clone())
-    }
-
-    fn failure_domain(&self) -> (String, Vec<String>) {
-        (
-            self.prefix.clone(),
-            self.selectors
-                .chunks_exact(2)
-                .filter(|selector| selector[0] != "metric")
-                .flatten()
-                .cloned()
-                .collect(),
-        )
-    }
-}
-
-struct CleanedTokens {
-    attrs: Vec<String>,
-    selectors: Vec<String>,
-    nhid: bool,
-}
-
-fn keep(
-    attrs: &mut Vec<String>,
-    selectors: &mut BTreeMap<usize, [String; 2]>,
-    key: &str,
-    value: Option<&str>,
-) {
-    attrs.push(key.to_owned());
-    if let Some(value) = value {
-        attrs.push(value.to_owned());
-        if let Some(i) = SELECTOR_KEYWORDS.iter().position(|s| *s == key) {
-            selectors.insert(i, [key.to_owned(), value.to_owned()]);
+/// Specific routes are `main`'s; a per-interface table holds only its default.
+async fn ensure_table_rules(v6: bool, table_id: u32, rules_output: &str) {
+    let ip = || {
+        let mut c = Command::new("ip");
+        if v6 {
+            c.arg("-6");
         }
+        c
+    };
+    let table_str = table_id.to_string();
+    // A reject-type default in `main` ends the lookup before it can be suppressed.
+    // A `throw` in `main` falls through to the outbound table's default.
+    if !rules_output.lines().any(|l| {
+        let l = l.trim();
+        l.starts_with("50:")
+            && rule_has(l, "lookup", "main")
+            && l.contains("suppress_prefixlength 0")
+    }) {
+        ip().arg("rule")
+            .arg("add")
+            .arg("lookup")
+            .arg("main")
+            .arg("suppress_prefixlength")
+            .arg("0")
+            .arg("priority")
+            .arg("50")
+            .invoke(ErrorKind::Network)
+            .await
+            .log_err();
     }
-}
-
-/// Attributes expanded from a nexthop id cannot be replayed with it.
-fn clean_route_tokens<'a>(tokens: impl IntoIterator<Item = &'a str>) -> CleanedTokens {
-    let mut attrs = Vec::new();
-    let mut selectors = BTreeMap::new();
-    let mut nhid = false;
-    let mut tokens = tokens.into_iter().peekable();
-    while let Some(token) = tokens.next() {
-        match token {
-            // `error` is output-only; the route type determines errno.
-            // A copied lifetime is never renewed.
-            "error" | "expires" => {
-                tokens.next();
-            }
-            "nhid" => {
-                nhid = true;
-                attrs.push(token.to_owned());
-                attrs.extend(tokens.next().map(str::to_owned));
-            }
-            "encap" if nhid => {
-                // An ip encap always prints its own `tos`; the route's follows it.
-                let mut payload_tos = tokens.next() == Some("ip");
-                while let Some(token) = tokens.next_if(|t| !matches!(*t, "via" | "dev")) {
-                    if token != "tos" {
-                        continue;
-                    }
-                    if payload_tos {
-                        payload_tos = false;
-                        tokens.next();
-                    } else {
-                        keep(&mut attrs, &mut selectors, token, tokens.next());
-                    }
-                }
-            }
-            "via" if nhid => {
-                if tokens.next() == Some("inet6") {
-                    tokens.next();
-                }
-            }
-            "dev" | "weight" if nhid => {
-                tokens.next();
-            }
-            "onlink" if nhid => {}
-            "ttl-propogate" => {
-                attrs.push("ttl-propagate".to_owned());
-                attrs.extend(tokens.next().map(str::to_owned));
-            }
-            key if VALUED_KEYWORDS.contains(&key) => {
-                keep(&mut attrs, &mut selectors, key, tokens.next());
-            }
-            flag if DISPLAY_FLAGS.contains(&flag) => {}
-            token => attrs.push(token.to_owned()),
-        }
-    }
-    CleanedTokens {
-        attrs,
-        selectors: selectors.into_values().flatten().collect(),
-        nhid,
-    }
-}
-
-fn parse_route_show(output: &str) -> Vec<ShownRoute> {
-    let mut routes = Vec::<ShownRoute>::new();
-    for line in output.lines() {
-        let mut tokens = line.split_whitespace().peekable();
-        let Some(&first) = tokens.peek() else {
-            continue;
-        };
-        if first == "nexthop" {
-            if let Some(route) = routes.last_mut().filter(|r| !r.nhid) {
-                route.nexthops.extend(clean_route_tokens(tokens).attrs);
-            }
+    let mut reply_rule = false;
+    for line in rules_output.lines().map(str::trim) {
+        if !(rule_has(line, "fwmark", &format!("0x{table_id:x}"))
+            && rule_has(line, "lookup", &table_str))
+        {
             continue;
         }
-        let CleanedTokens {
-            attrs,
-            selectors,
-            nhid,
-        } = clean_route_tokens(tokens);
-        let prefix = attrs
-            .iter()
-            .find(|t| !ROUTE_TYPES.contains(&t.as_str()))
-            .cloned()
-            .unwrap_or_default();
-        routes.push(ShownRoute {
-            prefix,
-            selectors,
-            nhid,
-            attrs,
-            nexthops: Vec::new(),
-        });
+        match line.split(':').next() {
+            Some("51") => reply_rule = true,
+            Some(priority) => {
+                ip().arg("rule")
+                    .arg("del")
+                    .arg("fwmark")
+                    .arg(&table_str)
+                    .arg("lookup")
+                    .arg(&table_str)
+                    .arg("priority")
+                    .arg(priority)
+                    .invoke(ErrorKind::Network)
+                    .await
+                    .log_err();
+            }
+            None => {}
+        }
     }
-    routes
-}
-
-// `table` must precede a multipath `nexthop` list.
-fn route_replace_args(route: &ShownRoute, table: &str) -> Vec<String> {
-    route
-        .attrs
-        .iter()
-        .cloned()
-        .chain(["table".to_owned(), table.to_owned()])
-        .chain(route.nexthops.iter().cloned())
-        .collect()
-}
-
-fn route_del_args(route: &ShownRoute, table: &str) -> Vec<String> {
-    [route.prefix.clone()]
-        .into_iter()
-        .chain(route.selectors.iter().cloned())
-        .chain(["table".to_owned(), table.to_owned()])
-        .collect()
+    if !reply_rule {
+        ip().arg("rule")
+            .arg("add")
+            .arg("fwmark")
+            .arg(&table_str)
+            .arg("lookup")
+            .arg(&table_str)
+            .arg("priority")
+            .arg("51")
+            .invoke(ErrorKind::Network)
+            .await
+            .log_err();
+    }
 }
 
 async fn apply_policy_routing(
@@ -2215,93 +2061,24 @@ async fn apply_policy_routing(
         })
         .copied();
 
-    // `replace` keeps the table live; a flush would open a connectivity gap.
-    let mut desired = None;
-
-    if let Ok(main_routes) = Command::new("ip")
-        .arg("route")
-        .arg("show")
+    let mut cmd = Command::new("ip");
+    cmd.arg("route").arg("replace").arg("default");
+    if let Some(gw) = ipv4_gateway {
+        cmd.arg("via").arg(gw.to_string());
+    }
+    cmd.arg("dev")
+        .arg(iface.as_str())
         .arg("table")
-        .arg("main")
-        .invoke(ErrorKind::Network)
-        .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
-    {
-        let mut identities = BTreeSet::new();
-        let mut failed_domains = BTreeSet::new();
-        for route in parse_route_show(&main_routes) {
-            if route.prefix == "default" {
-                continue;
-            }
-            identities.insert(route.identity());
-            let mut cmd = Command::new("ip");
-            cmd.arg("route")
-                .arg("replace")
-                .args(route_replace_args(&route, &table_str));
-            if let Err(e) = cmd.invoke(ErrorKind::Network).await {
-                failed_domains.insert(route.failure_domain());
-                // Transient interfaces (podman, wg-quick, etc.) may
-                // vanish between reading the main table and replaying
-                // the route — demote to debug to avoid log noise.
-                if e.source.to_string().contains("No such file or directory") {
-                    tracing::trace!("ip route replace (transient device): {e}");
-                } else {
-                    tracing::error!("{e}");
-                    tracing::debug!("{e:?}");
-                }
-            }
-        }
-        desired = Some((identities, failed_domains));
+        .arg(&table_str);
+    if ipv4_gateway.is_none() {
+        cmd.arg("scope").arg("link");
     }
-
-    // Replace the default route via this interface's gateway.
-    {
-        let mut cmd = Command::new("ip");
-        cmd.arg("route").arg("replace").arg("default");
-        if let Some(gw) = ipv4_gateway {
-            cmd.arg("via").arg(gw.to_string());
-        }
-        cmd.arg("dev")
-            .arg(iface.as_str())
-            .arg("table")
-            .arg(&table_str);
-        if ipv4_gateway.is_none() {
-            cmd.arg("scope").arg("link");
-        }
-        cmd.invoke(ErrorKind::Network).await.log_err();
-    }
-
-    let existing_routes = Command::new("ip")
-        .arg("route")
-        .arg("show")
-        .arg("table")
-        .arg(&table_str)
-        .invoke(ErrorKind::Network)
-        .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
-    if let (Some((desired, failed_domains)), Ok(existing_routes)) = (desired, existing_routes) {
-        for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default"
-                || desired.contains(&route.identity())
-                || failed_domains.contains(&route.failure_domain())
-            {
-                continue;
-            }
-            Command::new("ip")
-                .arg("route")
-                .arg("del")
-                .args(route_del_args(&route, &table_str))
-                .invoke(ErrorKind::Network)
-                .await
-                .log_err();
-        }
-    }
+    cmd.invoke(ErrorKind::Network).await.log_err();
 
     // The mangle CONNMARK rules — the global `restore-mark` (mangle PREROUTING +
     // OUTPUT) and this interface's `mark-<iface>` — are reconciled centrally and
     // atomically by `reconcile_mangle_rules`, so they are not touched here.
 
-    // Ensure fwmark-based ip rule for this interface's table
     let rules_output = String::from_utf8(
         Command::new("ip")
             .arg("rule")
@@ -2309,23 +2086,7 @@ async fn apply_policy_routing(
             .invoke(ErrorKind::Network)
             .await?,
     )?;
-    if !rules_output
-        .lines()
-        .any(|l| l.contains("fwmark") && l.contains(&format!("lookup {table_id}")))
-    {
-        Command::new("ip")
-            .arg("rule")
-            .arg("add")
-            .arg("fwmark")
-            .arg(&table_str)
-            .arg("lookup")
-            .arg(&table_str)
-            .arg("priority")
-            .arg("50")
-            .invoke(ErrorKind::Network)
-            .await
-            .log_err();
-    }
+    ensure_table_rules(false, table_id, &rules_output).await;
 
     Ok(())
 }
@@ -2343,15 +2104,15 @@ fn carries_v6(gateway: Option<Ipv6Addr>, addrs: impl IntoIterator<Item = Ipv6Add
 
 /// IPv6 counterpart of [`apply_policy_routing`]'s per-interface table work.
 ///
-/// The table `1000 + ifindex` mirrors `main`'s non-default v6 routes (so
-/// on-link/local v6 still goes direct) plus a default: `default [via gw] dev
-/// iface` when the interface can carry v6, otherwise `blackhole default`. That
+/// The table `1000 + ifindex` holds one route: `default [via gw] dev iface`
+/// when the interface can carry v6, otherwise `blackhole default`; specific
+/// routes are `main`'s, consulted first by the priority-50 rule. That
 /// per-gateway blackhole is the leak guard — a gateway with no IPv6 selected as
 /// the default outbound (the priority-75 catch-all) then drops v6 rather than
 /// letting it fall through to some other interface's default.
 ///
 /// The table backs three rule layers: the priority-75 default-outbound catch-all
-/// ([`apply_default_outbound`]), the priority-50 CONNMARK reply-routing rule
+/// ([`apply_default_outbound`]), the priority-51 CONNMARK reply-routing rule
 /// installed at the end here (IPv4 parity; marks set by
 /// [`reconcile_mangle_rules`]), and — v6-only — a priority-60 source rule per
 /// global address on the interface. IPv6 has no NAT/SNI-demux reply layer to
@@ -2390,44 +2151,6 @@ async fn apply_policy_routing_v6(
         }),
     );
 
-    // Mirror main's non-default v6 routes into the per-interface table, so the
-    // priority-75 catch-all does not send on-link/local v6 through the gateway.
-    let mut desired = None;
-    if let Ok(main_routes) = Command::new("ip")
-        .arg("-6")
-        .arg("route")
-        .arg("show")
-        .arg("table")
-        .arg("main")
-        .invoke(ErrorKind::Network)
-        .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8))
-    {
-        let mut identities = BTreeSet::new();
-        let mut failed_domains = BTreeSet::new();
-        for route in parse_route_show(&main_routes) {
-            if route.prefix == "default" {
-                continue;
-            }
-            identities.insert(route.identity());
-            let mut cmd = Command::new("ip");
-            cmd.arg("-6")
-                .arg("route")
-                .arg("replace")
-                .args(route_replace_args(&route, &table_str));
-            if let Err(e) = cmd.invoke(ErrorKind::Network).await {
-                failed_domains.insert(route.failure_domain());
-                if e.source.to_string().contains("No such file or directory") {
-                    tracing::trace!("ip -6 route replace (transient device): {e}");
-                } else {
-                    tracing::error!("{e}");
-                    tracing::debug!("{e:?}");
-                }
-            }
-        }
-        desired = Some((identities, failed_domains));
-    }
-
     // Replace the default: a real route when the interface can carry v6, else a
     // blackhole so a non-v6 gateway selected as default outbound drops v6.
     {
@@ -2451,39 +2174,6 @@ async fn apply_policy_routing_v6(
         cmd.invoke(ErrorKind::Network).await.log_err();
     }
 
-    let existing_routes = Command::new("ip")
-        .arg("-6")
-        .arg("route")
-        .arg("show")
-        .arg("table")
-        .arg(&table_str)
-        .invoke(ErrorKind::Network)
-        .await
-        .and_then(|b| String::from_utf8(b).with_kind(ErrorKind::Utf8));
-    if let (Some((desired, failed_domains)), Ok(existing_routes)) = (desired, existing_routes) {
-        for route in parse_route_show(&existing_routes) {
-            if route.prefix == "default"
-                || desired.contains(&route.identity())
-                || failed_domains.contains(&route.failure_domain())
-            {
-                continue;
-            }
-            Command::new("ip")
-                .arg("-6")
-                .arg("route")
-                .arg("del")
-                .args(route_del_args(&route, &table_str))
-                .invoke(ErrorKind::Network)
-                .await
-                .log_err();
-        }
-    }
-
-    // Ensure the priority-50 fwmark ip rule for this interface's table — the
-    // IPv6 half of the CONNMARK reply-routing layer (marks set by
-    // `reconcile_mangle_rules`). Mirrors `apply_policy_routing`'s IPv4 rule so a
-    // reply to a connection that arrived on this interface (host-terminated or
-    // DNAT'd to a container) routes back out it rather than being lost.
     let rules_output = String::from_utf8(
         Command::new("ip")
             .arg("-6")
@@ -2492,24 +2182,7 @@ async fn apply_policy_routing_v6(
             .invoke(ErrorKind::Network)
             .await?,
     )?;
-    if !rules_output
-        .lines()
-        .any(|l| l.contains("fwmark") && l.contains(&format!("lookup {table_id}")))
-    {
-        Command::new("ip")
-            .arg("-6")
-            .arg("rule")
-            .arg("add")
-            .arg("fwmark")
-            .arg(&table_str)
-            .arg("lookup")
-            .arg(&table_str)
-            .arg("priority")
-            .arg("50")
-            .invoke(ErrorKind::Network)
-            .await
-            .log_err();
-    }
+    ensure_table_rules(true, table_id, &rules_output).await;
 
     // Ensure a priority-60 source rule per global v6 address on this interface.
     // The CONNMARK rule above cannot catch the reply that opens a connection:
@@ -2634,7 +2307,7 @@ async fn poll_ip_info(
     if let Some(guard) = policy_guard {
         apply_policy_routing(guard, iface, &lan_ip).await?;
         // v6 has no NAT/SNI-demux reply layer, but this now installs the v6
-        // CONNMARK reply-routing rule (priority 50, IPv4 parity — marks set by
+        // CONNMARK reply-routing rule (priority 51, IPv4 parity — marks set by
         // `reconcile_mangle_rules`) alongside readying the interface's v6 table
         // for the default-outbound catch-all and the per-gateway leak-guard
         // blackhole (when the interface can't carry v6).
@@ -3778,331 +3451,5 @@ mod wg_config_tests {
         assert!(!parsed.to_nm_settings("wg0", None).unwrap()["connection"].contains_key("uuid"));
         let updated = parsed.to_nm_settings("wg0", Some("uuid-x")).unwrap();
         assert_eq!(as_str(&updated["connection"]["uuid"]), "uuid-x");
-    }
-}
-
-#[cfg(test)]
-mod route_show_tests {
-    use super::*;
-
-    fn strs(v: &[&str]) -> Vec<String> {
-        v.iter().map(|s| s.to_string()).collect()
-    }
-
-    #[test]
-    fn a_multipath_route_folds_its_next_hops_behind_the_table() {
-        let shown = "default proto ra metric 1024 pref medium\n\
-                     \tnexthop via fe80::1 dev enp2s0 weight 1\n\
-                     \tnexthop via fe80::2 dev enp2s0 weight 1\n";
-        let routes = parse_route_show(shown);
-        assert_eq!(routes.len(), 1);
-        assert_eq!(routes[0].prefix, "default");
-        assert_eq!(
-            route_replace_args(&routes[0], "75"),
-            strs(&[
-                "default", "proto", "ra", "metric", "1024", "pref", "medium", "table", "75",
-                "nexthop", "via", "fe80::1", "dev", "enp2s0", "weight", "1", "nexthop", "via",
-                "fe80::2", "dev", "enp2s0", "weight", "1",
-            ])
-        );
-    }
-
-    #[test]
-    fn a_lifetime_is_dropped() {
-        let routes = parse_route_show(
-            "2001:db8::/64 via fe80::1 dev eth0 proto ra metric 1024 expires 1786sec hoplimit 64 pref medium",
-        );
-        assert_eq!(
-            routes[0].attrs,
-            strs(&[
-                "2001:db8::/64",
-                "via",
-                "fe80::1",
-                "dev",
-                "eth0",
-                "proto",
-                "ra",
-                "metric",
-                "1024",
-                "hoplimit",
-                "64",
-                "pref",
-                "medium",
-            ])
-        );
-    }
-
-    #[test]
-    fn an_interface_named_like_a_flag_survives() {
-        for name in ["trap", "error", "expires"] {
-            let routes = parse_route_show(&format!(
-                "2001:db8::/64 dev {name} proto ra metric 100 trap"
-            ));
-            assert_eq!(
-                routes[0].attrs,
-                strs(&["2001:db8::/64", "dev", name, "proto", "ra", "metric", "100"]),
-                "{name}"
-            );
-        }
-    }
-
-    #[test]
-    fn nested_interface_keywords_keep_their_values() {
-        for line in [
-            "2001:db8::/64 dev eth0 iif trap oif error metric 100",
-            "10.0.0.0/8 dev tun0 link_dev expires metric 5",
-        ] {
-            assert_eq!(
-                parse_route_show(line)[0].attrs,
-                line.split_whitespace().collect::<Vec<_>>(),
-                "{line}"
-            );
-        }
-    }
-
-    #[test]
-    fn a_nexthop_id_drops_its_expansion() {
-        for shown in [
-            "10.0.0.0/8 nhid 5 via 10.0.0.1 dev eth0 proto ra metric 100",
-            "10.0.0.0/8 nhid 5 via inet6 fe80::1 dev eth0 proto ra metric 100",
-            "10.0.0.0/8 nhid 5 encap mpls 100/200 via 10.0.0.1 dev eth0 onlink proto ra metric 100",
-        ] {
-            assert_eq!(
-                parse_route_show(shown)[0].attrs,
-                strs(&["10.0.0.0/8", "nhid", "5", "proto", "ra", "metric", "100"]),
-                "{shown}"
-            );
-        }
-        for shown in [
-            "10.0.0.0/8 via 10.0.0.1 dev nhid proto static metric 100",
-            "10.0.0.0/8 encap mpls 100 via 10.0.0.1 dev eth0 proto static metric 100",
-        ] {
-            let route = &parse_route_show(shown)[0];
-            assert!(!route.nhid, "{shown}");
-            assert_eq!(
-                route.attrs,
-                shown.split_whitespace().collect::<Vec<_>>(),
-                "{shown}"
-            );
-        }
-
-        // iproute2 6.9 output: the route's `tos` follows the expansion, an ip encap carries one of its own.
-        for (shown, attrs) in [
-            (
-                "10.1.0.0/16 nhid 5 tos 0x10 via 10.0.0.1 dev dummy0",
-                vec!["10.1.0.0/16", "nhid", "5", "tos", "0x10"],
-            ),
-            (
-                "10.3.0.0/16 nhid 6  encap ip id 7 src 0.0.0.0 dst 10.0.0.9 ttl 0 tos 0 tos 0x10 via 10.0.0.1 dev dummy0",
-                vec!["10.3.0.0/16", "nhid", "6", "tos", "0x10"],
-            ),
-            (
-                "10.3.0.0/16 nhid 6  encap ip id 7 src 0.0.0.0 dst 10.0.0.9 ttl 0 tos 0 via 10.0.0.1 dev dummy0",
-                vec!["10.3.0.0/16", "nhid", "6"],
-            ),
-            (
-                "10.0.0.0/8 nhid 5 encap mpls 100/200 tos 0x10 via 10.0.0.1 dev eth0 proto ra metric 100",
-                vec![
-                    "10.0.0.0/8",
-                    "nhid",
-                    "5",
-                    "tos",
-                    "0x10",
-                    "proto",
-                    "ra",
-                    "metric",
-                    "100",
-                ],
-            ),
-        ] {
-            let route = &parse_route_show(shown)[0];
-            assert_eq!(route.attrs, strs(&attrs), "{shown}");
-            let tos: Vec<_> = attrs
-                .windows(2)
-                .find(|w| w[0] == "tos")
-                .into_iter()
-                .flatten()
-                .copied()
-                .collect();
-            assert_eq!(
-                route
-                    .selectors
-                    .iter()
-                    .take(2)
-                    .map(String::as_str)
-                    .collect::<Vec<_>>(),
-                tos,
-                "{shown}"
-            );
-        }
-
-        let group = parse_route_show(
-            "default nhid 7 proto ra metric 1024 pref medium\n\
-             \tnexthop via fe80::1 dev eth0 weight 1\n\
-             \tnexthop via fe80::2 dev eth0 weight 1\n",
-        );
-        assert_eq!(group.len(), 1);
-        assert!(group[0].nexthops.is_empty());
-        assert_eq!(
-            route_replace_args(&group[0], "75"),
-            strs(&[
-                "default", "nhid", "7", "proto", "ra", "metric", "1024", "pref", "medium", "table",
-                "75",
-            ])
-        );
-    }
-
-    #[test]
-    fn routes_differing_only_in_metric_are_distinct_and_deleted_by_metric() {
-        let routes = parse_route_show(
-            "2001:db8::/64 dev eth0 proto ra metric 100\n\
-             2001:db8::/64 dev eth0 proto kernel metric 1024\n",
-        );
-        assert_ne!(routes[0].identity(), routes[1].identity());
-        assert_eq!(
-            route_del_args(&routes[1], "75"),
-            strs(&["2001:db8::/64", "metric", "1024", "table", "75"])
-        );
-        assert_eq!(
-            route_del_args(&parse_route_show("10.0.0.0/8 dev eth0")[0], "75"),
-            strs(&["10.0.0.0/8", "table", "75"])
-        );
-    }
-
-    #[test]
-    fn routes_alias_on_tos_and_source_and_are_deleted_with_them() {
-        let v4 = parse_route_show(
-            "10.0.0.0/8 via 10.0.0.1 dev eth0 metric 100\n\
-             10.0.0.0/8 tos 0x10 via 10.0.0.2 dev eth0 metric 100\n",
-        );
-        assert_ne!(v4[0].identity(), v4[1].identity());
-        assert_eq!(
-            route_del_args(&v4[1], "75"),
-            strs(&["10.0.0.0/8", "tos", "0x10", "metric", "100", "table", "75"])
-        );
-
-        let v6 = parse_route_show(
-            "2001:db8::/64 via fe80::1 dev eth0 metric 1024\n\
-             2001:db8::/64 from 2001:db8:1::/64 via fe80::2 dev eth0 metric 1024\n",
-        );
-        assert_ne!(v6[0].identity(), v6[1].identity());
-        assert_eq!(
-            route_del_args(&v6[1], "75"),
-            strs(&[
-                "2001:db8::/64",
-                "from",
-                "2001:db8:1::/64",
-                "metric",
-                "1024",
-                "table",
-                "75"
-            ])
-        );
-        assert_eq!(
-            v6[0].failure_domain(),
-            ("2001:db8::/64".to_owned(), Vec::new())
-        );
-        assert_eq!(
-            v6[1].failure_domain(),
-            (
-                "2001:db8::/64".to_owned(),
-                strs(&["from", "2001:db8:1::/64"])
-            )
-        );
-    }
-
-    #[test]
-    fn ttl_propagate_uses_the_spelling_accepted_on_replay() {
-        for value in ["enabled", "disabled"] {
-            let route = parse_route_show(&format!("192.0.2.0/24 dev eth0 ttl-propogate {value}"));
-            assert_eq!(
-                route[0].attrs,
-                strs(&["192.0.2.0/24", "dev", "eth0", "ttl-propagate", value])
-            );
-        }
-    }
-
-    #[test]
-    fn an_xresolve_route_keeps_its_destination() {
-        let routes = parse_route_show("xresolve 10.0.0.0/8 dev lo metric 1024");
-        assert_eq!(routes[0].prefix, "10.0.0.0/8");
-        assert_eq!(
-            routes[0].attrs,
-            strs(&["xresolve", "10.0.0.0/8", "dev", "lo", "metric", "1024"])
-        );
-    }
-
-    #[test]
-    fn a_typed_route_keeps_its_type_and_drops_its_errno() {
-        let routes =
-            parse_route_show("unreachable fd00::/64 dev lo metric 1024 error -113 pref medium");
-        assert_eq!(routes[0].prefix, "fd00::/64");
-        assert_eq!(
-            routes[0].attrs,
-            strs(&[
-                "unreachable",
-                "fd00::/64",
-                "dev",
-                "lo",
-                "metric",
-                "1024",
-                "pref",
-                "medium"
-            ])
-        );
-    }
-
-    #[test]
-    fn a_blackhole_default_is_a_default() {
-        let routes = parse_route_show("blackhole default dev lo metric 1024 error -22 pref medium");
-        assert_eq!(routes[0].prefix, "default");
-    }
-
-    #[test]
-    fn display_flags_are_dropped() {
-        let routes = parse_route_show(
-            "2001:db8::/64 dev eth0 proto kernel metric 256 rt_offload linkdown dead pref medium",
-        );
-        assert_eq!(
-            routes[0].attrs,
-            strs(&[
-                "2001:db8::/64",
-                "dev",
-                "eth0",
-                "proto",
-                "kernel",
-                "metric",
-                "256",
-                "pref",
-                "medium"
-            ])
-        );
-    }
-
-    #[test]
-    fn a_plain_route_passes_through() {
-        let routes = parse_route_show("fe80::/64 dev eno0 proto kernel metric 1024 pref medium\n");
-        assert_eq!(routes[0].prefix, "fe80::/64");
-        assert_eq!(
-            route_replace_args(&routes[0], "75"),
-            strs(&[
-                "fe80::/64",
-                "dev",
-                "eno0",
-                "proto",
-                "kernel",
-                "metric",
-                "1024",
-                "pref",
-                "medium",
-                "table",
-                "75"
-            ])
-        );
-    }
-
-    #[test]
-    fn a_stray_next_hop_line_is_ignored() {
-        assert!(parse_route_show("nexthop via fe80::1 dev eth0 weight 1\n").is_empty());
     }
 }

--- a/shared-libs/crates/start-core/src/net/socks.rs
+++ b/shared-libs/crates/start-core/src/net/socks.rs
@@ -5,7 +5,11 @@ use fast_socks5::client::{Config as ClientConfig, Socks5Stream};
 use fast_socks5::server::Socks5ServerProtocol;
 use fast_socks5::util::target_addr::TargetAddr;
 use fast_socks5::{ReplyError, Socks5Command};
-use tokio::net::{TcpListener, TcpStream};
+use futures::StreamExt;
+use futures::stream::FuturesUnordered;
+use itertools::Itertools;
+use tokio::net::{TcpListener, TcpStream, lookup_host};
+use tokio::time::Instant;
 
 use crate::HOST_IP;
 use crate::net::mdns::resolve_mdns;
@@ -22,6 +26,51 @@ pub const DEFAULT_SOCKS_LISTEN: SocketAddr = SocketAddr::V4(SocketAddrV4::new(
 /// reachable from the host via the embedded DNS once that service is running.
 /// Matches the default the registry server uses for its own onion requests.
 const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
+
+/// RFC 8305 connection attempt delay.
+const CONNECT_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
+
+fn interleave_families(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
+    let mut addrs = addrs.into_iter().peekable();
+    let first_is_v6 = addrs.peek().is_some_and(SocketAddr::is_ipv6);
+    let (first, second): (Vec<_>, Vec<_>) = addrs.partition(|a| a.is_ipv6() == first_is_v6);
+    first.into_iter().interleave(second).collect()
+}
+
+/// Connects to whichever address answers first; attempts start
+/// [`CONNECT_ATTEMPT_DELAY`] apart, alternating address families.
+async fn connect_any(addrs: impl IntoIterator<Item = SocketAddr>) -> Result<TcpStream, Error> {
+    let mut pending = interleave_families(addrs).into_iter();
+    let mut attempts = FuturesUnordered::new();
+    let mut last_err = None;
+    let next_attempt = tokio::time::sleep(Duration::ZERO);
+    tokio::pin!(next_attempt);
+    loop {
+        tokio::select! {
+            _ = &mut next_attempt, if pending.len() > 0 => {
+                if let Some(addr) = pending.next() {
+                    attempts.push(TcpStream::connect(addr));
+                }
+                next_attempt.as_mut().reset(Instant::now() + CONNECT_ATTEMPT_DELAY);
+            }
+            Some(res) = attempts.next() => match res {
+                Ok(stream) => return Ok(stream),
+                Err(e) => {
+                    last_err = Some(e);
+                    next_attempt.as_mut().reset(Instant::now());
+                }
+            },
+            else => break,
+        }
+    }
+    match last_err {
+        Some(e) => Err(e).with_kind(ErrorKind::Network),
+        None => Err(Error::new(
+            eyre!("no address to connect to"),
+            ErrorKind::Network,
+        )),
+    }
+}
 
 /// Open a connection to a SOCKS `CONNECT` target, special-casing the two address
 /// families the host's resolver/router can't reach on its own:
@@ -53,9 +102,14 @@ async fn connect_target(addr: TargetAddr) -> Result<TcpStream, Error> {
                 .await
                 .with_kind(ErrorKind::Network)
         }
-        TargetAddr::Domain(domain, port) => TcpStream::connect((domain, port))
+        TargetAddr::Domain(domain, port) => {
+            connect_any(
+                lookup_host((domain, port))
+                    .await
+                    .with_kind(ErrorKind::Network)?,
+            )
             .await
-            .with_kind(ErrorKind::Network),
+        }
         TargetAddr::Ip(addr) => TcpStream::connect(addr).await.with_kind(ErrorKind::Network),
     }
 }
@@ -157,9 +211,44 @@ impl SocksController {
 
 #[cfg(test)]
 mod test {
+    use std::net::Ipv6Addr;
+
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
+
+    #[test]
+    fn interleave_families_alternates_from_the_first_family() {
+        let v6 = |n| SocketAddr::from((Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, n), 1));
+        let v4 = |n| SocketAddr::from((Ipv4Addr::new(192, 0, 2, n), 1));
+        assert_eq!(
+            interleave_families([v6(1), v6(2), v4(1)]),
+            [v6(1), v4(1), v6(2)]
+        );
+        assert_eq!(
+            interleave_families([v4(1), v6(1), v6(2)]),
+            [v4(1), v6(1), v6(2)]
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_any_does_not_wait_on_a_black_hole() -> Result<(), Error> {
+        let target = echo_server().await?;
+        let started = Instant::now();
+        let mut sock =
+            connect_any([SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 9)), target]).await?;
+        assert!(started.elapsed() < Duration::from_secs(5));
+
+        sock.write_all(b"hello")
+            .await
+            .with_kind(ErrorKind::Network)?;
+        let mut buf = [0u8; 5];
+        sock.read_exact(&mut buf)
+            .await
+            .with_kind(ErrorKind::Network)?;
+        assert_eq!(&buf, b"hello");
+        Ok(())
+    }
 
     async fn echo_server() -> Result<SocketAddr, Error> {
         let l = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))

--- a/shared-libs/crates/start-core/src/net/socks.rs
+++ b/shared-libs/crates/start-core/src/net/socks.rs
@@ -1,3 +1,4 @@
+use std::future::Future;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 use std::time::Duration;
 
@@ -29,6 +30,7 @@ const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
 
 /// RFC 8305 connection attempt delay.
 const CONNECT_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
+const CONNECT_ATTEMPTS_IN_FLIGHT: usize = 2;
 
 fn interleave_families(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
     let mut addrs = addrs.into_iter().peekable();
@@ -37,9 +39,17 @@ fn interleave_families(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<Socke
     first.into_iter().interleave(second).collect()
 }
 
-/// Connects to whichever address answers first; attempts start
-/// [`CONNECT_ATTEMPT_DELAY`] apart, alternating address families.
-async fn connect_any(addrs: impl IntoIterator<Item = SocketAddr>) -> Result<TcpStream, Error> {
+/// Connects to the first address that answers, alternating families. Starts
+/// another attempt after [`CONNECT_ATTEMPT_DELAY`] or an earlier failure, with
+/// at most [`CONNECT_ATTEMPTS_IN_FLIGHT`] pending.
+async fn connect_each<F, Fut>(
+    addrs: impl IntoIterator<Item = SocketAddr>,
+    mut connect: F,
+) -> Result<TcpStream, Error>
+where
+    F: FnMut(SocketAddr) -> Fut,
+    Fut: Future<Output = std::io::Result<TcpStream>>,
+{
     let mut pending = interleave_families(addrs).into_iter();
     let mut attempts = FuturesUnordered::new();
     let mut last_err = None;
@@ -47,9 +57,9 @@ async fn connect_any(addrs: impl IntoIterator<Item = SocketAddr>) -> Result<TcpS
     tokio::pin!(next_attempt);
     loop {
         tokio::select! {
-            _ = &mut next_attempt, if pending.len() > 0 => {
+            _ = &mut next_attempt, if pending.len() > 0 && attempts.len() < CONNECT_ATTEMPTS_IN_FLIGHT => {
                 if let Some(addr) = pending.next() {
-                    attempts.push(TcpStream::connect(addr));
+                    attempts.push(connect(addr));
                 }
                 next_attempt.as_mut().reset(Instant::now() + CONNECT_ATTEMPT_DELAY);
             }
@@ -103,10 +113,11 @@ async fn connect_target(addr: TargetAddr) -> Result<TcpStream, Error> {
                 .with_kind(ErrorKind::Network)
         }
         TargetAddr::Domain(domain, port) => {
-            connect_any(
+            connect_each(
                 lookup_host((domain, port))
                     .await
                     .with_kind(ErrorKind::Network)?,
+                |addr| TcpStream::connect(addr),
             )
             .await
         }
@@ -213,9 +224,25 @@ impl SocksController {
 mod test {
     use std::net::Ipv6Addr;
 
+    use futures::FutureExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     use super::*;
+
+    const STALLED: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 9));
+    const REFUSED: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 2), 9));
+
+    async fn echo_round_trip(sock: &mut TcpStream) -> Result<(), Error> {
+        sock.write_all(b"hello")
+            .await
+            .with_kind(ErrorKind::Network)?;
+        let mut buf = [0u8; 5];
+        sock.read_exact(&mut buf)
+            .await
+            .with_kind(ErrorKind::Network)?;
+        assert_eq!(&buf, b"hello");
+        Ok(())
+    }
 
     #[test]
     fn interleave_families_alternates_from_the_first_family() {
@@ -231,23 +258,56 @@ mod test {
         );
     }
 
-    #[tokio::test]
-    async fn connect_any_does_not_wait_on_a_black_hole() -> Result<(), Error> {
+    #[tokio::test(start_paused = true)]
+    async fn the_second_attempt_starts_one_delay_after_a_stalled_first() -> Result<(), Error> {
         let target = echo_server().await?;
         let started = Instant::now();
-        let mut sock =
-            connect_any([SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 9)), target]).await?;
-        assert!(started.elapsed() < Duration::from_secs(5));
+        let mut starts = Vec::new();
+        let mut sock = connect_each([STALLED, target], |addr| {
+            starts.push((addr, started.elapsed()));
+            if addr == STALLED {
+                futures::future::pending().boxed()
+            } else {
+                TcpStream::connect(addr).boxed()
+            }
+        })
+        .await?;
+        assert_eq!(
+            starts,
+            [(STALLED, Duration::ZERO), (target, CONNECT_ATTEMPT_DELAY)]
+        );
+        echo_round_trip(&mut sock).await
+    }
 
-        sock.write_all(b"hello")
-            .await
-            .with_kind(ErrorKind::Network)?;
-        let mut buf = [0u8; 5];
-        sock.read_exact(&mut buf)
-            .await
-            .with_kind(ErrorKind::Network)?;
-        assert_eq!(&buf, b"hello");
-        Ok(())
+    #[tokio::test(start_paused = true)]
+    async fn a_third_attempt_waits_for_a_failure() -> Result<(), Error> {
+        let target = echo_server().await?;
+        let started = Instant::now();
+        let mut starts = Vec::new();
+        let mut sock = connect_each([STALLED, REFUSED, target], |addr| {
+            starts.push((addr, started.elapsed()));
+            if addr == STALLED {
+                futures::future::pending().boxed()
+            } else if addr == REFUSED {
+                async {
+                    tokio::time::sleep(Duration::from_secs(3)).await;
+                    Err(std::io::ErrorKind::ConnectionRefused.into())
+                }
+                .boxed()
+            } else {
+                TcpStream::connect(addr).boxed()
+            }
+        })
+        .await?;
+        assert_eq!(
+            starts,
+            [
+                (STALLED, Duration::ZERO),
+                (REFUSED, CONNECT_ATTEMPT_DELAY),
+                (target, Duration::from_secs(3) + CONNECT_ATTEMPT_DELAY),
+            ]
+        );
+        echo_round_trip(&mut sock).await
     }
 
     async fn echo_server() -> Result<SocketAddr, Error> {

--- a/shared-libs/crates/start-core/src/net/socks.rs
+++ b/shared-libs/crates/start-core/src/net/socks.rs
@@ -30,7 +30,6 @@ const TOR_PROXY: (&str, u16) = ("tor.startos", 9050);
 
 /// RFC 8305 connection attempt delay.
 const CONNECT_ATTEMPT_DELAY: Duration = Duration::from_millis(250);
-const CONNECT_ATTEMPTS_IN_FLIGHT: usize = 2;
 
 fn interleave_families(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
     let mut addrs = addrs.into_iter().peekable();
@@ -40,8 +39,7 @@ fn interleave_families(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<Socke
 }
 
 /// Connects to the first address that answers, alternating families. Starts
-/// another attempt after [`CONNECT_ATTEMPT_DELAY`] or an earlier failure, with
-/// at most [`CONNECT_ATTEMPTS_IN_FLIGHT`] pending.
+/// another attempt after [`CONNECT_ATTEMPT_DELAY`] or an earlier failure.
 async fn connect_each<F, Fut>(
     addrs: impl IntoIterator<Item = SocketAddr>,
     mut connect: F,
@@ -57,7 +55,7 @@ where
     tokio::pin!(next_attempt);
     loop {
         tokio::select! {
-            _ = &mut next_attempt, if pending.len() > 0 && attempts.len() < CONNECT_ATTEMPTS_IN_FLIGHT => {
+            _ = &mut next_attempt, if pending.len() > 0 => {
                 if let Some(addr) = pending.next() {
                     attempts.push(connect(addr));
                 }
@@ -225,14 +223,18 @@ mod test {
     use std::net::Ipv6Addr;
 
     use futures::FutureExt;
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
     use super::*;
 
     const STALLED: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 9));
-    const REFUSED: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 2), 9));
+    const STALLED_TOO: SocketAddr =
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 2), 9));
+    const REFUSED: SocketAddr = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 3), 9));
 
-    async fn echo_round_trip(sock: &mut TcpStream) -> Result<(), Error> {
+    async fn echo_round_trip(
+        sock: &mut (impl AsyncRead + AsyncWrite + Unpin),
+    ) -> Result<(), Error> {
         sock.write_all(b"hello")
             .await
             .with_kind(ErrorKind::Network)?;
@@ -280,7 +282,32 @@ mod test {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn a_third_attempt_waits_for_a_failure() -> Result<(), Error> {
+    async fn stalled_attempts_do_not_hold_up_the_next() -> Result<(), Error> {
+        let target = echo_server().await?;
+        let started = Instant::now();
+        let mut starts = Vec::new();
+        let mut sock = connect_each([STALLED, STALLED_TOO, target], |addr| {
+            starts.push((addr, started.elapsed()));
+            if addr == target {
+                TcpStream::connect(addr).boxed()
+            } else {
+                futures::future::pending().boxed()
+            }
+        })
+        .await?;
+        assert_eq!(
+            starts,
+            [
+                (STALLED, Duration::ZERO),
+                (STALLED_TOO, CONNECT_ATTEMPT_DELAY),
+                (target, 2 * CONNECT_ATTEMPT_DELAY),
+            ]
+        );
+        echo_round_trip(&mut sock).await
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_failure_starts_the_next_attempt_at_once() -> Result<(), Error> {
         let target = echo_server().await?;
         let started = Instant::now();
         let mut starts = Vec::new();
@@ -290,7 +317,7 @@ mod test {
                 futures::future::pending().boxed()
             } else if addr == REFUSED {
                 async {
-                    tokio::time::sleep(Duration::from_secs(3)).await;
+                    tokio::time::sleep(Duration::from_millis(100)).await;
                     Err(std::io::ErrorKind::ConnectionRefused.into())
                 }
                 .boxed()
@@ -304,7 +331,7 @@ mod test {
             [
                 (STALLED, Duration::ZERO),
                 (REFUSED, CONNECT_ATTEMPT_DELAY),
-                (target, Duration::from_secs(3) + CONNECT_ATTEMPT_DELAY),
+                (target, CONNECT_ATTEMPT_DELAY + Duration::from_millis(100)),
             ]
         );
         echo_round_trip(&mut sock).await
@@ -362,16 +389,7 @@ mod test {
         )
         .await
         .with_kind(ErrorKind::Network)?;
-
-        sock.write_all(b"hello")
-            .await
-            .with_kind(ErrorKind::Network)?;
-        let mut buf = [0u8; 5];
-        sock.read_exact(&mut buf)
-            .await
-            .with_kind(ErrorKind::Network)?;
-        assert_eq!(&buf, b"hello");
-        Ok(())
+        echo_round_trip(&mut sock).await
     }
 
     #[tokio::test]

--- a/shared-libs/crates/start-core/src/net/wifi.rs
+++ b/shared-libs/crates/start-core/src/net/wifi.rs
@@ -1106,7 +1106,7 @@ pub async fn synchronize_network_manager<P: AsRef<Path>>(
     // outbound points its priority-75 catch-all at a `blackhole default` table
     // (see `apply_policy_routing_v6`), dropping the host's v6 egress without also
     // blackholing replies to inbound tunnel connections — those are pinned to
-    // their arrival interface by the priority-50 CONNMARK rule.
+    // their arrival interface by the priority-51 CONNMARK rule.
     Command::new("ip")
         .arg("-6")
         .arg("rule")


### PR DESCRIPTION
An OS update from the beta registry sat at 0 bytes for over four minutes before completing. The download itself then ran at 17 MB/s. Two independent defects combine to produce that stall, and this fixes both.

## The network state that reveals it

The dev box's LAN router advertises an IPv6 default route (router lifetime 1800s) with two on-link prefixes, both `A=0`, and `M=1 O=1` — SLAAC off, get your address from DHCPv6. Its DHCPv6 server then issues no lease. So `eno0` ends up with a default route, prefix routes, and only a link-local address. The box's one global IPv6 address belongs to a StartTunnel gateway on `wg0`.

That is not an exotic configuration. Any server on a LAN whose router advertises IPv6 without handing out an address lands in it, and so does any server behind an ISP whose IPv6 is silently broken.

## `gateway.rs` — the leak

`apply_policy_routing_v6` installs a `blackhole default` in an interface's policy table when that interface cannot carry v6, so that selecting a non-v6 gateway as default outbound drops v6 rather than leaking it. The condition was `has an IPv6 gateway OR has a global address`. NetworkManager reports a gateway for `eno0` straight from that RA, so `eno0` passed with no address to send from and got a real default route.

Routing was correct throughout — the priority-75 rule pointed at `eno0`'s table, and every SYN left on `eno0`. What leaked was the *source address*: a global destination needs a global-scope source, `eno0` had none, so the kernel fell back to the only global address on the host, `wg0`'s. Those packets left `eno0` carrying a StartTunnel address the LAN discards, and hung until the kernel gave up.

The check is now whether the interface has a non-link-local address of its own — global where there is no gateway, ULA accepted where there is, so a NAT66 LAN still qualifies. The gateway only decides whether the route needs `via`. On this box `eno0`'s table now holds the blackhole, every IPv6 connect fails instantly, and nothing can carry the `wg0` address out `eno0`.

## `socks.rs` — the two-minute wait per address

`startd` routes its outbound HTTP through its own SOCKS proxy (`socks5h`, so the proxy resolves). The CONNECT handler called `TcpStream::connect((domain, port))`, which tries the resolved addresses **sequentially** with no timeout of its own, moving on only once the previous attempt fails. The CDN host has two AAAA records and one A record, so the download did: AAAA #1, ~2 min SYN timeout; AAAA #2, ~2 min; A record, connected in 50 ms.

The proxy now resolves first and races the addresses RFC 8305 style: attempts start 250 ms apart alternating address families, a failure starts the next immediately, and the first to connect wins while the rest are dropped. There is deliberately no cap on attempts in flight: with two dead addresses ahead of a live one, a cap holds the live one back until a kernel timeout, which is the stall being removed. Sockets held while nothing answers are bounded by the RRset. IPv6 stays preferred where it works. The raw-IP, `.local` and `.onion` paths are unchanged, and no overall deadline is introduced — a host that is simply slow still gets as long as it did before.

The blackhole fix alone would have covered this box. This one covers what no local guard can detect: a v6 route that is valid on the server but dead further along the path.

## Also here: the gateway watcher's `ip route` usage spam — and the end of the route mirror

`apply_policy_routing` / `apply_policy_routing_v6` used to mirror the main table into each gateway's policy table by feeding every line of `ip route show` back into `ip route replace`, dropping only `linkdown` and `dead`. Show output isn't replace input: a multipath route prints as a header plus indented `nexthop …` continuation lines, so `ip -6 route replace nexthop via … table N` ran on every `watch_ip` pass for every gateway and iproute2 printed its full usage. On a Server One whose LAN router advertises a two-next-hop IPv6 default, that was 140 usage dumps — 40% of a 10,000-line OS log export.

Five review rounds of a text parser found five more ways that text fails to round-trip (lifetimes, errno, display flags, nexthop-id expansions, encap payloads carrying their own `tos`, multi-line option output, interface names that collide with keywords), so the mirror is gone. **A per-gateway table now holds only its default route, or the v6 leak-guard blackhole.** Specific routes come from `main` directly: a `lookup main suppress_prefixlength 0` rule ahead of the table rules consults `main` for every route except a default, which is exactly the set the mirror copied (its loops skipped `default`). wg-quick relies on the same rule for full-tunnel mode.

Verified in a container with iproute2 6.9, tables holding only their default or blackhole:

```
192.168.8.50   -> dev lan                      on-link, from main
10.0.3.7       -> dev lxcbr0                   container subnet, from main
10.8.0.9       -> dev wg0                      VPN-peer route (an encap route the parser could never replay), from main
8.8.8.8        -> dev wg0 table 1004           the gateway's default
fd00:3::9      -> dev lan                      ULA on-link, from main
2606:4700::1   -> RTNETLINK answers: Invalid argument   v6 leak guard (blackhole) holds
mark 0x3ec -> 192.168.8.50 -> dev lan          reply mark, on-link still wins
mark 0x3ec -> 8.8.8.8      -> dev wg0 table 1004
```

Rule order is now `49` transparent divert, `50` `lookup main suppress_prefixlength 0`, `51` per-interface reply mark, `60` IPv6 source, `74` WireGuard encap mark, `75` selected outbound. The reply-mark rules moved from 50 to 51 so a marked reply consults `main` first; one found at any other priority is deleted, so a hot restart of `startd` converges too.

Two semantics differ from the mirror and are accepted: a `throw` in `main` falls through to the outbound table's default, and a reject-type default in `main` ends the lookup before it can be suppressed. StartOS installs neither into `main`. Tables survive a hot restart of `startd` but not the reboot every OS update performs, so no cleanup of previously mirrored entries is carried; on a dev box hot-replaced via `make start-os-update-startbox`, entries mirrored by the old build linger in the tables until reboot and can only matter for a destination whose route has since left `main`.

The IPv6 `RouteData` subscription existed to reconcile the mirror and goes with it.

## Verification

Four unit tests for `carries_v6` covering the router-without-address, ULA-with-router, global-without-router, and ULA-without-router cases; four for the SOCKS path — family interleaving, and three on paused Tokio time with an injected connector that assert exactly when each attempt starts: the second one delay after a first that never resolves, the third on the cadence past two that never resolve, and the next immediately after an earlier failure. The rule logic was exercised against a command shim (adds both rules when absent, leaves present ones alone, moves a stale reply-mark rule, and does not mistake `lookup 10020` for `lookup 1002`), and the routing semantics in the container above. The `start-core` suite is heavy to build locally, so these were exercised in scratch crates against the same dependency versions and left for CI to run in place.
