### PR TITLE
fix(cli): describe attach's --subcontainer as the Guid it matches

### DIFF
--- a/projects/start-cli/man/start-cli-package-attach.1
+++ b/projects/start-cli/man/start-cli-package-attach.1
@@ -13,10 +13,10 @@ Execute commands in container
 Force TTY mode for I/O
 .TP
 \fB\-s\fR, \fB\-\-subcontainer\fR \fI<SUBCONTAINER>\fR
-Name of the subcontainer
+Guid of the subcontainer, or a prefix; use \-\-name to select by name
 .TP
 \fB\-n\fR, \fB\-\-name\fR \fI<NAME>\fR
-Name of the container
+Name of the subcontainer
 .TP
 \fB\-u\fR, \fB\-\-user\fR \fI<USER>\fR
 User name to run as

--- a/shared-libs/crates/start-core/locales/i18n.yaml
+++ b/shared-libs/crates/start-core/locales/i18n.yaml
@@ -3315,11 +3315,11 @@ help.arg.config-file-path:
   pl_PL: "Ścieżka do pliku konfiguracyjnego"
 
 help.arg.container-name:
-  en_US: "Name of the container"
-  de_DE: "Name des Containers"
-  es_ES: "Nombre del contenedor"
-  fr_FR: "Nom du conteneur"
-  pl_PL: "Nazwa kontenera"
+  en_US: "Name of the subcontainer"
+  de_DE: "Name des Subcontainers"
+  es_ES: "Nombre del subcontenedor"
+  fr_FR: "Nom du sous-conteneur"
+  pl_PL: "Nazwa podkontenera"
 
 help.arg.data-directory:
   en_US: "Path to data directory"
@@ -4009,11 +4009,11 @@ help.arg.squashfs-image-path:
   pl_PL: "Ścieżka do pliku obrazu squashfs"
 
 help.arg.subcontainer-name:
-  en_US: "Name of the subcontainer"
-  de_DE: "Name des Subcontainers"
-  es_ES: "Nombre del subcontenedor"
-  fr_FR: "Nom du sous-conteneur"
-  pl_PL: "Nazwa podkontenera"
+  en_US: "Guid of the subcontainer, or a prefix; use --name to select by name"
+  de_DE: "Guid des Subcontainers oder ein Präfix davon; --name wählt nach Name aus"
+  es_ES: "Guid del subcontenedor, o un prefijo; use --name para seleccionar por nombre"
+  fr_FR: "Guid du sous-conteneur, ou un préfixe ; utilisez --name pour sélectionner par nom"
+  pl_PL: "Guid podkontenera lub jego prefiks; użyj --name, aby wybrać według nazwy"
 
 help.arg.target-disk:
   en_US: "Target disk for installation"


### PR DESCRIPTION
`start-cli package attach -s/--subcontainer` matches the subcontainer's internal **Guid** (`service/mod.rs:977` — the map key, uppercase base32). Its help string read *"Name of the subcontainer"*, which is the one value it will not accept. `-n/--name`, which does take the name, read the vaguer *"Name of the container"*.

So the flag advertised as the name-taker rejects names, and the flag that accepts them doesn't say so:

```
$ start-cli package attach nextcloud -s nextcloud-sub
Not Found: package.attach: no matching subcontainers are running for nextcloud; some possible choices are:
$ start-cli package attach nextcloud -n nextcloud-sub
root@2ZX3NWIL5ZQPFFCARGR4B7D3KUEF6HCW:/var/www/html#
```

## The change

String table only. Both keys are used at exactly one site each, `CliAttachParams` (`service/mod.rs:1343`, `:1345`).

- `help.arg.container-name` (`-n`) takes over the strings that were under `help.arg.subcontainer-name`. All five values change, but none is newly authored — each is an existing, already-reviewed translation moved onto the flag it actually describes.
- `help.arg.subcontainer-name` (`-s`) gets new text naming the Guid and pointing at `--name`. Those five strings are the only new translations in the diff.

Prefixes are mentioned because the match is `contains`, not equality, so a Guid prefix works.

## Deliberately not done

The key `help.arg.subcontainer-name` is now a misnomer for text about a Guid. Renaming it to `…-guid` would also want `container-name` → `subcontainer-name`, which collides with the old key and means relocating entries to hold the file's alphabetical ordering. Happy to do that swap if a reviewer prefers it — left out here to keep the diff to values.

The matching code itself is correct and deliberate: for `name` both sides are uppercased, while for `subcontainer` only the needle is, because Guids are uppercase by construction. This PR changes no logic.

## Verified

- YAML parses; 965 keys; both entries carry all five locales.
- `npx prettier --check` clean on the file.
- `rust_i18n::i18n!` loads this file at compile time; the change is values-only inside a file that still parses, with no keys added or removed.
- Rendered `--help` **is** confirmed: the man pages are clap-generated and committed, so `make manpages-check` in CI built the binary and regenerated `start-cli-package-attach.1`. Its only drift was these two strings, taken in the second commit.

Fixing the help text does not fix the failure it currently invites: a wrong `-s` still reports the wrong cause and still prints an empty choices list. That is tracked separately in #3921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

