### PR TITLE
chore(release): write notes for StartOS 0.4.0 and Start SDK 2.0.9

### DIFF
--- a/projects/start-os/release-notes/0.4.0.md
+++ b/projects/start-os/release-notes/0.4.0.md
@@ -1,0 +1,25 @@
+**v0.4.0 is a complete rewrite of StartOS.** After six years of building, we believe we have arrived at the correct architecture and foundation to deliver on the promise of sovereign computing.
+
+## ⚠️ Before You Update
+
+> 0.4.0 is finally out of public beta! However, **the only way to update is by following the [0.4.0 Update Guide](https://docs.start9.com/start-os/update-040.html) precisely.** This is a sensitive update between two essentially distinct operating systems — skipping steps or improvising can result in data loss.
+>
+> 👉 **[Read the full update guide before proceeding](https://docs.start9.com/start-os/update-040.html)**
+>
+> If anything goes wrong, **stop and [contact support](https://start9.com/contact)** — do not attempt to troubleshoot on your own.
+
+## Highlights
+
+- **Redesigned UI** — faster, more intuitive, mobile-friendly, with a real-time system metrics dashboard
+- **Completely new networking stack** — LAN port forwarding, Wireguard VPN gateways, private and public domains (clearnet), Let's Encrypt, built-in DNS, and Tor as an optional plugin
+- **StartTunnel** — free, open-source reverse tunnel to expose services on a public domain without revealing your home IP
+- **LXC container runtime** — replacing Docker/Podman with a reliable, nested container architecture supporting hardware acceleration and multi-container setups
+- **Improved backups** — differential backups, cross-server restore, and a new FUSE module for cross-platform reliability
+- **Internationalization** — multiple languages and keyboard layouts for StartOS and services
+- **TypeScript SDK** — build and ship a StartOS package in minutes
+- **New S9PK format** — signature verification, partial downloads, and multi-architecture support
+- **SMTP notifications** — email alerts from StartOS and services via Gmail, SES, or any SMTP provider
+
+## Important
+
+Previous backups are incompatible with v0.4.0. After updating, immediately update all services and create a fresh backup.

--- a/projects/start-sdk/release-notes/2.0.9.md
+++ b/projects/start-sdk/release-notes/2.0.9.md
@@ -1,0 +1,5 @@
+**A one-fix patch release**, correcting a type that made the option it fixes unusable.
+
+## Highlights
+
+- **`sdk.host.getBridgeAddress` types its result as non-null when `fallbackPort` is given.** That option exists precisely so the value is never `null` — it resolves to `<osIp>:<fallbackPort>` while the dependency is absent — but 2.0.8 typed every call `string | null` regardless, so assigning it straight to a non-nullable config field (Bitcoin's `proxy`, LND's `tor.socks`) failed to compile. It is now overloaded on the presence of `fallbackPort`.


### PR DESCRIPTION
The last two releases without a notes file. Both are backfills of shipped versions, so a re-cut of either now reproduces its body instead of losing it — and with #3927, StartOS 0.4.0 is a version the build would refuse to produce without one.

**StartOS 0.4.0** is its published body verbatim, minus the `# StartOS v0.4.0` heading the title already carries. The `## ⚠️ Before You Update` warning keeps its original wording rather than the `## ⚠️ Updating from 0.3.5.1` heading 0.4.0.1's rewrite uses: this text shipped, and there is no reason to edit it after the fact.

**Start SDK 2.0.9** is written from its changelog — one fix, one bullet.

Both live releases are updated to match, and titled by display name: [StartOS v0.4.0](https://github.com/Start9Labs/start-technologies/releases/tag/start-os/v0.4.0), [Start SDK v2.0.9](https://github.com/Start9Labs/start-technologies/releases/tag/start-sdk/v2.0.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)