### PR TITLE
fix(ui): name the install finalization phase for the work

### DIFF
--- a/projects/start-os/CHANGELOG.md
+++ b/projects/start-os/CHANGELOG.md
@@ -91,6 +91,10 @@ file tracks notable changes since the move to the monorepo.
 
 ### Changed
 
+- **The install phase covering a service's own setup is named for the work** —
+  _Setting up_, _Applying update_, or _Restoring data_, with the service's own
+  phases nested under it.
+
 - **Your server's name is now its `.local` address, without the `.local` on the
   end.** A server previously carried two names: a display label shown in the
   browser tab, and the `.local` address derived from it by lowercasing and

--- a/projects/start-sdk/docs/src/init.md
+++ b/projects/start-sdk/docs/src/init.md
@@ -320,11 +320,13 @@ urllib.request.urlopen(req)`,
 
 ## Reporting Init Progress
 
-Init progress is surfaced in the **Installing** / **Updating** phase of the install, so a long first-run setup (migrations, bootstrapping a server, downloading assets) shows a moving bar instead of an apparent stall. This mirrors backup progress reporting.
+Init progress is surfaced inside the install's **Setting up** phase — **Applying update** or **Restoring data** for the other two transitions — so a long first-run setup (migrations, bootstrapping a server, downloading assets) shows a moving bar instead of an apparent stall. This mirrors backup progress reporting.
 
 You never call the progress effect directly. The init harness builds one `FullProgressTracker` and passes it to **every** init handler as a third argument. Each handler adds its own phases (with its own names) to the shared tracker, unaware of the others. Add phases and update them — **every update auto-reports to StartOS in the background**, so there's nothing to flush by hand.
 
 `progress.addPhase(name, contribution)` returns a `PhaseHandle` with `start()`, `setTotal(n)`, `setDone(n)`, `setUnits('steps' | 'bytes')`, and `complete()`. Just update the handle; the report follows automatically.
+
+**Name a phase for the work, not for your package.** Your phases render indented under **Setting up**, on a page already headed by the service's name and icon, so `Installing <Package>` spends both its words on what the reader can already see. Name the step instead — `Creating the database`, `Copying bundled models`, `Compiling assets`.
 
 ```typescript
 export const initializeService = sdk.setupOnInit(async (effects, kind, progress) => {
@@ -381,7 +383,9 @@ export const v2_0_0 = VersionInfo.of({
 
 ### Multi-phase Handlers
 
-For a handler with several distinct steps, add one phase per step. The tracker weights them by their `contribution` and reports a combined percentage:
+For a handler with several distinct steps, add one phase per step. The tracker weights them by their `contribution` and reports a combined percentage.
+
+Set `contribution` from how long each step actually takes — install the package once, read the timings out of the service log, and use those seconds. Equal weights across a ten-second step and a two-minute one produce a bar that jumps to half and then freezes, which reads worse than no bar at all.
 
 ```typescript
 export const bootstrap = sdk.setupOnInit(async (effects, kind, progress) => {
@@ -399,6 +403,28 @@ export const bootstrap = sdk.setupOnInit(async (effects, kind, progress) => {
   seedPhase.complete()
 })
 ```
+
+### Driving Progress From a Daemon's Output
+
+The slow step is usually a program that already prints where it has got to. `exec.onStdout` / `exec.onStderr` on a daemon or oneshot turn that into a real percentage, and into the phase transitions around it:
+
+```typescript
+const app = progress.addPhase(i18n('Installing the ERPNext app'), 11)
+
+let tail = ''
+const onOutput = (chunk: Buffer | string) => {
+  process.stdout.write(chunk)
+  tail = (tail + chunk).slice(-4096) // a marker can straddle two chunks
+  const percent = /Updating DocTypes[^[]*\[[^\]]*\]\s*(\d+)%/g
+  const last = [...tail.matchAll(percent)].pop()
+  if (last) app.setDone(Number(last[1]))
+}
+```
+
+> [!WARNING]
+> Attaching **either** callback switches the process from `stdio: 'inherit'` to `'pipe'` — on all three streams. Re-emit both, or the service log goes silent and the unread stderr pipe eventually blocks the process. Attach an `onStderr` that only re-emits even when you parse nothing from it.
+
+Upstream can reword its output in any release, so keep the failure benign: a marker that stops matching should leave the phase indeterminate, never wedge init.
 
 ## Common Patterns
 

--- a/shared-libs/crates/start-core/src/service/service_map.rs
+++ b/shared-libs/crates/start-core/src/service/service_map.rs
@@ -245,12 +245,12 @@ impl ServiceMap {
         let size = s9pk.size();
         let op_name = if recovery_source.is_none() {
             if service.is_none() {
-                "Installing"
+                "Setting up"
             } else {
-                "Updating"
+                "Applying update"
             }
         } else {
-            "Restoring"
+            "Restoring data"
         };
         let mut finalization_progress = progress.add_phase(op_name.into(), Some(50));
         let restoring = recovery_source.is_some();
@@ -617,9 +617,9 @@ impl ServiceRefReloadInfo {
         let id = self.id.clone();
         let error_string = error.to_string();
         let title = match self.operation {
-            "Installing" => t!("service.service-map.installing-failed"),
-            "Updating" => t!("service.service-map.updating-failed"),
-            "Restoring" => t!("service.service-map.restoring-failed"),
+            "Setting up" => t!("service.service-map.installing-failed"),
+            "Applying update" => t!("service.service-map.updating-failed"),
+            "Restoring data" => t!("service.service-map.restoring-failed"),
             "Uninstall" => t!("service.service-map.uninstall-failed"),
             other => t!("service.service-map.operation-failed", operation = other),
         }

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/de.ts
@@ -820,4 +820,7 @@ export default {
   928: 'Aufsteigend',
   929: 'Absteigend',
   930: 'Dienste in diesem Register werden von der Start9-Community gepflegt und befinden sich in der Betaphase. Fehler sind zu erwarten. Die Installation erfolgt auf eigenes Risiko. Bei Problemen wenden Sie sich bitte an den Paketentwickler.',
+  931: 'Wird eingerichtet',
+  932: 'Update wird angewendet',
+  933: 'Daten werden wiederhergestellt',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/en.ts
@@ -821,4 +821,7 @@ export const ENGLISH: Record<string, number> = {
   'Ascending': 928,
   'Descending': 929,
   'Services from this registry are packaged and maintained by members of the Start9 community and are undergoing beta testing. Bugs are expected. Install at your own risk. If you experience an issue or have a question related to a service in this marketplace, please reach out to the package developer for assistance.': 930,
+  'Setting up': 931,
+  'Applying update': 932,
+  'Restoring data': 933,
 }

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/es.ts
@@ -820,4 +820,7 @@ export default {
   928: 'Ascendente',
   929: 'Descendente',
   930: 'Los servicios de este registro están empaquetados y mantenidos por miembros de la comunidad Start9 y están en fase de prueba beta. Se esperan errores. Instálalos bajo tu propio riesgo. Si experimentas un problema o tienes una pregunta sobre un servicio en este mercado, comunícate con el desarrollador del paquete.',
+  931: 'Configurando',
+  932: 'Aplicando la actualización',
+  933: 'Restaurando los datos',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/fr.ts
@@ -820,4 +820,7 @@ export default {
   928: 'Croissant',
   929: 'Décroissant',
   930: 'Les services de cette bibliothèque sont maintenus par la communauté Start9 et sont en phase de test bêta. Des bugs sont à prévoir. Installez-les à vos risques et périls. En cas de problème ou de question, veuillez contacter le développeur en charge du paquet.',
+  931: 'Configuration',
+  932: 'Application de la mise à jour',
+  933: 'Restauration des données',
 } satisfies i18n

--- a/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
+++ b/shared-libs/ts-modules/shared/src/i18n/dictionaries/pl.ts
@@ -820,4 +820,7 @@ export default {
   928: 'Rosnąco',
   929: 'Malejąco',
   930: 'Serwisy z tego katalogu są tworzone i utrzymywane przez członków społeczności Start9 i są w fazie testów beta. Należy spodziewać się błędów. Instalujesz je na własne ryzyko. W przypadku problemów lub pytań skontaktuj się z twórcą pakietu.',
+  931: 'Konfigurowanie',
+  932: 'Wprowadzanie aktualizacji',
+  933: 'Przywracanie danych',
 } satisfies i18n


### PR DESCRIPTION
Installing ERPNext on the dev box showed `Installing — 0%` with `Installing ERPNext — in progress…` under it for 4m22s.

`setInitProgress` replaces the finalization phase's *value* with the service's whole nested `FullProgress`, and the UI renders that phase's row plus its children indented beneath. So whenever a package names its own phase after itself — nextcloud, open-webui and erpnext all did — the label appeared twice. The three operation strings are now the phase labels and say what the phase covers: `Setting up`, `Applying update`, `Restoring data`. `notify_failure` is the only other consumer and its match arms move with them.

The 0% is a package-side fault, not a core one — a single unweighted, total-less phase computes `{done: 0, total: 1}`, so the parent reads 0% until it completes. Fixed in the package PRs, which emit weighted and (where a real signal exists) determinate phases:

- Start9Labs/erpnext-startos#2
- Start9Labs/nextcloud-startos#145
- Start9Labs/open-webui-startos#41

## Packaging guide

`init.md` gains what stops packages reproducing the duplicate label:

- name a phase for the work, not the package — the surrounding phase and the page title already carry it
- set `contribution` from measured seconds, not equal weights
- a new section on driving phases from a daemon's own output, with the stdio contract: attaching `onStdout` **or** `onStderr` switches the process from `inherit` to `pipe` on all three streams, so a handler that doesn't re-emit silently drops the service log and leaves an unread stderr pipe to fill

Routed to master rather than live-docs because the prose names the new labels, which don't exist in shipped StartOS yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)