### PR TITLE
fix(start-wrt): write the eMMC partition table instead of trusting the card's

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7914,7 +7914,7 @@ dependencies = [
 
 [[package]]
 name = "startwrt-core"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "arc-swap",
  "async_cell",

--- a/projects/start-wrt/CHANGELOG.md
+++ b/projects/start-wrt/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to StartWRT are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1]
+
+### Fixed
+
+- **Flashing to internal storage no longer depends on the microSD card's
+  partition table being untouched since the image was written.** A card whose
+  table a partition tool had rewritten to span the whole card, or whose last
+  partition had been grown to fill it, made the flash fail with
+  `rootfs_data partition not found on eMMC` and left the router unable to boot
+  from internal storage until reflashed.
+
 ## [1.1.0]
 
 ### Added

--- a/projects/start-wrt/backend/ctrl/Cargo.toml
+++ b/projects/start-wrt/backend/ctrl/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "MIT"
 name = "startwrt-core"
-version = "1.1.0"      # VERSION_BUMP
+version = "1.1.1"      # VERSION_BUMP
 
 [lib]
 name = "startwrt"

--- a/projects/start-wrt/backend/ctrl/src/flash.rs
+++ b/projects/start-wrt/backend/ctrl/src/flash.rs
@@ -95,6 +95,37 @@ pub(crate) fn node_partition_number(node: &str) -> Result<u64, Error> {
     ))
 }
 
