### PR TITLE
docs(start-os): correct the package attach selectors and package stats usage

### DIFF
--- a/projects/start-os/docs/src/cli-reference.md
+++ b/projects/start-os/docs/src/cli-reference.md
@@ -244,19 +244,19 @@ Display logs from a service. These are also readable and downloadable on the ser
 - `-B, --before` — Show logs before cursor
 - `-b, --boot <ID>` — Filter by boot ID
 
-### `start-cli package attach <ID> [COMMAND]`
+### `start-cli package attach <ID> [-- COMMAND]`
 
 Open a shell inside a service's subcontainer (within the LXC container), or run a one-off command. If the service has only one subcontainer, you are placed directly into it; if there are multiple, you will be prompted to choose. See [Accessing Service Containers](service-containers.md) for details.
 
-- `-s, --subcontainer <NAME>` — Target a specific subcontainer
-- `-n, --name <NAME>` — Container name
-- `-u, --user <USER>` — Run as a specific user
-- `-i, --image-id <ID>` — Image identifier
+- `-n, --name <NAME>` — Select the subcontainer by name; the package's README lists them
+- `-s, --subcontainer <GUID>` — Select the subcontainer by its internal Guid, or a prefix of it (names go to `-n`)
+- `-i, --image-id <ID>` — Select the subcontainer by the image it runs
+- `-u, --user <USER>` — Run as this user instead of the image's default
 - `--force-tty` — Force TTY mode
 
-### `start-cli package stats <ID>`
+### `start-cli package stats`
 
-Display LXC container resource usage.
+Display LXC container resource usage for every installed service.
 
 - `--format` — Output format
 

--- a/projects/start-os/docs/src/service-containers.md
+++ b/projects/start-os/docs/src/service-containers.md
@@ -29,10 +29,16 @@ Replace `<PACKAGE>` with the package identifier (e.g., `bitcoind`, `lnd`). You c
 start-cli package list
 ```
 
-This drops you into a shell inside the service's **subcontainer** (not the LXC container itself). If the service has only one subcontainer, you are placed directly into it. If there is more than one subcontainer, you will be prompted to choose one. To skip the prompt, specify the subcontainer ID directly:
+This drops you into a shell inside the service's **subcontainer** (not the LXC container itself). If the service has only one subcontainer, you are placed directly into it. If there is more than one subcontainer, you will be prompted to choose one. To skip the prompt, name the subcontainer with `-n` (the package's README lists them):
 
 ```bash
-start-cli package attach <PACKAGE> <SUBCONTAINER>
+start-cli package attach <PACKAGE> -n <SUBCONTAINER>
+```
+
+To run one command instead of opening a shell, put it after `--`. Commands run as the image's default user; `-u` runs them as another, which some services' command-line tools require:
+
+```bash
+start-cli package attach <PACKAGE> -n <SUBCONTAINER> -u <USER> -- <COMMAND>
 ```
 
 Type `exit` or press `Ctrl+D` to return to the host.
@@ -41,10 +47,10 @@ Type `exit` or press `Ctrl+D` to return to the host.
 
 In rare cases, you may need to access the LXC container itself rather than a subcontainer. For example, subcontainers are only accessible while the service is running, but the LXC container remains accessible even when the service is stopped — useful for inspecting or repairing state that prevents a service from starting.
 
-First, obtain the container ID:
+First, find the container ID in the stats table:
 
 ```bash
-start-cli package stats <PACKAGE>
+start-cli package stats
 ```
 
 Then attach directly to the LXC container:


### PR DESCRIPTION
## Summary

The StartOS book misdescribed `start-cli package attach`'s selector flags, and `package stats`'s arguments, in ways that send a reader to the wrong command:

- `cli-reference.md` listed `-s, --subcontainer <NAME>` as "Target a specific subcontainer" and `-n, --name` as "Container name". `-s` matches the subcontainer's internal Guid (`service/mod.rs`, `AttachParams`); `-n` matches its name. Following the page as written selects the one flag that rejects the value the reader has, and the resulting error (#3921) says the subcontainer is not running.
- `service-containers.md` showed `start-cli package attach <PACKAGE> <SUBCONTAINER>`. There is no positional selector; attach reads that token as the command to run.
- Both pages gave `start-cli package stats <ID>`. `stats` takes no ID and reports every installed service.

Now `-n` is documented as the name selector, `-s` as the Guid selector with a pointer back to `-n`, and the one-off-command form shows `--` and mentions `-u` for services whose CLI tools must run as a specific user. `package stats` is documented as it behaves. The packaging book already said this (`workflow.md`, `agent-context.md`); the StartOS book now agrees with it.

Targets `live-docs`: all of this is true of shipped StartOS 0.4.0.1, and the CLI reference is what Dux reads when a user asks how to attach. Companion to #3922, which fixes the same two strings in `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)