### PR TITLE
docs(repo): describe the support portal in the frontend skill

### DIFF
--- a/.claude/skills/start9-frontend/SKILL.md
+++ b/.claude/skills/start9-frontend/SKILL.md
@@ -35,16 +35,16 @@ exactly what this skill exists to eliminate. Never guess a Taiga API: verify aga
 
 ## The fleet
 
-| App                    | Location                                        | Angular | Taiga | Zone                       | Theme                        | i18n               | Backend                              |
-| ---------------------- | ----------------------------------------------- | ------- | ----- | -------------------------- | ---------------------------- | ------------------ | ------------------------------------ |
-| StartOS `ui`           | `start-technologies` `projects/start-os/web/ui` | 22      | 5.11  | zone.js (zoneless pending) | dark, `provideTaiga({mode})` | yes (shared dicts) | JSON-RPC + PatchDB push              |
-| `setup-wizard`         | `projects/start-os/web/setup-wizard`            | 22      | 5.11  | zone.js                    | dark                         | yes (shared)       | JSON-RPC                             |
-| `start-tunnel`         | `projects/start-tunnel/web`                     | 22      | 5.11  | **zoneless**               | dark                         | yes (local dicts)  | JSON-RPC + PatchDB                   |
-| `start-wrt`            | `projects/start-wrt/web`                        | 22      | 5.11  | **zoneless**               | dual (`TUI_DARK_MODE`)       | yes (local dicts)  | JSON-RPC, own HTTP stack, 5s polling |
-| `brochure-marketplace` | `projects/brochure-marketplace`                 | 22      | 5.11  | zone.js (legacy)           | dark                         | yes (shared)       | registry RPC direct                  |
-| `start9-store`         | `ops/start9-store/web`                          | 22      | 5.14  | **zoneless**               | light                        | no                 | REST + Zod via `/api` BFF, **SSR**   |
-| `ops-server`           | `ops/ops-server/web`                            | 22      | 5.14  | **zoneless**               | dark, `#07a4ff`, Montserrat  | no                 | REST `/_api`, same-origin Express    |
-| `support-server`       | `ops/support-server/web`                        | 22      | 5.14  | **zoneless**               | dark, `#07a4ff`, Montserrat  | no                 | REST `/_api`                         |
+| App                    | Location                                        | Angular | Taiga | Zone                       | Theme                                | i18n               | Backend                                                          |
+| ---------------------- | ----------------------------------------------- | ------- | ----- | -------------------------- | ------------------------------------ | ------------------ | ---------------------------------------------------------------- |
+| StartOS `ui`           | `start-technologies` `projects/start-os/web/ui` | 22      | 5.11  | zone.js (zoneless pending) | dark, `provideTaiga({mode})`         | yes (shared dicts) | JSON-RPC + PatchDB push                                          |
+| `setup-wizard`         | `projects/start-os/web/setup-wizard`            | 22      | 5.11  | zone.js                    | dark                                 | yes (shared)       | JSON-RPC                                                         |
+| `start-tunnel`         | `projects/start-tunnel/web`                     | 22      | 5.11  | **zoneless**               | dark                                 | yes (local dicts)  | JSON-RPC + PatchDB                                               |
+| `start-wrt`            | `projects/start-wrt/web`                        | 22      | 5.11  | **zoneless**               | dual (`TUI_DARK_MODE`)               | yes (local dicts)  | JSON-RPC, own HTTP stack, 5s polling                             |
+| `brochure-marketplace` | `projects/brochure-marketplace`                 | 22      | 5.11  | zone.js (legacy)           | dark                                 | yes (shared)       | registry RPC direct                                              |
+| `start9-store`         | `ops/start9-store/web`                          | 22      | 5.22  | **zoneless**               | light                                | no                 | REST + Zod via `/api` BFF, **SSR**                               |
+| `ops-server`           | `ops/ops-server/web`                            | 22      | 5.14  | **zoneless**               | dark, `#07a4ff`, Montserrat          | no                 | REST `/_api`, same-origin Express                                |
+| `support-server`       | `ops/support-server/web`                        | 22      | 5.22  | **zoneless**               | dual (OS preference), StartOS tokens | yes (local dicts)  | Frappe `/api/method` + socket.io, same-origin; `web/mock` in dev |
 
 TypeScript ~6.0, rxjs ~7.8 everywhere. Taiga is **pinned exact** — bump only with the
 maintainer's blessing. Monorepo apps share **one Angular workspace rooted at the repo root**;

