### PR TITLE
docs(registry): note native proxy requirements

### DIFF
--- a/projects/start-registry/README.md
+++ b/projects/start-registry/README.md
@@ -50,6 +50,12 @@ Configuration is read from CLI flags and a config file (`-c <path>`; default sea
 
 Server state lives in `<datadir>/registry.db` (PatchDB) plus a SQLite metrics database and hosted asset files.
 
+> [!NOTE]
+> **Non-StartOS deployments only:** A separately managed reverse proxy must forward `/rpc/`,
+> `/ws/rpc/`, and `/rest/rpc/`. The WebSocket route also needs HTTP/1.1 upgrade forwarding and a
+> long-lived idle timeout. StartOS-hosted registries expose all three routes through their exported
+> `protocol: 'http'` interface automatically.
+
 ## Where things are
 
 - `Cargo.toml` — crate `start-registry`, bin `registrybox`, depends on `start-core` (package name `start-core`, lib `start_core`).


### PR DESCRIPTION
## Summary
- add a compact **Non-StartOS deployments only** note beside the native registry quickstart
- state the three route families and WebSocket requirements for separately managed reverse proxies
- state that StartOS-hosted registries expose the routes automatically through their HTTP interface

## Context

StartOS-hosted registries already forward complete paths and WebSocket upgrades. The note applies only to the exceptional native deployment that places nginx, Apache, Caddy, or another separately managed proxy in front of `start-registryd`.

The current official registry VPSes use that exceptional architecture, which caused #3920. Their concrete nginx include and rollout procedure are in Start9Labs/operations#36.

## Verification
- pinned Prettier check for `projects/start-registry/README.md`
- `git diff --check`