+/// Strip the lines that tie an `sfdisk --dump` to the disk it was taken from,
+/// and the overlay's size, which sfdisk then extends to the end of the disk.
+pub(crate) fn portable_partition_script(dump: &str) -> String {
+    dump.lines()
+        .filter(|line| {
+            let key = line.split(':').next().unwrap_or("").trim();
+            !matches!(key, "device" | "last-lba")
+        })
+        .map(|line| {
+            if line.contains("name=\"rootfs_data\"") {
+                drop_partition_field(line, "size=")
+            } else {
+                line.to_string()
+            }
+        })
+        .map(|line| format!("{line}\n"))
+        .collect()
+}
+
+fn drop_partition_field(line: &str, key: &str) -> String {
+    let Some((node, fields)) = line.split_once(':') else {
+        return line.to_string();
+    };
+    let kept: Vec<&str> = fields
+        .split(',')
+        .map(str::trim)
+        .filter(|field| !field.starts_with(key))
+        .collect();
+    format!("{} : {}", node.trim(), kept.join(", "))
+}
+
 /// Run sfdisk with the given arguments, piping `script` to stdin.
 pub(crate) async fn run_sfdisk(args: &[&str], script: &str) -> Result<(), Error> {
     let mut input = std::io::Cursor::new(script.as_bytes().to_vec());
@@ -500,7 +531,22 @@ async fn run_flash_core(
     report("Copying firmware to eMMC...");
     copy_raw(&sd_path, &emmc_path, copy_end_bytes, on_progress)?;
 
-    // 9. Read eMMC partition table and find rootfs / rootfs_data
+    // 9. Write the source's partition table onto the eMMC. The raw copy left
+    //    the card's GPT header there, and a header rewritten for the card
+    //    describes a disk larger than the eMMC.
+    report("Writing partition table...");
+    let dump = tokio::process::Command::new("sfdisk")
+        .args(["--dump", &sd_path])
+        .invoke(ErrorKind::Filesystem.into())
+        .await?;
+    let script = portable_partition_script(&String::from_utf8_lossy(&dump));
+    run_sfdisk(
+        &["--no-reread", "--no-tell-kernel", "--force", &emmc_path],
+        &script,
+    )
+    .await?;
+
+    // 10. Read eMMC partition table and find rootfs / rootfs_data
     let emmc_sfdisk = read_partition_table(&emmc_path).await?;
     let emmc_parts = &emmc_sfdisk.partition_table.partitions;
 
@@ -528,7 +574,7 @@ async fn run_flash_core(
     let rootfs_data_start = rootfs_data_part.start;
     let rootfs_data_part_num = node_partition_number(&rootfs_data_part.node)?;
 
-    // 10. Expand rootfs_data to fill remaining eMMC space.
+    // 11. Expand rootfs_data to fill remaining eMMC space.
     let last_usable = emmc_sectors - 34;
     let new_rootfs_data_size = last_usable - rootfs_data_start;
 
@@ -542,7 +588,7 @@ async fn run_flash_core(
     )
     .await?;
 
-    // 11. Refresh kernel partition table.
+    // 12. Refresh kernel partition table.
     //     partx -d + -a is the cleanest (wipe stale entries, re-read GPT),
     //     but -a fails if entries already exist and -d fails if partitions
     //     are busy.  Fall back to -u (updates existing entries) which is
@@ -561,14 +607,14 @@ async fn run_flash_core(
         run_cmd("partx", &["-u", &emmc_path]).await?;
     }
 
-    // 12. Format rootfs_data as ext4 (clean overlay)
+    // 13. Format rootfs_data as ext4 (clean overlay)
     let rootfs_data_dev = format!("{emmc_path}p{rootfs_data_part_num}");
     report(&format!(
         "Formatting rootfs_data overlay ({rootfs_data_dev})..."
     ));
     run_cmd("mkfs.ext4", &["-L", "rootfs_data", "-F", &rootfs_data_dev]).await?;
 
-    // 13. Provision the eMMC hardware boot partitions. The raw copy above
+    // 14. Provision the eMMC hardware boot partitions. The raw copy above
     //     only wrote the user area; the K1 BootROM boots eMMC from boot0
     //     (bootinfo + FSBL), which factory provisioning may have left empty
     //     or stale on this board. Converge boot0/boot1 to the FSBL that just
@@ -576,7 +622,7 @@ async fn run_flash_core(
     report("Provisioning eMMC boot firmware...");
     crate::boot0::provision_emmc_boot(partitions, &emmc_dev, &report).await?;
 
-    // 14. Success
+    // 15. Success
     report("Flash complete.");
 
     Ok(Some(FlashResult {
@@ -735,6 +781,49 @@ mod tests {
         // Should fall back to partition boundary
         let end = find_copy_end(dev.to_str().unwrap(), &parsed.partition_table.partitions).unwrap();
         assert_eq!(end, (1024 + 2048) * 512);
+    }
+
+    #[test]
+    fn portable_partition_script_drops_disk_geometry() {
+        let dump = "\
+label: gpt
+label-id: 5452574F-2211-4433-5566-778899AABB00
+device: /dev/mmcblk0
+unit: sectors
+first-lba: 34
+last-lba: 124735454
+sector-size: 512
+
+/dev/mmcblk0p1 : start=         256, size=         512, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name=\"fsbl\"
+/dev/mmcblk0p7 : start=      661120, size=      524288, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, name=\"rootfs_data\"
+/dev/mmcblk0p128 : start=          34, size=         222, type=21686148-6449-6E6F-744E-656564454649
+";
+        let script = portable_partition_script(dump);
+        assert!(!script.contains("device:"));
+        assert!(!script.contains("last-lba:"));
+        assert!(script.contains("label: gpt\n"));
+        assert!(script.contains("first-lba: 34\n"));
+        assert!(script.contains("/dev/mmcblk0p128 : start="));
+        assert_eq!(script.lines().count(), dump.lines().count() - 2);
+    }
+
+    #[test]
+    fn portable_partition_script_unsizes_rootfs_data() {
+        let dump = "\
+/dev/mmcblk0p6 : start=      137216, size=      523904, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=E613C649-750D-459D-B2FD-E14E4FD01D7C, name=\"rootfs\"
+/dev/mmcblk0p7 : start=      661120, size=   124074335, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=41A6B2FF-3487-4D73-8B52-65D303617EF2, name=\"rootfs_data\"
+";
+        let script = portable_partition_script(dump);
+        let mut lines = script.lines();
+        assert_eq!(
+            lines.next().unwrap(),
+            "/dev/mmcblk0p6 : start=      137216, size=      523904, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=E613C649-750D-459D-B2FD-E14E4FD01D7C, name=\"rootfs\""
+        );
+        assert_eq!(
+            lines.next().unwrap(),
+            "/dev/mmcblk0p7 : start=      661120, type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=41A6B2FF-3487-4D73-8B52-65D303617EF2, name=\"rootfs_data\""
+        );
+        assert!(lines.next().is_none());
     }
 
     #[test]

--- a/projects/start-wrt/release-notes/1.1.1.md
+++ b/projects/start-wrt/release-notes/1.1.1.md
@@ -1,0 +1,5 @@
+**StartWRT 1.1.1 fixes flashing to internal storage from a microSD card whose partition table was altered after the image was written.**
+
+## Highlights
+
+- **Flashing to internal storage no longer depends on an untouched microSD card.** Opening the card in a partition tool that offered to "fix" its partition table, or growing its last partition to fill the card, made the flash fail with `rootfs_data partition not found on eMMC` and left the router unable to boot from internal storage until reflashed. A card in that state now flashes like a freshly written one.


### PR DESCRIPTION
## Problem

The flash raw-copies the first ~95 MB of the microSD card onto the eMMC and then expects the copied GPT header to parse. That header describes the ~580 MB image, so it only works while nothing has touched the card's partition table since it was written. Any partition tool that "fixes" the card (gparted/parted's Fix prompt, `sgdisk -e`, a write from fdisk) rewrites the header's last usable sector to the card's real size. Copied from a card larger than the eMMC, that header is rejected by libfdisk, the kernel and U-Boot, and all three fall back to whatever backup GPT the eMMC already held at its last sector. On a factory board that is a table with a rootfs and no rootfs_data, so the flash fails with `rootfs_data partition not found on eMMC` and the board no longer boots from eMMC (`GPT: last_usable_lba incorrect: 76F4FDE > 1d1f000`). The hardware supplier hit this flashing v1.1.0 from a 64 GB card.

## Fix

After the copy, dump the card's table with `sfdisk --dump`, drop the two header lines that describe the card (`device`, `last-lba`) and the size of `rootfs_data`, and write the result to the eMMC with `sfdisk --force`. sfdisk derives the last usable sector from the eMMC, writes both the primary and the backup copy, and extends rootfs_data to the free space, which the existing expansion step then pins to the last usable sector as before. Dropping the size also covers a card whose rootfs_data was grown to fill it, which sfdisk would otherwise refuse on the smaller eMMC. Partition starts, sizes, names and UUIDs are carried over unchanged, so the resulting table is the one every flash produced before, and OTA is unaffected.

Bumps StartWRT to 1.1.1 with the changelog entry and release notes.

## Verification

- Bench on a BPI-F3 with a 32 GB card:
  - 1.1.0 + card header relocated to the card's size: reproduces the supplier's failure.
  - this build + relocated header: flashes clean, eMMC boots.
  - this build + relocated header + rootfs_data grown to 29.4 GB: flashes clean, eMMC boots.
  - In each passing case `sfdisk --verify` on the eMMC is clean, last-lba is the eMMC's own, and rootfs_data ends on the last usable sector.
- A pristine card is unaffected (verified on sparse files and on the bench).
- `cargo test -p startwrt-core flash`: 12 passed.

https://claude.ai/code/session_01C779xbxXwoX1AGUKchrcMz