--- a/.claude/skills/start9-frontend/references/conventions.md
+++ b/.claude/skills/start9-frontend/references/conventions.md
@@ -6,9 +6,10 @@
 - Dictionaries: `en.ts` maps English → numeric id; `de/es/fr/pl.ts` map id → translation. Adding
   a string = add to `en.ts` with the next id + real translations in **all** other dictionaries.
   `npm run check:i18n` (and per-app `check:i18n:wrt`/`:tunnel`) scans for misses.
-- `shared` hosts the dictionaries for ui/setup-wizard/brochure; start-wrt/start-tunnel keep
-  local copies of the same machinery (consolidation into shared is planned — don't grow them
-  further apart). Ops-container apps are English-only: hardcode strings there.
+- `shared` hosts the dictionaries for ui/setup-wizard/brochure; start-wrt, start-tunnel, and
+  support-server's portal keep local copies of the same machinery (consolidation into shared
+  is planned — don't grow them further apart). ops-server and start9-store are English-only:
+  hardcode strings there.
 - Shared-lib services translate centrally: `DialogService`/`TaskService` accept `i18nKey`-typed
   labels, so callers pass English keys and never pre-translate.
 

--- a/.claude/skills/start9-frontend/references/repos.md
+++ b/.claude/skills/start9-frontend/references/repos.md
@@ -14,9 +14,19 @@
   into `angular.json` — hoisted-workspace limitation); `TUI_MEDIA.mobile: 1120` is measured —
   adding a nav item means re-measuring; light theme is a deliberate deferral of design;
   checkout is a redirect in Phase 1 (Shopify) — multi-step checkout is Phase 2 (Vendure).
-- **ops-server / support-server** — same-origin Express serves the build; relative `/_api`
-  URLs, no proxy/environments/CORS; dark theme, accent `#07a4ff`, Montserrat. ops: no route
-  guards — `AdminShell` gates on `adminService.token()`; admin-only actions check
+- **ops-server** — same-origin Express serves the build; relative `/_api` URLs, no
+  proxy/environments/CORS; dark theme, accent `#07a4ff`, Montserrat. No route guards —
+  `AdminShell` gates on `adminService.token()`; admin-only actions check
   `adminService.isAdmin()`; all HTTP through `AdminService` (authed) / `ApiService` (public).
-  support: no auth in the frontend at all. Husky+lint-staged Prettier on commit — fix
-  formatting, never `--no-verify`. Never commit `.env`.
+  Husky+lint-staged Prettier on commit — fix formatting, never `--no-verify`. Never commit
+  `.env`.
+- **support-server** (`web/`) — the customer support portal over Frappe Helpdesk, not a
+  dashboard: same-origin `/api/method/start9_support.api.*` (Frappe's `{ message }` envelope,
+  `X-Frappe-CSRF-Token` on every POST) plus Frappe's socket.io for live updates; no
+  environments — `ng serve` proxies to `web/mock`, an Express + socket.io server that is the
+  dev backend (there is no `MockApiService`; extend the mock). Frappe session in the frontend:
+  inline `canMatch` guards on `SessionService.user()`. Both themes follow the OS preference
+  (`provideTaiga()` with no `mode`, StartOS tokens for dark, no in-app toggle). Local i18n
+  machinery with `en.ts` only. No commit hook: `npm run check` runs the compiler,
+  `check-i18n`, the mock's type-check, and `prettier --check`. Its `web/AGENTS.md` carries the
+  portal-specific rules.


### PR DESCRIPTION
The `start9-frontend` skill's fleet table and `repos.md` still described support-server's `web/` as the Matrix access-code redemption dashboard (REST `/_api`, `#07a4ff`, Montserrat, no auth, husky hook). That app is gone; `web/` is now the customer support portal over Frappe Helpdesk (Start9Labs/support-server#44, plan in Start9Labs/support-server#31), scaffolded in Start9Labs/support-server@ee4390b.

- Fleet table: support-server's row reflects the portal (Taiga 5.22, both themes following the OS preference on StartOS tokens, local i18n, Frappe `/api/method` + socket.io with `web/mock` in development). start9-store's Taiga version is corrected to 5.22, which is what its `package.json` pins.
- `repos.md`: ops-server and support-server get separate entries; the portal's says what differs from the dashboards (Frappe session and envelope, the mock server in place of a `MockApiService`, no commit hook, where its own rules live).
- `conventions.md`: the portal keeps the local i18n machinery like start-wrt and start-tunnel; the English-only rule now names ops-server and start9-store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
